### PR TITLE
ci: pin solana-cli-version to 3.1.10 (fix flaky CI from upstream 'stable' resolver)

### DIFF
--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -138,7 +138,14 @@ jobs:
       - uses: heyAyushh/setup-anchor@v4.999
         with:
           anchor-version: 1.0.0
-          solana-cli-version: stable
+          # Pinned to 3.1.10 (not `stable`) because heyAyushh/setup-anchor's
+          # `stable` resolver intermittently returns an empty version string,
+          # which makes the action curl https://release.anza.xyz/v/install and
+          # 404. 3.1.10 is the version recommended by Anchor 1.0.0's release
+          # notes and pinned by Anchor's own CI in 1.0.0-rc.5+. Bump in lockstep
+          # with anchor-version above. See upstream issue tracking the brittle
+          # `stable` behaviour.
+          solana-cli-version: 3.1.10
       - name: Install Surfpool
         run: curl -sL https://run.surfpool.run/ | bash
       - name: Display Versions

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -222,7 +222,16 @@ jobs:
       - name: Setup Solana Stable
         uses: heyAyushh/setup-solana@v5.9
         with:
-          solana-cli-version: stable
+          # Pinned to 3.1.10 (not `stable`) because heyAyushh/setup-solana's
+          # `stable` resolver intermittently returns an empty version string,
+          # which makes the action curl https://release.anza.xyz/v/install and
+          # 404. 3.1.10 is the version recommended by Anchor 1.0.0's release
+          # notes; we use it here too to keep the matrix consistent across
+          # frameworks. The `beta` step below intentionally stays floating —
+          # it's the channel-tracking job and is already marked
+          # continue-on-error. See upstream issue tracking the brittle `stable`
+          # behaviour.
+          solana-cli-version: 3.1.10
       - name: Build and Test with Stable
         run: |
           source build_and_test.sh

--- a/.github/workflows/pinocchio.yml
+++ b/.github/workflows/pinocchio.yml
@@ -222,7 +222,16 @@ jobs:
       - name: Setup Solana Stable
         uses: heyAyushh/setup-solana@v5.9
         with:
-          solana-cli-version: stable
+          # Pinned to 3.1.10 (not `stable`) because heyAyushh/setup-solana's
+          # `stable` resolver intermittently returns an empty version string,
+          # which makes the action curl https://release.anza.xyz/v/install and
+          # 404. 3.1.10 is the version recommended by Anchor 1.0.0's release
+          # notes; we use it here too to keep the matrix consistent across
+          # frameworks. The `beta` step below intentionally stays floating —
+          # it's the channel-tracking job and is already marked
+          # continue-on-error. See upstream issue tracking the brittle `stable`
+          # behaviour.
+          solana-cli-version: 3.1.10
       - name: Build and Test with Stable
         run: |
           source build_and_test.sh

--- a/.github/workflows/quasar.yml
+++ b/.github/workflows/quasar.yml
@@ -197,7 +197,13 @@ jobs:
       - name: Setup Solana Stable
         uses: heyAyushh/setup-solana@v5.9
         with:
-          solana-cli-version: stable
+          # Pinned to 3.1.10 (not `stable`) because heyAyushh/setup-solana's
+          # `stable` resolver intermittently returns an empty version string,
+          # which makes the action curl https://release.anza.xyz/v/install and
+          # 404. 3.1.10 is the version recommended by Anchor 1.0.0's release
+          # notes; using it here keeps the matrix consistent across frameworks.
+          # See upstream issue tracking the brittle `stable` behaviour.
+          solana-cli-version: 3.1.10
       - name: Install Quasar CLI
         # Pinned to quasar rev 3d6fb0d8 (the HEAD this migration was written
         # against, immediately after PRs #195 + #196). The next merged PR


### PR DESCRIPTION
## Problem

