### PR TITLE
Quasar followup: address cursor[bot] review and complete API migration in lever

### DIFF
--- a/basics/cross-program-invocation/quasar/hand/src/instructions/pull_lever.rs
+++ b/basics/cross-program-invocation/quasar/hand/src/instructions/pull_lever.rs
@@ -15,24 +15,27 @@ pub struct PullLever {
 pub fn handle_pull_lever(accounts: &PullLever, name: &str) -> Result<(), ProgramError> {
     log("Hand is pulling the lever!");
 
-    // Build the switch_power instruction data for the lever program:
-    //   [disc=1] [name: u32 len + bytes]
-    // 128 bytes is enough for any reasonable name.
+    // Build the switch_power instruction data for the lever program.
+    //
+    // Wire format: [discriminator = 1] [name: u8 length prefix + bytes].
+    //
+    // The lever's switch_power instruction takes `String<50>`, which Quasar
+    // serialises with a single-byte length prefix (matching every other
+    // Quasar program: account-data, close-account, rent, realloc,
+    // repository-layout). An earlier version of this builder used a u32
+    // length prefix, which sent a malformed payload on every CPI call.
+    //
+    // 128 bytes is enough for any reasonable name (max 50 + 1 + 1 = 52).
     let mut data = [0u8; 128];
     let name_bytes = name.as_bytes();
-    let data_len = 1 + 4 + name_bytes.len();
+    let data_len = 1 + 1 + name_bytes.len();
 
     data[0] = 1;
-
-    let len_bytes = (name_bytes.len() as u32).to_le_bytes();
-    data[1] = len_bytes[0];
-    data[2] = len_bytes[1];
-    data[3] = len_bytes[2];
-    data[4] = len_bytes[3];
+    data[1] = name_bytes.len() as u8;
 
     let mut i = 0;
     while i < name_bytes.len() {
-        data[5 + i] = name_bytes[i];
+        data[2 + i] = name_bytes[i];
         i += 1;
     }
 

--- a/basics/cross-program-invocation/quasar/hand/src/tests.rs
+++ b/basics/cross-program-invocation/quasar/hand/src/tests.rs
@@ -30,10 +30,17 @@ fn power_account(address: Pubkey, is_on: bool) -> Account {
 }
 
 /// Build pull_lever instruction data (discriminator = 0).
-/// Wire format: [disc=0] [name: String]
+///
+/// Wire format: [discriminator = 0] [name: u8 length prefix + bytes].
+///
+/// The hand's pull_lever instruction takes `String<50>`, which Quasar
+/// serialises with a single-byte length prefix. The CPI builder in
+/// `pull_lever.rs` re-serialises the same name into the lever's
+/// instruction data using the same u8 prefix.
 fn build_pull_lever(name: &str) -> Vec<u8> {
-    let mut data = vec![0u8]; // discriminator = 0
-    data.extend_from_slice(&(name.len() as u32).to_le_bytes());
+    let mut data = Vec::with_capacity(2 + name.len());
+    data.push(0u8); // discriminator = 0
+    data.push(name.len() as u8);
     data.extend_from_slice(name.as_bytes());
     data
 }
@@ -72,6 +79,14 @@ fn test_pull_lever_turns_on() {
     assert!(logs.contains("Hand is pulling"), "hand should log");
     assert!(logs.contains("pulling the power switch"), "lever should log");
     assert!(logs.contains("now on"), "power should turn on");
+    // Verifies the CPI wire format: the lever logs the name it
+    // deserialised. A stale u32 length prefix on either the inbound
+    // `pull_lever` payload or the CPI to `switch_power` would corrupt
+    // this (e.g. "\0\0\0Al" instead of "Alice").
+    assert!(
+        logs.contains("Alice"),
+        "name should round-trip through hand → lever CPI; logs: {logs}"
+    );
 
     let account = result.account(&power_addr).unwrap();
     assert_eq!(account.data[1], 1, "power should be on");
@@ -107,6 +122,10 @@ fn test_pull_lever_turns_off() {
 
     let logs = result.logs.join("\n");
     assert!(logs.contains("now off"), "power should turn off");
+    assert!(
+        logs.contains("Bob"),
+        "name should round-trip through hand → lever CPI; logs: {logs}"
+    );
 
     let account = result.account(&power_addr).unwrap();
     assert_eq!(account.data[1], 0, "power should be off");

--- a/basics/cross-program-invocation/quasar/lever/src/instructions/initialize.rs
+++ b/basics/cross-program-invocation/quasar/lever/src/instructions/initialize.rs
@@ -1,21 +1,21 @@
 use {
-    crate::state::PowerStatus,
+    crate::state::{PowerStatus, PowerStatusInner},
     quasar_lang::prelude::*,
 };
 
 /// Accounts for initialising the power status (PDA seeded by "power").
 #[derive(Accounts)]
-pub struct InitializeLever<'info> {
+pub struct InitializeLever {
     #[account(mut)]
-    pub payer: &'info mut Signer,
-    #[account(mut, init, payer = payer, seeds = [b"power"], bump)]
-    pub power: &'info mut Account<PowerStatus>,
-    pub system_program: &'info Program<System>,
+    pub payer: Signer,
+    #[account(mut, init, payer = payer, seeds = PowerStatus::seeds(), bump)]
+    pub power: Account<PowerStatus>,
+    pub system_program: Program<System>,
 }
 
 #[inline(always)]
 pub fn handle_initialize(accounts: &mut InitializeLever) -> Result<(), ProgramError> {
-    // Power starts off (false).
-    accounts.power.set_inner(PodBool::from(false));
+    // Power starts off (false). Counter-style fixed-size set_inner takes only the inner value.
+    accounts.power.set_inner(PowerStatusInner { is_on: PodBool::from(false) });
     Ok(())
 }

--- a/basics/cross-program-invocation/quasar/lever/src/instructions/switch_power.rs
+++ b/basics/cross-program-invocation/quasar/lever/src/instructions/switch_power.rs
@@ -11,13 +11,18 @@ pub struct SwitchPower {
 }
 
 #[inline(always)]
-pub fn handle_switch_power(accounts: &mut SwitchPower, _name: &str) -> Result<(), ProgramError> {
+pub fn handle_switch_power(accounts: &mut SwitchPower, name: &str) -> Result<(), ProgramError> {
     let current: bool = accounts.power.is_on.into();
     let new_state = !current;
     accounts.power.is_on = PodBool::from(new_state);
 
     // Quasar's log() takes &str — no format! in no_std.
+    // Logging the name verifies the wire format end-to-end: a stale u32
+    // length prefix would surface here as a corrupted name (e.g. the
+    // first three bytes parsed as zeros, leaving "\0\0\0Al" instead of
+    // "Alice").
     log("Someone is pulling the power switch!");
+    log(name);
 
     if new_state {
         log("The power is now on.");

--- a/basics/cross-program-invocation/quasar/lever/src/instructions/switch_power.rs
+++ b/basics/cross-program-invocation/quasar/lever/src/instructions/switch_power.rs
@@ -5,9 +5,9 @@ use {
 
 /// Accounts for toggling the power switch.
 #[derive(Accounts)]
-pub struct SwitchPower<'info> {
+pub struct SwitchPower {
     #[account(mut)]
-    pub power: &'info mut Account<PowerStatus>,
+    pub power: Account<PowerStatus>,
 }
 
 #[inline(always)]

--- a/basics/cross-program-invocation/quasar/lever/src/lib.rs
+++ b/basics/cross-program-invocation/quasar/lever/src/lib.rs
@@ -22,7 +22,7 @@ mod quasar_lever {
 
     /// Toggle the power switch. Logs who is pulling the lever.
     #[instruction(discriminator = 1)]
-    pub fn switch_power(ctx: Ctx<SwitchPower>, name: String) -> Result<(), ProgramError> {
+    pub fn switch_power(ctx: Ctx<SwitchPower>, name: String<50>) -> Result<(), ProgramError> {
         instructions::handle_switch_power(&mut ctx.accounts, name)
     }
 }

--- a/basics/cross-program-invocation/quasar/lever/src/state.rs
+++ b/basics/cross-program-invocation/quasar/lever/src/state.rs
@@ -1,7 +1,9 @@
 use quasar_lang::prelude::*;
 
 /// Onchain power status: a single boolean toggle.
-#[account(discriminator = 1)]
+/// Derived as a PDA from the seed "power" (single global account).
+#[account(discriminator = 1, set_inner)]
+#[seeds(b"power")]
 pub struct PowerStatus {
     pub is_on: PodBool,
 }

--- a/basics/cross-program-invocation/quasar/lever/src/tests.rs
+++ b/basics/cross-program-invocation/quasar/lever/src/tests.rs
@@ -47,10 +47,19 @@ fn build_initialize() -> Vec<u8> {
 }
 
 /// Build switch_power instruction data (discriminator = 1).
-/// Wire format: [disc=1] [name: String]
+///
+/// Wire format: [discriminator = 1] [name: u8 length prefix + bytes].
+///
+/// The lever's switch_power instruction takes `String<50>`, which Quasar
+/// serialises with a single-byte length prefix (matching every other
+/// Quasar program: account-data, close-account, rent, realloc,
+/// repository-layout). An earlier version of this builder used a u32
+/// length prefix, which produced a malformed payload that happened to
+/// pass because the handler ignored the deserialised name.
 fn build_switch_power(name: &str) -> Vec<u8> {
-    let mut data = vec![1u8]; // discriminator = 1
-    data.extend_from_slice(&(name.len() as u32).to_le_bytes());
+    let mut data = Vec::with_capacity(2 + name.len());
+    data.push(1u8); // discriminator = 1
+    data.push(name.len() as u8);
     data.extend_from_slice(name.as_bytes());
     data
 }
@@ -104,6 +113,12 @@ fn test_switch_power_on() {
     let logs = result.logs.join("\n");
     assert!(logs.contains("pulling the power switch"), "should log switch");
     assert!(logs.contains("now on"), "should say power is on");
+    // Verifies wire format: a stale u32 length prefix would corrupt the
+    // deserialised name (e.g. "\0\0\0Al" instead of "Alice").
+    assert!(
+        logs.contains("Alice"),
+        "deserialised name should round-trip exactly; logs: {logs}"
+    );
 
     let account = result.account(&power_addr).unwrap();
     assert_eq!(account.data[1], 1, "power should now be on");
@@ -128,6 +143,10 @@ fn test_switch_power_off() {
 
     let logs = result.logs.join("\n");
     assert!(logs.contains("now off"), "should say power is off");
+    assert!(
+        logs.contains("Bob"),
+        "deserialised name should round-trip exactly; logs: {logs}"
+    );
 
     let account = result.account(&power_addr).unwrap();
     assert_eq!(account.data[1], 0, "power should now be off");

--- a/tokens/token-extensions/basics/quasar/Cargo.toml
+++ b/tokens/token-extensions/basics/quasar/Cargo.toml
@@ -26,6 +26,6 @@ quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master"
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]
-quasar-svm = { version = "0.1" }
+quasar-svm = { git = "https://github.com/blueshift-gg/quasar-svm" }
 spl-token-interface = { version = "2.0.0" }
 solana-program-pack = { version = "3.1.0" }

--- a/tokens/token-extensions/cpi-guard/quasar/Cargo.toml
+++ b/tokens/token-extensions/cpi-guard/quasar/Cargo.toml
@@ -25,6 +25,6 @@ quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master"
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]
-quasar-svm = { version = "0.1" }
+quasar-svm = { git = "https://github.com/blueshift-gg/quasar-svm" }
 spl-token-interface = { version = "2.0.0" }
 solana-program-pack = { version = "3.1.0" }

--- a/tokens/token-extensions/default-account-state/quasar/Cargo.toml
+++ b/tokens/token-extensions/default-account-state/quasar/Cargo.toml
@@ -25,6 +25,6 @@ quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master"
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]
-quasar-svm = { version = "0.1" }
+quasar-svm = { git = "https://github.com/blueshift-gg/quasar-svm" }
 spl-token-interface = { version = "2.0.0" }
 solana-program-pack = { version = "3.1.0" }

--- a/tokens/token-extensions/group/quasar/Cargo.toml
+++ b/tokens/token-extensions/group/quasar/Cargo.toml
@@ -25,6 +25,6 @@ quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master"
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]
-quasar-svm = { version = "0.1" }
+quasar-svm = { git = "https://github.com/blueshift-gg/quasar-svm" }
 spl-token-interface = { version = "2.0.0" }
 solana-program-pack = { version = "3.1.0" }

--- a/tokens/token-extensions/immutable-owner/quasar/Cargo.toml
+++ b/tokens/token-extensions/immutable-owner/quasar/Cargo.toml
@@ -25,6 +25,6 @@ quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master"
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]
-quasar-svm = { version = "0.1" }
+quasar-svm = { git = "https://github.com/blueshift-gg/quasar-svm" }
 spl-token-interface = { version = "2.0.0" }
 solana-program-pack = { version = "3.1.0" }

--- a/tokens/token-extensions/interest-bearing/quasar/Cargo.toml
+++ b/tokens/token-extensions/interest-bearing/quasar/Cargo.toml
@@ -25,6 +25,6 @@ quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master"
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]
-quasar-svm = { version = "0.1" }
+quasar-svm = { git = "https://github.com/blueshift-gg/quasar-svm" }
 spl-token-interface = { version = "2.0.0" }
 solana-program-pack = { version = "3.1.0" }

--- a/tokens/token-extensions/memo-transfer/quasar/Cargo.toml
+++ b/tokens/token-extensions/memo-transfer/quasar/Cargo.toml
@@ -25,6 +25,6 @@ quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master"
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]
-quasar-svm = { version = "0.1" }
+quasar-svm = { git = "https://github.com/blueshift-gg/quasar-svm" }
 spl-token-interface = { version = "2.0.0" }
 solana-program-pack = { version = "3.1.0" }

--- a/tokens/token-extensions/mint-close-authority/quasar/Cargo.toml
+++ b/tokens/token-extensions/mint-close-authority/quasar/Cargo.toml
@@ -25,6 +25,6 @@ quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master"
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]
-quasar-svm = { version = "0.1" }
+quasar-svm = { git = "https://github.com/blueshift-gg/quasar-svm" }
 spl-token-interface = { version = "2.0.0" }
 solana-program-pack = { version = "3.1.0" }

--- a/tokens/token-extensions/non-transferable/quasar/Cargo.toml
+++ b/tokens/token-extensions/non-transferable/quasar/Cargo.toml
@@ -25,6 +25,6 @@ quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master"
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]
-quasar-svm = { version = "0.1" }
+quasar-svm = { git = "https://github.com/blueshift-gg/quasar-svm" }
 spl-token-interface = { version = "2.0.0" }
 solana-program-pack = { version = "3.1.0" }

--- a/tokens/token-extensions/permanent-delegate/quasar/Cargo.toml
+++ b/tokens/token-extensions/permanent-delegate/quasar/Cargo.toml
@@ -25,6 +25,6 @@ quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master"
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]
-quasar-svm = { version = "0.1" }
+quasar-svm = { git = "https://github.com/blueshift-gg/quasar-svm" }
 spl-token-interface = { version = "2.0.0" }
 solana-program-pack = { version = "3.1.0" }

--- a/tokens/token-extensions/transfer-fee/quasar/Cargo.toml
+++ b/tokens/token-extensions/transfer-fee/quasar/Cargo.toml
@@ -25,6 +25,6 @@ quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master"
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]
-quasar-svm = { version = "0.1" }
+quasar-svm = { git = "https://github.com/blueshift-gg/quasar-svm" }
 spl-token-interface = { version = "2.0.0" }
 solana-program-pack = { version = "3.1.0" }


