### PR TITLE
fix(ci): use find as single source of truth for framework project detection

### DIFF
--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -50,8 +50,35 @@ jobs:
           ignore_pattern=$(grep -v '^#' .github/.ghaignore | grep -v '^$' | tr '\n' '|' | sed 's/|$//')
           echo "Ignore pattern: $ignore_pattern"
 
+          # Single source of truth for "what is a framework project": a directory
+          # whose name is exactly "anchor". `find -type d -name anchor` gives us
+          # that by construction — no substring matching, no path-segment trickery,
+          # so siblings like "anchor-example/" or nested files such as
+          # "anchor-example/app/pages/api/foo.ts" can never enter the build list.
           function get_projects() {
             find . -type d -name "anchor" | grep -vE "$ignore_pattern" | sort
+          }
+
+          # Filter the full project list down to projects touched by the given
+          # changed files. A file "touches" a project iff it lives inside that
+          # project directory (prefix match on "<project>/"). This is an
+          # intersection against get_projects(), so the result is always a subset
+          # of the authoritative project list.
+          function filter_by_changes() {
+            local all_projects="$1"
+            shift
+            local changed_files=("$@")
+            echo "$all_projects" | while read -r project; do
+              [ -z "$project" ] && continue
+              # Strip leading ./ so prefix comparison matches git's output
+              local project_prefix="${project#./}/"
+              for file in "${changed_files[@]}"; do
+                if [[ "$file" == "$project_prefix"* ]]; then
+                  echo "$project"
+                  break
+                fi
+              done
+            done | sort -u
           }
 
           # Determine which projects to build and test
@@ -60,15 +87,15 @@ jobs:
             projects=$(get_projects)
           elif [[ "${{ github.event_name }}" == "push" ]]; then
             # On push, only build projects with changes since parent commit
