### PR TITLE
Fix CI failures: stale lockfile, lever typo, Quasar CLI rename, add Quasar badge

### DIFF
--- a/.github/workflows/solana-quasar.yml
+++ b/.github/workflows/solana-quasar.yml
@@ -171,7 +171,7 @@ jobs:
         with:
           solana-cli-version: stable
       - name: Install Quasar CLI
-        run: cargo install --git https://github.com/blueshift-gg/quasar cli --locked
+        run: cargo install --git https://github.com/blueshift-gg/quasar quasar-cli --locked
       - name: Build and Test with Stable
         run: |
           source build_and_test.sh

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Onchain program examples for ⚓ Anchor, 🤥 Pinocchio, 💫 Quasar, and 🦀 Native Rust.
 
-[![Anchor](https://github.com/solana-developers/program-examples/actions/workflows/anchor.yml/badge.svg?event=schedule)](https://github.com/solana-developers/program-examples/actions/workflows/anchor.yml) [![Pinocchio](https://github.com/solana-developers/program-examples/actions/workflows/solana-pinocchio.yml/badge.svg?event=schedule)](https://github.com/solana-developers/program-examples/actions/workflows/solana-pinocchio.yml) [![Native](https://github.com/solana-developers/program-examples/actions/workflows/solana-native.yml/badge.svg?event=schedule)](https://github.com/solana-developers/program-examples/actions/workflows/solana-native.yml)
+[![Anchor](https://github.com/solana-developers/program-examples/actions/workflows/anchor.yml/badge.svg?event=schedule)](https://github.com/solana-developers/program-examples/actions/workflows/anchor.yml) [![Pinocchio](https://github.com/solana-developers/program-examples/actions/workflows/solana-pinocchio.yml/badge.svg?event=schedule)](https://github.com/solana-developers/program-examples/actions/workflows/solana-pinocchio.yml) [![Native](https://github.com/solana-developers/program-examples/actions/workflows/solana-native.yml/badge.svg?event=schedule)](https://github.com/solana-developers/program-examples/actions/workflows/solana-native.yml) [![Quasar](https://github.com/solana-developers/program-examples/actions/workflows/solana-quasar.yml/badge.svg?event=schedule)](https://github.com/solana-developers/program-examples/actions/workflows/solana-quasar.yml)
 
 This repo contains Solana onchain programs (referred to as 'Smart Contracts' in other blockchains).
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Program Examples
 
-## Onchain program examples for ⚓ Anchor, 🤥 Pinocchio, 💫 Quasar, and 🦀 Native Rust.
+## Onchain program examples for ⚓ Anchor, 💫 Quasar, 🤥 Pinocchio, and 🦀 Native Rust.
 
-[![Anchor](https://github.com/solana-developers/program-examples/actions/workflows/anchor.yml/badge.svg?event=schedule)](https://github.com/solana-developers/program-examples/actions/workflows/anchor.yml) [![Pinocchio](https://github.com/solana-developers/program-examples/actions/workflows/solana-pinocchio.yml/badge.svg?event=schedule)](https://github.com/solana-developers/program-examples/actions/workflows/solana-pinocchio.yml) [![Native](https://github.com/solana-developers/program-examples/actions/workflows/solana-native.yml/badge.svg?event=schedule)](https://github.com/solana-developers/program-examples/actions/workflows/solana-native.yml) [![Quasar](https://github.com/solana-developers/program-examples/actions/workflows/solana-quasar.yml/badge.svg?event=schedule)](https://github.com/solana-developers/program-examples/actions/workflows/solana-quasar.yml)
+[![Anchor](https://github.com/solana-developers/program-examples/actions/workflows/anchor.yml/badge.svg?event=schedule)](https://github.com/solana-developers/program-examples/actions/workflows/anchor.yml) [![Quasar](https://github.com/solana-developers/program-examples/actions/workflows/solana-quasar.yml/badge.svg?event=schedule)](https://github.com/solana-developers/program-examples/actions/workflows/solana-quasar.yml) [![Pinocchio](https://github.com/solana-developers/program-examples/actions/workflows/solana-pinocchio.yml/badge.svg?event=schedule)](https://github.com/solana-developers/program-examples/actions/workflows/solana-pinocchio.yml) [![Native](https://github.com/solana-developers/program-examples/actions/workflows/solana-native.yml/badge.svg?event=schedule)](https://github.com/solana-developers/program-examples/actions/workflows/solana-native.yml)
 
 This repo contains Solana onchain programs (referred to as 'Smart Contracts' in other blockchains).
 
@@ -18,11 +18,11 @@ Each folder includes examples for one or more of the following:
   Use `anchor build` and `anchor deploy` to build and deploy the program.
   Tests should be executed using `pnpm test` as defined in the `Anchor.toml` scripts section.
 
-- `pinocchio` - Written using [Pinocchio](https://github.com/febo/pinocchio), a zero-copy, zero-allocation library for Solana programs.
+- `quasar` - Written using [Quasar](https://github.com/blueshift-gg/quasar), a zero-copy, zero-allocation `no_std` framework for Solana programs with Anchor-compatible ergonomics.
   Build and test commands are the same as native examples.
   Run `pnpm test` to execute tests.
 
-- `quasar` - Written using [Quasar](https://github.com/blueshift-gg/quasar), a zero-copy, zero-allocation `no_std` framework for Solana programs with Anchor-compatible ergonomics.
+- `pinocchio` - Written using [Pinocchio](https://github.com/febo/pinocchio), a zero-copy, zero-allocation library for Solana programs.
   Build and test commands are the same as native examples.
   Run `pnpm test` to execute tests.
 
@@ -39,43 +39,43 @@ Each folder includes examples for one or more of the following:
 
 [Hello World on Solana! A minimal program that logs a greeting.](./basics/hello-solana/README.md)
 
-[anchor](./basics/hello-solana/anchor) [pinocchio](./basics/hello-solana/pinocchio) [quasar](./basics/hello-solana/quasar) [native](./basics/hello-solana/native)
+[anchor](./basics/hello-solana/anchor) [quasar](./basics/hello-solana/quasar) [pinocchio](./basics/hello-solana/pinocchio) [native](./basics/hello-solana/native)
 
 ### Account-data
 
 Store and retrieve data using Solana accounts.
 
-[anchor](./basics/account-data/anchor) [pinocchio](./basics/account-data/pinocchio) [quasar](./basics/account-data/quasar) [native](./basics/account-data/native)
+[anchor](./basics/account-data/anchor) [quasar](./basics/account-data/quasar) [pinocchio](./basics/account-data/pinocchio) [native](./basics/account-data/native)
 
 ### Storing global state - Counter
 
 [Use a PDA to store global state, making a counter that increments when called.](./basics/counter/README.md)
 
-[anchor](./basics/counter/anchor) [pinocchio](./basics/counter/pinocchio) [quasar](./basics/counter/quasar) [native](./basics/counter/native)
+[anchor](./basics/counter/anchor) [quasar](./basics/counter/quasar) [pinocchio](./basics/counter/pinocchio) [native](./basics/counter/native)
 
 ### Saving per-user state - Favorites
 
 Save and update per-user state on the blockchain, ensuring users can only update their own information.
 
-[anchor](./basics/favorites/anchor) [pinocchio](./basics/favorites/pinocchio) [quasar](./basics/favorites/quasar) [native](./basics/favorites/native)
+[anchor](./basics/favorites/anchor) [quasar](./basics/favorites/quasar) [pinocchio](./basics/favorites/pinocchio) [native](./basics/favorites/native)
 
 ### Checking Instruction Accounts
 
 [Check that the accounts provided in incoming instructions meet particular criteria.](./basics/checking-accounts/README.md)
 
-[anchor](./basics/checking-accounts/anchor) [pinocchio](./basics/checking-accounts/pinocchio) [quasar](./basics/checking-accounts/quasar) [native](./basics/checking-accounts/native)
+[anchor](./basics/checking-accounts/anchor) [quasar](./basics/checking-accounts/quasar) [pinocchio](./basics/checking-accounts/pinocchio) [native](./basics/checking-accounts/native)
 
 ### Closing Accounts
 
 Close an account and get the Lamports back.
 
-[anchor](./basics/close-account/anchor) [pinocchio](./basics/close-account/pinocchio) [quasar](./basics/close-account/quasar) [native](./basics/close-account/native)
+[anchor](./basics/close-account/anchor) [quasar](./basics/close-account/quasar) [pinocchio](./basics/close-account/pinocchio) [native](./basics/close-account/native)
 
 ### Creating Accounts
 
 [Make new accounts on the blockchain.](./basics/create-account/README.md)
 
-[anchor](./basics/create-account/anchor) [pinocchio](./basics/create-account/pinocchio) [quasar](./basics/create-account/quasar) [native](./basics/create-account/native)
+[anchor](./basics/create-account/anchor) [quasar](./basics/create-account/quasar) [pinocchio](./basics/create-account/pinocchio) [native](./basics/create-account/native)
 
 ### Cross program invocations
 
@@ -87,31 +87,31 @@ Close an account and get the Lamports back.
 
 [Use a PDA to pay the rent for the creation of a new account.](./basics/pda-rent-payer/README.md)
 
-[anchor](./basics/pda-rent-payer/anchor) [pinocchio](./basics/pda-rent-payer/pinocchio) [quasar](./basics/pda-rent-payer/quasar) [native](./basics/pda-rent-payer/native)
+[anchor](./basics/pda-rent-payer/anchor) [quasar](./basics/pda-rent-payer/quasar) [pinocchio](./basics/pda-rent-payer/pinocchio) [native](./basics/pda-rent-payer/native)
 
 ### Processing instructions
 
 [Add parameters to an instruction handler and use them.](./basics/processing-instructions/README.md)
 
-[anchor](./basics/processing-instructions/anchor) [pinocchio](./basics/processing-instructions/pinocchio) [quasar](./basics/processing-instructions/quasar) [native](./basics/processing-instructions/native)
+[anchor](./basics/processing-instructions/anchor) [quasar](./basics/processing-instructions/quasar) [pinocchio](./basics/processing-instructions/pinocchio) [native](./basics/processing-instructions/native)
 
 ### Storing date in program derived addresses
 
 Store and retrieve state in Solana.
 
-[anchor](./basics/program-derived-addresses/anchor) [pinocchio](./basics/program-derived-addresses/pinocchio) [quasar](./basics/program-derived-addresses/quasar) [native](./basics/program-derived-addresses/native)
+[anchor](./basics/program-derived-addresses/anchor) [quasar](./basics/program-derived-addresses/quasar) [pinocchio](./basics/program-derived-addresses/pinocchio) [native](./basics/program-derived-addresses/native)
 
 ### Handling accounts that expand in size
 
 How to store state that changes size in Solana.
 
-[anchor](./basics/realloc/anchor) [pinocchio](./basics/realloc/pinocchio) [quasar](./basics/realloc/quasar) [native](./basics/realloc/native)
+[anchor](./basics/realloc/anchor) [quasar](./basics/realloc/quasar) [pinocchio](./basics/realloc/pinocchio) [native](./basics/realloc/native)
 
 ### Calculating account size to determine rent
 
 [Determine the necessary minimum rent by calculating an account's size.](./basics/rent/README.md)
 
-[anchor](./basics/rent/anchor) [pinocchio](./basics/rent/pinocchio) [quasar](./basics/rent/quasar) [native](./basics/rent/native)
+[anchor](./basics/rent/anchor) [quasar](./basics/rent/quasar) [pinocchio](./basics/rent/pinocchio) [native](./basics/rent/native)
 
 ### Laying out larger programs
 
@@ -123,7 +123,7 @@ How to store state that changes size in Solana.
 
 [Send SOL between two accounts.](./basics/transfer-sol/README.md)
 
-[anchor](./basics/transfer-sol/anchor) [pinocchio](./basics/transfer-sol/pinocchio) [quasar](./basics/transfer-sol/quasar) [native](./basics/transfer-sol/native)
+[anchor](./basics/transfer-sol/anchor) [quasar](./basics/transfer-sol/quasar) [pinocchio](./basics/transfer-sol/pinocchio) [native](./basics/transfer-sol/native)
 ## Tokens
 ### Creating tokens
 

--- a/basics/cross-program-invocation/anchor/programs/lever/src/lib.rs
+++ b/basics/cross-program-invocation/anchor/programs/lever/src/lib.rs
@@ -6,7 +6,7 @@ declare_id!("E64FVeubGC4NPNF2UBJYX4AkrVowf74fRJD9q6YhwstN");
 pub mod lever {
     use super::*;
 
-    pub fn initialize(_mut context: Context<InitializeLeverAccountConstraints>) -> Result<()> {
+    pub fn initialize(context: Context<InitializeLeverAccountConstraints>) -> Result<()> {
         Ok(())
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@anchor-lang/core':
-        specifier: 1.0.0-rc.5
-        version: 1.0.0-rc.5(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)
+        specifier: 1.0.0
+        version: 1.0.0(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)
       '@solana/web3.js':
         specifier: ^1.98.4
         version: 1.98.4(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)
@@ -45,18 +45,18 @@ importers:
 
 packages:
 
-  '@anchor-lang/borsh@1.0.0-rc.5':
-    resolution: {integrity: sha512-17a+xOmvrn7zSIqlbsjqgz4f64vQEvAmZ7qyQuETCHSskC23LTtjRI0DqAl/r/vC6kosPJGWyOr9ddVIqUVtww==}
+  '@anchor-lang/borsh@1.0.0':
+    resolution: {integrity: sha512-kiUd4S/iGKZ4aZvHtX07vNiNnHa/mI/IHmw+0y0sWlvGpPsAWsLXXMrohII5vNCdgZrw+5vVXH9kt836yP9YmQ==}
     engines: {node: '>=10'}
     peerDependencies:
       '@solana/web3.js': ^1.69.0
 
-  '@anchor-lang/core@1.0.0-rc.5':
-    resolution: {integrity: sha512-4iPy4RiEFn6obzYY7zx8IaGAXz2fvJ0uCTF6agAcUBjGNZeypfEb4ZZh6TfLnJy78Lh06JeB7XGqKsaBCMEmQA==}
+  '@anchor-lang/core@1.0.0':
+    resolution: {integrity: sha512-YHJQCJNQwF1M1M5VNNOj1DuR7B9v7f/6I9NkFYty7HAbpb3+1HpuDD7nOqI+X3CafXzteWGWZE2kn+Ts7PBKNQ==}
     engines: {node: '>=17'}
 
-  '@anchor-lang/errors@1.0.0-rc.5':
-    resolution: {integrity: sha512-kLx7oLGVCRhtWeS9PQWGkzZTDpNrGkiJQBrx1rAhEiFemL4YumhUuEbXaaEVuLBt7qZcT1eBPN4LQxYGj3QWyw==}
+  '@anchor-lang/errors@1.0.0':
+    resolution: {integrity: sha512-j3ymePewd9Bi6OcXATViRS0IPdPBT8qW4LVM3/hNePH/rZdgi8qDkToiDGuR1fFccfn7t+BrNGudHvcs6JWCFQ==}
     engines: {node: '>=10'}
 
   '@babel/runtime@7.25.0':
@@ -85,24 +85,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.10':
     resolution: {integrity: sha512-7MH1CMW5uuxQ/s7FLST63qF8B3Hgu2HRdZ7tA1X1+mk+St4JOuIrqdhIBnnyqeyWJNI+Bww7Es5QZ0wIc1Cmkw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.10':
     resolution: {integrity: sha512-kDTi3pI6PBN6CiczsWYOyP2zk0IJI08EWEQyDMQWW221rPaaEz6FvjLhnU07KMzLv8q3qSuoB93ua6inSQ55Tw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.10':
     resolution: {integrity: sha512-tZLvEEi2u9Xu1zAqRjTcpIDGVtldigVvzug2fTuPG0ME/g8/mXpRPcNgLB22bGn6FvLJpHHnqLnwliOu8xjYrg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.10':
     resolution: {integrity: sha512-umwQU6qPzH+ISTf/eHyJ/QoQnJs3V9Vpjz2OjZXe9MVBZ7prgGafMy7yYeRGnlmDAn87AKTF3Q6weLoMGpeqdQ==}
@@ -426,12 +430,14 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   solana-bankrun-linux-x64-musl@0.3.0:
     resolution: {integrity: sha512-xsS2CS2xb1Sw4ivNXM0gPz/qpW9BX0neSvt/pnok5L330Nu9xlTnKAY8FhzzqOP9P9sJlGRM787Y6d0yYwt6xQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   solana-bankrun@0.3.0:
     resolution: {integrity: sha512-YkH7sa8TB/AoRPzG17CXJtYsRIQHEkEqGLz1Vwc13taXhDBkjO7z6NI5JYw7n0ybRymDHwMYTc7sd+5J40TyVQ==}
@@ -528,16 +534,16 @@ packages:
 
 snapshots:
 
-  '@anchor-lang/borsh@1.0.0-rc.5(@solana/web3.js@1.98.4(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10))':
+  '@anchor-lang/borsh@1.0.0(@solana/web3.js@1.98.4(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/web3.js': 1.98.4(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)
       bn.js: 5.2.2
       buffer-layout: 1.2.2
 
-  '@anchor-lang/core@1.0.0-rc.5(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)':
+  '@anchor-lang/core@1.0.0(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)':
     dependencies:
-      '@anchor-lang/borsh': 1.0.0-rc.5(@solana/web3.js@1.98.4(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10))
-      '@anchor-lang/errors': 1.0.0-rc.5
+      '@anchor-lang/borsh': 1.0.0(@solana/web3.js@1.98.4(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10))
+      '@anchor-lang/errors': 1.0.0
       '@noble/hashes': 1.8.0
       '@solana/web3.js': 1.98.4(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)
       bn.js: 5.2.2
@@ -555,7 +561,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@anchor-lang/errors@1.0.0-rc.5': {}
+  '@anchor-lang/errors@1.0.0': {}
 
   '@babel/runtime@7.25.0':
     dependencies:


### PR DESCRIPTION
## Summary

Fixes all 4 CI failures on `main` (Anchor, TypeScript, Rust Lint, Quasar workflows).

### Changes

1. **Fix stale pnpm lockfile** — `pnpm-lock.yaml` referenced `@anchor-lang/core 1.0.0-rc.5` but `package.json` specifies `1.0.0`. Regenerated lockfile. Fixes Anchor + TypeScript (Biome) workflows.

2. **Fix lever syntax error** — `basics/cross-program-invocation/anchor/programs/lever/src/lib.rs` had `_mut context` (bad find-and-replace from `ctx` → `context` rename). Changed to `context` since the parameter isn't mutated. Fixes Rust Lint (Clippy) workflow.

3. **Fix Quasar CLI install** — The `cli` crate in `blueshift-gg/quasar` was renamed to `quasar-cli`. Updated `.github/workflows/solana-quasar.yml` to use `cargo install --git ... quasar-cli`. Fixes Quasar workflow.

4. **Add Quasar CI badge** — Added Quasar workflow badge to README.md alongside Anchor, Pinocchio, and Native badges.