CI on `main` is flaky and failing semi-randomly across all four framework workflows (anchor, native, pinocchio, quasar). Concrete example: run [25696483414](https://github.com/quiknode-labs/solana-program-examples/actions/runs/25696483414) (Anchor, on the merge commit for #12).

The failing step is `Setup Solana Stable` inside [`heyAyushh/setup-solana@v5.9`](https://github.com/heyAyushh/setup-solana) (used directly in native/pinocchio/quasar, and transitively via [`heyAyushh/setup-anchor@v4.999`](https://github.com/heyAyushh/setup-anchor) in anchor.yml). With `solana-cli-version: stable` the action's resolver reads an upstream `STABLE_CHANNEL_LATEST_TAG` env var and strips the leading `v` — but when that var is unset/empty for a given run, the action logs:

```
Using stable version: 
Using Solana CLI version 
```

…and then curls `https://release.anza.xyz/v/install` (no version) which returns:

```
curl: (22) The requested URL returned error: 404
##[error]Process completed with exit code 1.
```

This is non-deterministic — same commit, same workflow, sometimes passes, sometimes 404s. It's currently breaking PR-merge CI and the scheduled nightly runs.

## Why the action is the problem (and why we can't just upgrade it)

- `v4.999` / `v5.9` ARE the latest tags. The maintainer uses a non-standard `v4.99X`/`v5.X` floating-tag scheme where higher = newer (formal `v4.0` was July 2024; `v4.99X` tags have been the de facto latest since).
- The maintainer's most recent commit message on `setup-anchor` (2025-06-10) is literally **"bumped action because of solana stable"** — i.e. upstream is openly chasing solana-stable brittleness but consumers still get `stable` as the de facto default.
- We've already had to add `continue-on-error: true` + an explanatory comment on the matching `beta` steps in native.yml/pinocchio.yml for an analogous upstream beta-404 issue.

Given the action is already at its latest tag and the maintainer has acknowledged the issue without fixing the consumer-facing default, the only defensive option available to us is to **stop using `stable` and pin a concrete version**.

## Fix

Replace `solana-cli-version: stable` with `solana-cli-version: 3.1.10` in:

- `.github/workflows/anchor.yml`
- `.github/workflows/native.yml` (stable step only)
- `.github/workflows/pinocchio.yml` (stable step only)
- `.github/workflows/quasar.yml`

### Why 3.1.10?

- Anchor 1.0.0's [release notes](https://www.anchor-lang.com/docs/updates/release-notes/1-0-0) state: **"The recommended Solana version is 3.1.10"** and **"Anchor 1.0.0 targets Solana 3.x"**.
- Anchor's own CHANGELOG for [1.0.0-rc.5](https://github.com/solana-foundation/anchor/blob/v1.0.0/CHANGELOG.md) explicitly says: _"Bumping CI and docker builds to use Solana CLI version 3.1.10."_
- It's compatible with our existing `anchor-version: 1.0.0` pin.
- It exists at `https://release.anza.xyz/v3.1.10/install` (verified: HTTP 200).

The non-anchor frameworks (native, pinocchio, quasar) are pinned to the same value to keep the CI matrix consistent across frameworks; nothing in those workflows requires a different CLI.

### What's intentionally left floating

The `beta` steps in native.yml and pinocchio.yml. Those are channel-tracking jobs by design and are already `continue-on-error: true` with a comment explaining the upstream beta-404 behaviour. Pinning them would defeat the point.

## Maintenance note

Each pin has an inline comment explaining why `stable` was rejected and that the version should be bumped **in lockstep with `anchor-version`** when Anchor is upgraded. A separate issue will be filed upstream at `heyAyushh/setup-solana` documenting the empty-version resolver bug; if upstream ever fixes it cleanly we can revisit reverting to `stable`, but the inline comments will survive that decision.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` clean on all four workflows.
- Diff is comment + value change only, no structural changes.
- Once this PR's CI runs we should see all four framework workflows pass deterministically.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only changes that pin the Solana CLI version to avoid flaky installs; no production code or runtime behavior is modified.
> 
> **Overview**
> Pins the GitHub Actions Solana toolchain from `stable` to **`3.1.10`** in the Anchor, Native, Pinocchio, and Quasar workflows to prevent intermittent `setup-solana`/`setup-anchor` failures.
> 
> Adds inline comments documenting the upstream `stable` resolver flakiness and noting that the pin should be bumped in lockstep with the Anchor version (while leaving existing beta channel tracking behavior unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e90f11fb48794984109746cc86c2dd9a47d714cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->