### PR DESCRIPTION
This PR addresses the [cursor[bot] review comments on #8](https://github.com/quiknode-labs/solana-program-examples/pull/8) (now merged) and verifies the impl→free-function migration is complete across all Quasar programs.

## Cursor[bot] review on #8 — status of all 8 comments

| # | File | Severity | Status |
|---|------|----------|--------|
| 1 | `tokens/escrow/quasar/src/lib.rs` — renamed handler functions don't match calls | HIGH | **Already fixed** before merge (`handle_withdraw_tokens_and_close_take` / `_refund` are referenced and defined). |
| 2 | Many programs still using `ctx.accounts.xxx()` method-style dispatch | MEDIUM | **Already fixed** — every `*/quasar/src/lib.rs` now uses `handle_xxx(&mut ctx.accounts, …)`, and zero `fn foo(&self, …)` handlers remain in any quasar/src file. |
| 3 | `basics/counter/quasar/src/lib.rs` unconditional `#![no_std]` | MEDIUM | **Already fixed** — uses `#![cfg_attr(not(test), no_std)]`. |
| 4 | `.gitignore` `.claire` typo | LOW | **Already addressed** — `.claire` was removed in a later commit; current `.gitignore` only has `.claude`. (If `.claire` is a real coding-agent dir like `.claude`, the entry can be re-added separately.) |
| 5 | `basics/cross-program-invocation/quasar/{hand,lever}` unconditional `#![no_std]` | MEDIUM | **Already fixed** — both use `#![cfg_attr(not(test), no_std)]`. |
| 6 | Token-extension crates kept `quasar-svm = { version = "0.1" }` from crates.io while every other quasar crate migrated to `git = "https://…/quasar-svm"` | MEDIUM | **Fixed in this PR** (commit `37bc8084`) for all 11 `tokens/token-extensions/*/quasar/Cargo.toml`. Verified by building + `cargo test --release` on `basics`, `cpi-guard`, and `transfer-fee`. |
| 7 | `basics/realloc/quasar/src/tests.rs` — `String<1024>` likely needs u16 prefix | HIGH | **Verified — code is correct.** Quasar re-exports `PodString as String`; `PodString<const N, const PFX = 1>` defaults the prefix width to **1 byte** (u8) regardless of `N`. Quasar's own test suite states *"String\<N\> instruction args use u8 prefix on the wire"* (see `quasar/tests/suite/src/dynamic.rs`). Tests pass on the build with the current u8 wire format. |
| 8 | `basics/cross-program-invocation/quasar/lever` — Cargo.toml updated but source still uses pre-migration API | MEDIUM | **Fixed in this PR** (commit `ddea756d`). The lever crate is excluded from CI via `.github/.ghaignore` (CPI uses sub-crates rather than a root `Quasar.toml`), so the breakage was masked. Verified locally: `quasar build && cargo test --release` passes for both lever (4 tests) and hand (3 tests). |

## What changed

1. **`fix(token-extensions): migrate quasar-svm to git dep`** — eleven `tokens/token-extensions/*/quasar/Cargo.toml` files now fetch `quasar-svm` from `https://github.com/blueshift-gg/quasar-svm`, matching the rest of the workspace. Eliminates the crates.io ↔ git mismatch that risked version conflicts at runtime.
2. **`fix(cpi/lever): migrate to current Quasar API`** — drop `<'info>` lifetime parameters from account context structs; replace `&'info mut Signer` / `&'info mut Account<...>` / `&'info Program<...>` with their owned forms; move the `b"power"` PDA seed onto the state struct via `#[seeds(...)]`; mark `PowerStatus` with `set_inner` and use `PowerStatusInner` from the handler; constrain the `name` instruction arg to `String<50>` (plain `String` doesn't compile any more).

## Verification

- `quasar build && cargo test --release` runs clean locally for `tokens/token-extensions/{basics,cpi-guard,transfer-fee}/quasar`, `basics/cross-program-invocation/quasar/lever` (4 tests), and `basics/cross-program-invocation/quasar/hand` (3 tests).
- The `Quasar` workflow does not exercise `basics/cross-program-invocation/quasar` (excluded in `.github/.ghaignore` because CPI uses sub-projects), so this fix is verified locally only — but the project now actually builds, which it did not before this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CPI instruction encoding and lever account initialization/seeding, so mistakes could break cross-program calls or PDA expectations. Changes are localized and are backed by expanded tests that validate end-to-end name deserialization.
> 
> **Overview**
> Fixes the cross-program invocation between `hand` and `lever` by serializing the `name` argument with a **u8 length prefix** (matching Quasar `String<50>`), instead of the previously malformed u32-prefixed payload.
> 
> Completes the lever program’s Quasar API migration by updating `Accounts` structs and PDA seeding to the current patterns (`#[seeds]`, `set_inner`/`PowerStatusInner`, and `String<50>` for `switch_power`), and adds logging + stronger tests in both programs to assert the name round-trips through the CPI path.
> 
> Separately, updates all token-extension Quasar examples to pull `quasar-svm` as a git dev-dependency instead of the crates.io `0.1` release to avoid dependency mismatches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ec7de121bfcfc9084fc29d0b4952747432a28db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->