-            changed_files=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "")
-            if [ -z "$changed_files" ]; then
+            mapfile -t changed_files < <(git diff --name-only HEAD~1 HEAD 2>/dev/null || true)
+            if [ ${#changed_files[@]} -eq 0 ]; then
               projects=$(get_projects)
             else
-              projects=$(echo "$changed_files" | while read file; do dirname "$file" | grep anchor | sed 's#/anchor/.*#/anchor#g'; done | grep -vE "$ignore_pattern" | sort -u)
+              projects=$(filter_by_changes "$(get_projects)" "${changed_files[@]}")
             fi
           elif [[ "${{ steps.changes.outputs.anchor }}" == "true" ]]; then
             changed_files=(${{ steps.changes.outputs.anchor_files }})
-            projects=$(for file in "${changed_files[@]}"; do dirname "${file}" | grep anchor | sed 's#/anchor/.*#/anchor#g'; done | grep -vE "$ignore_pattern" | sort -u)
+            projects=$(filter_by_changes "$(get_projects)" "${changed_files[@]}")
           else
             projects=""
           fi

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -50,8 +50,33 @@ jobs:
           ignore_pattern=$(grep -v '^#' .github/.ghaignore | grep -v '^$' | tr '\n' '|' | sed 's/|$//')
           echo "Ignore pattern: $ignore_pattern"
 
+          # Single source of truth for "what is a framework project": a directory
+          # whose name is exactly "native". `find -type d -name native` gives us
+          # that by construction — no substring matching, no path-segment trickery,
+          # so siblings like "alternative/" can never enter the build list.
           function get_projects() {
             find . -type d -name "native" | grep -vE "$ignore_pattern" | sort
+          }
+
+          # Filter the full project list down to projects touched by the given
+          # changed files. A file "touches" a project iff it lives inside that
+          # project directory (prefix match on "<project>/"). This is an
+          # intersection against get_projects(), so the result is always a subset
+          # of the authoritative project list.
+          function filter_by_changes() {
+            local all_projects="$1"
+            shift
+            local changed_files=("$@")
+            echo "$all_projects" | while read -r project; do
+              [ -z "$project" ] && continue
+              local project_prefix="${project#./}/"
+              for file in "${changed_files[@]}"; do
+                if [[ "$file" == "$project_prefix"* ]]; then
+                  echo "$project"
+                  break
+                fi
+              done
+            done | sort -u
           }
 
           # Determine which projects to build and test
@@ -60,15 +85,15 @@ jobs:
             projects=$(get_projects)
           elif [[ "${{ github.event_name }}" == "push" ]]; then
             # On push, only build projects with changes since parent commit
-            changed_files=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "")
-            if [ -z "$changed_files" ]; then
+            mapfile -t changed_files < <(git diff --name-only HEAD~1 HEAD 2>/dev/null || true)
+            if [ ${#changed_files[@]} -eq 0 ]; then
               projects=$(get_projects)
             else
-              projects=$(echo "$changed_files" | while read file; do dirname "$file" | grep native | sed 's#/native/.*#/native#g'; done | grep -vE "$ignore_pattern" | sort -u)
+              projects=$(filter_by_changes "$(get_projects)" "${changed_files[@]}")
             fi
           elif [[ "${{ steps.changes.outputs.native }}" == "true" ]]; then
             changed_files=(${{ steps.changes.outputs.native_files }})
-            projects=$(for file in "${changed_files[@]}"; do dirname "${file}" | grep native | sed 's#/native/.*#/native#g'; done | grep -vE "$ignore_pattern" | sort -u)
+            projects=$(filter_by_changes "$(get_projects)" "${changed_files[@]}")
           else
             projects=""
           fi

--- a/.github/workflows/pinocchio.yml
+++ b/.github/workflows/pinocchio.yml
@@ -50,8 +50,34 @@ jobs:
           ignore_pattern=$(grep -v '^#' .github/.ghaignore | grep -v '^$' | tr '\n' '|' | sed 's/|$//')
           echo "Ignore pattern: $ignore_pattern"
 
+          # Single source of truth for "what is a framework project": a directory
+          # whose name is exactly "pinocchio". `find -type d -name pinocchio` gives
+          # us that by construction — no substring matching, no path-segment
+          # trickery, so siblings like "pinocchio-example/" can never enter the
+          # build list.
           function get_projects() {
             find . -type d -name "pinocchio" | grep -vE "$ignore_pattern" | sort
+          }
+
+          # Filter the full project list down to projects touched by the given
+          # changed files. A file "touches" a project iff it lives inside that
+          # project directory (prefix match on "<project>/"). This is an
+          # intersection against get_projects(), so the result is always a subset
+          # of the authoritative project list.
+          function filter_by_changes() {
+            local all_projects="$1"
+            shift
+            local changed_files=("$@")
+            echo "$all_projects" | while read -r project; do
+              [ -z "$project" ] && continue
+              local project_prefix="${project#./}/"
+              for file in "${changed_files[@]}"; do
+                if [[ "$file" == "$project_prefix"* ]]; then
+                  echo "$project"
+                  break
+                fi
+              done
+            done | sort -u
           }
 
           # Determine which projects to build and test
@@ -60,15 +86,15 @@ jobs:
             projects=$(get_projects)
           elif [[ "${{ github.event_name }}" == "push" ]]; then
             # On push, only build projects with changes since parent commit
-            changed_files=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "")
-            if [ -z "$changed_files" ]; then
+            mapfile -t changed_files < <(git diff --name-only HEAD~1 HEAD 2>/dev/null || true)
+            if [ ${#changed_files[@]} -eq 0 ]; then
               projects=$(get_projects)
             else
-              projects=$(echo "$changed_files" | while read file; do dirname "$file" | grep pinocchio | sed 's#/pinocchio/.*#/pinocchio#g'; done | grep -vE "$ignore_pattern" | sort -u)
+              projects=$(filter_by_changes "$(get_projects)" "${changed_files[@]}")
             fi
           elif [[ "${{ steps.changes.outputs.pinocchio }}" == "true" ]]; then
             changed_files=(${{ steps.changes.outputs.pinocchio_files }})
-            projects=$(for file in "${changed_files[@]}"; do dirname "${file}" | grep pinocchio | sed 's#/pinocchio/.*#/pinocchio#g'; done | grep -vE "$ignore_pattern" | sort -u)
+            projects=$(filter_by_changes "$(get_projects)" "${changed_files[@]}")
           else
             projects=""
           fi

--- a/.github/workflows/quasar.yml
+++ b/.github/workflows/quasar.yml
@@ -52,8 +52,33 @@ jobs:
           ignore_pattern=$(grep -v '^#' .github/.ghaignore | grep -v '^$' | tr '\n' '|' | sed 's/|$//')
           echo "Ignore pattern: $ignore_pattern"
 
+          # Single source of truth for "what is a framework project": a directory
+          # whose name is exactly "quasar". `find -type d -name quasar` gives us
+          # that by construction — no substring matching, no path-segment trickery,
+          # so siblings like "quasar-example/" can never enter the build list.
           function get_projects() {
             find . -type d -name "quasar" | grep -vE "$ignore_pattern" | sort
+          }
+
+          # Filter the full project list down to projects touched by the given
+          # changed files. A file "touches" a project iff it lives inside that
+          # project directory (prefix match on "<project>/"). This is an
+          # intersection against get_projects(), so the result is always a subset
+          # of the authoritative project list.
+          function filter_by_changes() {
+            local all_projects="$1"
+            shift
+            local changed_files=("$@")
+            echo "$all_projects" | while read -r project; do
+              [ -z "$project" ] && continue
+              local project_prefix="${project#./}/"
+              for file in "${changed_files[@]}"; do
+                if [[ "$file" == "$project_prefix"* ]]; then
+                  echo "$project"
+                  break
+                fi
+              done
+            done | sort -u
           }
 
           # Determine which projects to build and test
@@ -62,15 +87,15 @@ jobs:
             projects=$(get_projects)
           elif [[ "${{ github.event_name }}" == "push" ]]; then
             # On push, only build projects with changes since parent commit
-            changed_files=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "")
-            if [ -z "$changed_files" ]; then
+            mapfile -t changed_files < <(git diff --name-only HEAD~1 HEAD 2>/dev/null || true)
+            if [ ${#changed_files[@]} -eq 0 ]; then
               projects=$(get_projects)
             else
-              projects=$(echo "$changed_files" | while read file; do dirname "$file" | grep quasar | sed 's#/quasar/.*#/quasar#g'; done | grep -vE "$ignore_pattern" | sort -u)
+              projects=$(filter_by_changes "$(get_projects)" "${changed_files[@]}")
             fi
           elif [[ "${{ steps.changes.outputs.quasar }}" == "true" ]]; then
             changed_files=(${{ steps.changes.outputs.quasar_files }})
-            projects=$(for file in "${changed_files[@]}"; do dirname "${file}" | grep quasar | sed 's#/quasar/.*#/quasar#g'; done | grep -vE "$ignore_pattern" | sort -u)
+            projects=$(filter_by_changes "$(get_projects)" "${changed_files[@]}")
           else
             projects=""
           fi

--- a/.github/workflows/solana-asm.yml
+++ b/.github/workflows/solana-asm.yml
@@ -44,8 +44,34 @@ jobs:
           ignore_pattern=$(grep -v '^#' .github/.ghaignore | grep -v '^$' | tr '\n' '|' | sed 's/|$//')
           echo "Ignore pattern: $ignore_pattern"
 
+          # Single source of truth for "what is a framework project": a directory
+          # whose name is exactly "asm". `find -type d -name asm` gives us that by
+          # construction — no substring matching, no path-segment trickery, so
+          # anything containing the substring "asm" (e.g. "wasm/", "plasma/") can
+          # never enter the build list.
           function get_projects() {
             find . -type d -name "asm" | grep -vE "$ignore_pattern" | sort
+          }
+
+          # Filter the full project list down to projects touched by the given
+          # changed files. A file "touches" a project iff it lives inside that
+          # project directory (prefix match on "<project>/"). This is an
+          # intersection against get_projects(), so the result is always a subset
+          # of the authoritative project list.
+          function filter_by_changes() {
+            local all_projects="$1"
+            shift
+            local changed_files=("$@")
+            echo "$all_projects" | while read -r project; do
+              [ -z "$project" ] && continue
+              local project_prefix="${project#./}/"
+              for file in "${changed_files[@]}"; do
+                if [[ "$file" == "$project_prefix"* ]]; then
+                  echo "$project"
+                  break
+                fi
+              done
+            done | sort -u
           }
 
           # Determine which projects to build and test
@@ -53,7 +79,7 @@ jobs:
             projects=$(get_projects)
           elif [[ "${{ steps.changes.outputs.asm }}" == "true" ]]; then
             changed_files=(${{ steps.changes.outputs.asm_files }})
-            projects=$(for file in "${changed_files[@]}"; do dirname "${file}" | grep asm | sed 's#/asm/.*#/asm#g'; done | grep -vE "$ignore_pattern" | sort -u)
+            projects=$(filter_by_changes "$(get_projects)" "${changed_files[@]}")
           else
             projects=""
           fi


### PR DESCRIPTION
## The bug

Each framework workflow (`anchor.yml`, `native.yml`, `pinocchio.yml`, `quasar.yml`, `solana-asm.yml`) had **two** competing answers to "which projects are build targets":

1. **`workflow_dispatch` / `schedule`**: `find . -type d -name <framework>` — exact directory-name match. ✅
2. **`pull_request` / `push`**: a substring pipeline:
   ```bash
   dirname "$file" | grep <framework> | sed 's#/<framework>/.*#/<framework>#g'
   ```
   substring match. ❌

The substring path let ghost paths leak into the build list. For example, on PR #16 a change to:

```
tokens/nft-meta-data-pointer/anchor-example/app/pages/api/...
```

was matched by `grep anchor` (substring of `"anchor-example"`) and was **not** collapsed by `sed 's#/anchor/.*#/anchor#g'` because the path contains no literal `/anchor/` segment. The ghost path then entered the candidate list, `pnpm install` ran in a directory with no `package.json`, and CI went red.

## The fix

Single source of truth. Every workflow now uses one function — `get_projects()` — which calls `find . -type d -name <framework>`. The PR/push paths intersect that authoritative list with the changed files via a prefix match (`<project>/`):

```bash
function filter_by_changes() {
  local all_projects="$1"
  shift
  local changed_files=("$@")
  echo "$all_projects" | while read -r project; do
    [ -z "$project" ] && continue
    local project_prefix="${project#./}/"
    for file in "${changed_files[@]}"; do
      if [[ "$file" == "$project_prefix"* ]]; then
        echo "$project"
        break
      fi
    done
  done | sort -u
}
```

Key properties:
- **One source of truth**: `find -type d -name <framework>`.
- **Impossible by construction**: a path cannot enter the build list unless `find` returned it. No more substring matching, no more `sed` games — ghost siblings like `anchor-example/`, `wasm/`, `plasma/`, `pinocchio-example/` cannot leak in.
- **`.ghaignore` filter** is applied to the `find` output before the intersection.
- **Behaviour preserved** for `workflow_dispatch`, `schedule`, and workflow-file-changed events (those paths already called `get_projects()` directly). Empty `changed_files` on push still falls through to all projects.

## What changed

5 files, all in `.github/workflows/`:

- `anchor.yml`
- `native.yml`
- `pinocchio.yml`
- `quasar.yml`
- `solana-asm.yml`

Each gained a `filter_by_changes()` helper and dropped the `grep | sed | awk` substring pipeline from both the `push` branch and the `pull_request` branch.

## Expected CI state after merge

This PR fixes the **project-detection logic**. It does **not** fix any project's actual build/test failures. So:

| Trigger | Expected CI |
|---|---|
| Normal PR or push touching a healthy project's files | ✅ Green |
| Normal PR or push touching a currently-broken project's files (e.g. any `tokens/**/quasar` or `block-list/pinocchio`) | ❌ Red — the project itself doesn't build |
| Workflow-file change, scheduled run, or `workflow_dispatch` | ❌ Red — full matrix runs every project, exposes pre-existing failures |
| **This PR's own CI** (touches workflow files → full matrix) | ❌ Red — exposes the pre-existing failures listed below |

The PR is "ready to merge" in the sense that the logic change is correct and self-contained; the red CI on this PR is exposing failures that exist on `main` today, not failures this PR introduces.

## Pre-existing failures this exposes

Tracked separately, not in scope for this PR:

- **`tokens/**/quasar` (27 projects)** — upstream `quasar-spl` (git master) has duplicate definitions for `delegate` / `close_authority` / `mint_authority` / `freeze_authority` in `src/token.rs`, causing `error[E0592]` on every consumer. Fixed in parallel by pinning quasar-spl to a working revision (separate PR — link to follow).
- **`tokens/token-extensions/transfer-hook/block-list/pinocchio`** — WIP port from `pblock-list` with no `pnpm-lock.yaml`, no `tests/`, no build script. Either needs to be finished properly or removed from the tree (separate PR).

What is now impossible: a non-project path entering the matrix at all.
