### PR TITLE
docs: add ASM workflow badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A fork of the [Solana Foundation program examples](https://github.com/solana-developers/program-examples) with current versions, more programs, and additional frameworks.
 
-[![Anchor](../../actions/workflows/anchor.yml/badge.svg)](../../actions/workflows/anchor.yml) [![Quasar](../../actions/workflows/quasar.yml/badge.svg)](../../actions/workflows/quasar.yml) [![Pinocchio](../../actions/workflows/pinocchio.yml/badge.svg)](../../actions/workflows/pinocchio.yml) [![Native](../../actions/workflows/native.yml/badge.svg)](../../actions/workflows/native.yml)
+[![Anchor](../../actions/workflows/anchor.yml/badge.svg)](../../actions/workflows/anchor.yml) [![Quasar](../../actions/workflows/quasar.yml/badge.svg)](../../actions/workflows/quasar.yml) [![Pinocchio](../../actions/workflows/pinocchio.yml/badge.svg)](../../actions/workflows/pinocchio.yml) [![Native](../../actions/workflows/native.yml/badge.svg)](../../actions/workflows/native.yml) [![ASM](../../actions/workflows/solana-asm.yml/badge.svg)](../../actions/workflows/solana-asm.yml)
 
 Each example is available in one or more of the following frameworks:
 


### PR DESCRIPTION
Adds a CI status badge for the `solana-asm.yml` workflow alongside the existing Anchor / Quasar / Pinocchio / Native badges, so the badge row reflects every framework with working examples in the repo.

Docs-only change — no code or CI touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that adds a new workflow status badge; no code, build, or runtime behavior is affected.
> 
> **Overview**
> Updates `README.md` to include an additional CI status badge for the `solana-asm.yml` workflow alongside the existing framework badges, making the badge row reflect ASM coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bc8b984de5bb2fed67444f0d68efc5760d8ebd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->