### PR TITLE
docs: add ASM to framework list and per-example links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Each example is available in one or more of the following frameworks:
 - [💫 Quasar](https://quasar-lang.com/docs) — a newer, more performant framework with Anchor-compatible ergonomics. Run `pnpm test` to execute tests.
 - [🤥 Pinocchio](https://github.com/febo/pinocchio) — a zero-copy, zero-allocation library for Solana programs. Run `pnpm test` to execute tests.
 - [🦀 Native Rust](https://docs.solana.com/) — vanilla Rust using Solana's native crates. Run `pnpm test` to execute tests.
+- [🧬 ASM](https://github.com/blueshift-gg/sbpf) — hand-written sBPF assembly via the `sbpf` toolchain, for maximum control and minimum compute. Build with `sbpf build`, test with `pnpm test`.
 
 > [!NOTE]
 > You don't need to write your own program for basic tasks like creating accounts, transferring SOL, or minting tokens. These are handled by existing programs like the System Program and Token Program.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Read offchain price data onchain using the Pyth oracle network.
 
 A minimal program that logs a greeting.
 
-[⚓ Anchor](./basics/hello-solana/anchor) [💫 Quasar](./basics/hello-solana/quasar) [🤥 Pinocchio](./basics/hello-solana/pinocchio) [🦀 Native](./basics/hello-solana/native)
+[⚓ Anchor](./basics/hello-solana/anchor) [💫 Quasar](./basics/hello-solana/quasar) [🤥 Pinocchio](./basics/hello-solana/pinocchio) [🦀 Native](./basics/hello-solana/native) [🧬 ASM](./basics/hello-solana/asm)
 
 ### Account Data
 
@@ -71,7 +71,7 @@ Save and update per-user state, ensuring users can only modify their own data.
 
 Validate that accounts provided in incoming instructions meet specific criteria.
 
-[⚓ Anchor](./basics/checking-accounts/anchor) [💫 Quasar](./basics/checking-accounts/quasar) [🤥 Pinocchio](./basics/checking-accounts/pinocchio) [🦀 Native](./basics/checking-accounts/native)
+[⚓ Anchor](./basics/checking-accounts/anchor) [💫 Quasar](./basics/checking-accounts/quasar) [🤥 Pinocchio](./basics/checking-accounts/pinocchio) [🦀 Native](./basics/checking-accounts/native) [🧬 ASM](./basics/checking-accounts/asm)
 
 ### Close Account
 
@@ -83,7 +83,7 @@ Close an account and reclaim its lamports.
 
 Create new accounts on the blockchain.
 
-[⚓ Anchor](./basics/create-account/anchor) [💫 Quasar](./basics/create-account/quasar) [🤥 Pinocchio](./basics/create-account/pinocchio) [🦀 Native](./basics/create-account/native)
+[⚓ Anchor](./basics/create-account/anchor) [💫 Quasar](./basics/create-account/quasar) [🤥 Pinocchio](./basics/create-account/pinocchio) [🦀 Native](./basics/create-account/native) [🧬 ASM](./basics/create-account/asm)
 
 ### Cross-Program Invocation
 
@@ -131,7 +131,7 @@ Structure a larger Solana program across multiple files and modules.
 
 Send SOL between two accounts.
 
-[⚓ Anchor](./basics/transfer-sol/anchor) [💫 Quasar](./basics/transfer-sol/quasar) [🤥 Pinocchio](./basics/transfer-sol/pinocchio) [🦀 Native](./basics/transfer-sol/native)
+[⚓ Anchor](./basics/transfer-sol/anchor) [💫 Quasar](./basics/transfer-sol/quasar) [🤥 Pinocchio](./basics/transfer-sol/pinocchio) [🦀 Native](./basics/transfer-sol/native) [🧬 ASM](./basics/transfer-sol/asm)
 
 ## Tokens
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Each example is available in one or more of the following frameworks:
 - [💫 Quasar](https://quasar-lang.com/docs) — a newer, more performant framework with Anchor-compatible ergonomics. Run `pnpm test` to execute tests.
 - [🤥 Pinocchio](https://github.com/febo/pinocchio) — a zero-copy, zero-allocation library for Solana programs. Run `pnpm test` to execute tests.
 - [🦀 Native Rust](https://docs.solana.com/) — vanilla Rust using Solana's native crates. Run `pnpm test` to execute tests.
-- [🧬 ASM](https://github.com/blueshift-gg/sbpf) — hand-written sBPF assembly via the `sbpf` toolchain, for maximum control and minimum compute. Build with `sbpf build`, test with `pnpm test`.
+- [🧬 ASM](https://github.com/blueshift-gg/sbpf) — hand-written sBPF assembly built with the `sbpf` toolchain. Run `pnpm build-and-test` to build and test.
 
 > [!NOTE]
 > You don't need to write your own program for basic tasks like creating accounts, transferring SOL, or minting tokens. These are handled by existing programs like the System Program and Token Program.


### PR DESCRIPTION
Follow-up to #15. Two related fixes:

1. The framework bullet list still didn't include ASM \u2014 added an entry matching the style of the others.
2. Four examples have ASM implementations (`basics/hello-solana`, `basics/checking-accounts`, `basics/create-account`, `basics/transfer-sol`) but their per-example link rows weren't listing ASM. Added the missing links.

Docs-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change updating the README; the main risk is broken/incorrect links or confusing build instructions for ASM.
> 
> **Overview**
> Adds **ASM** to the top-level framework list in `README.md` with build/test instructions.
> 
> Updates the per-example framework link rows to include **ASM** for `basics/hello-solana`, `basics/checking-accounts`, `basics/create-account`, and `basics/transfer-sol`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2120474653df0880946a6597852bb936aa160915. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->