### PR TITLE
fix(quasar): pin quasar deps to 623bb70 (upstream zeropod 0.3.0 regression)

### DIFF
--- a/basics/account-data/quasar/Cargo.toml
+++ b/basics/account-data/quasar/Cargo.toml
@@ -22,7 +22,13 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/basics/checking-accounts/quasar/Cargo.toml
+++ b/basics/checking-accounts/quasar/Cargo.toml
@@ -22,7 +22,13 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/basics/close-account/quasar/Cargo.toml
+++ b/basics/close-account/quasar/Cargo.toml
@@ -20,7 +20,13 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/basics/counter/quasar/Cargo.toml
+++ b/basics/counter/quasar/Cargo.toml
@@ -22,7 +22,13 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/basics/create-account/quasar/Cargo.toml
+++ b/basics/create-account/quasar/Cargo.toml
@@ -22,7 +22,13 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/basics/cross-program-invocation/quasar/hand/Cargo.toml
+++ b/basics/cross-program-invocation/quasar/hand/Cargo.toml
@@ -21,7 +21,13 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/basics/cross-program-invocation/quasar/lever/Cargo.toml
+++ b/basics/cross-program-invocation/quasar/lever/Cargo.toml
@@ -21,7 +21,13 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/basics/favorites/quasar/Cargo.toml
+++ b/basics/favorites/quasar/Cargo.toml
@@ -20,7 +20,13 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/basics/hello-solana/quasar/Cargo.toml
+++ b/basics/hello-solana/quasar/Cargo.toml
@@ -22,7 +22,13 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/basics/pda-rent-payer/quasar/Cargo.toml
+++ b/basics/pda-rent-payer/quasar/Cargo.toml
@@ -22,7 +22,13 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/basics/processing-instructions/quasar/Cargo.toml
+++ b/basics/processing-instructions/quasar/Cargo.toml
@@ -20,7 +20,13 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/basics/program-derived-addresses/quasar/Cargo.toml
+++ b/basics/program-derived-addresses/quasar/Cargo.toml
@@ -22,7 +22,13 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/basics/realloc/quasar/Cargo.toml
+++ b/basics/realloc/quasar/Cargo.toml
@@ -20,7 +20,13 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/basics/rent/quasar/Cargo.toml
+++ b/basics/rent/quasar/Cargo.toml
@@ -22,7 +22,13 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/basics/repository-layout/quasar/Cargo.toml
+++ b/basics/repository-layout/quasar/Cargo.toml
@@ -22,7 +22,13 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/basics/transfer-sol/quasar/Cargo.toml
+++ b/basics/transfer-sol/quasar/Cargo.toml
@@ -22,7 +22,13 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/tokens/create-token/quasar/Cargo.toml
+++ b/tokens/create-token/quasar/Cargo.toml
@@ -22,8 +22,14 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/tokens/escrow/quasar/Cargo.toml
+++ b/tokens/escrow/quasar/Cargo.toml
@@ -22,8 +22,14 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-address = { version = "2.2.0" }
 solana-instruction = { version = "3.2.0" }
 

--- a/tokens/external-delegate-token-master/quasar/Cargo.toml
+++ b/tokens/external-delegate-token-master/quasar/Cargo.toml
@@ -24,8 +24,14 @@ debug = []
 [dependencies]
 # Pin both quasar deps to the same source-id (branch = "master") so trait
 # impls resolve consistently.
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 solana-define-syscall = "4.0"
 solana-keccak-hasher = "3.1"

--- a/tokens/nft-minter/quasar/Cargo.toml
+++ b/tokens/nft-minter/quasar/Cargo.toml
@@ -23,10 +23,16 @@ debug = []
 
 [dependencies]
 # All quasar deps share branch = "master" so trait impls resolve consistently.
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 # Metaplex metadata moved out of quasar-spl into a dedicated crate (PR #196).
-quasar-metadata = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+quasar-metadata = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/tokens/nft-operations/quasar/Cargo.toml
+++ b/tokens/nft-operations/quasar/Cargo.toml
@@ -23,10 +23,16 @@ debug = []
 
 [dependencies]
 # All quasar deps share branch = "master" so trait impls resolve consistently.
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 # Metaplex metadata moved out of quasar-spl into a dedicated crate (PR #196).
-quasar-metadata = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+quasar-metadata = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/tokens/pda-mint-authority/quasar/Cargo.toml
+++ b/tokens/pda-mint-authority/quasar/Cargo.toml
@@ -21,8 +21,14 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/tokens/spl-token-minter/quasar/Cargo.toml
+++ b/tokens/spl-token-minter/quasar/Cargo.toml
@@ -25,10 +25,16 @@ debug = []
 # All quasar deps share one source-id (branch = "master") so trait-impls
 # resolve consistently — mixing `{ git = ... }` with `{ git = ..., branch = "master" }`
 # was treated by Cargo as two distinct sources of the same crate.
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 # Metaplex metadata moved out of quasar-spl into its own crate (PR #196).
-quasar-metadata = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+quasar-metadata = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/tokens/token-extensions/basics/quasar/Cargo.toml
+++ b/tokens/token-extensions/basics/quasar/Cargo.toml
@@ -21,8 +21,14 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/tokens/token-extensions/cpi-guard/quasar/Cargo.toml
+++ b/tokens/token-extensions/cpi-guard/quasar/Cargo.toml
@@ -20,8 +20,14 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/tokens/token-extensions/default-account-state/quasar/Cargo.toml
+++ b/tokens/token-extensions/default-account-state/quasar/Cargo.toml
@@ -20,8 +20,14 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/tokens/token-extensions/group/quasar/Cargo.toml
+++ b/tokens/token-extensions/group/quasar/Cargo.toml
@@ -20,8 +20,14 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/tokens/token-extensions/immutable-owner/quasar/Cargo.toml
+++ b/tokens/token-extensions/immutable-owner/quasar/Cargo.toml
@@ -20,8 +20,14 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/tokens/token-extensions/interest-bearing/quasar/Cargo.toml
+++ b/tokens/token-extensions/interest-bearing/quasar/Cargo.toml
@@ -20,8 +20,14 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/tokens/token-extensions/memo-transfer/quasar/Cargo.toml
+++ b/tokens/token-extensions/memo-transfer/quasar/Cargo.toml
@@ -20,8 +20,14 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/tokens/token-extensions/mint-close-authority/quasar/Cargo.toml
+++ b/tokens/token-extensions/mint-close-authority/quasar/Cargo.toml
@@ -20,8 +20,14 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/tokens/token-extensions/non-transferable/quasar/Cargo.toml
+++ b/tokens/token-extensions/non-transferable/quasar/Cargo.toml
@@ -20,8 +20,14 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/tokens/token-extensions/permanent-delegate/quasar/Cargo.toml
+++ b/tokens/token-extensions/permanent-delegate/quasar/Cargo.toml
@@ -20,8 +20,14 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/tokens/token-extensions/transfer-fee/quasar/Cargo.toml
+++ b/tokens/token-extensions/transfer-fee/quasar/Cargo.toml
@@ -20,8 +20,14 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/tokens/token-extensions/transfer-hook/account-data-as-seed/quasar/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/account-data-as-seed/quasar/Cargo.toml
@@ -20,8 +20,14 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/tokens/token-extensions/transfer-hook/allow-block-list-token/quasar/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/allow-block-list-token/quasar/Cargo.toml
@@ -19,8 +19,14 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/tokens/token-extensions/transfer-hook/counter/quasar/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/counter/quasar/Cargo.toml
@@ -20,8 +20,14 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/tokens/token-extensions/transfer-hook/hello-world/quasar/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/hello-world/quasar/Cargo.toml
@@ -20,8 +20,14 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/tokens/token-extensions/transfer-hook/transfer-cost/quasar/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/transfer-cost/quasar/Cargo.toml
@@ -18,8 +18,14 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/tokens/token-extensions/transfer-hook/transfer-switch/quasar/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/transfer-switch/quasar/Cargo.toml
@@ -18,8 +18,14 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/tokens/token-extensions/transfer-hook/whitelist/quasar/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/whitelist/quasar/Cargo.toml
@@ -18,8 +18,14 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/tokens/token-fundraiser/quasar/Cargo.toml
+++ b/tokens/token-fundraiser/quasar/Cargo.toml
@@ -21,8 +21,14 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/tokens/token-swap/quasar/Cargo.toml
+++ b/tokens/token-swap/quasar/Cargo.toml
@@ -23,8 +23,14 @@ debug = []
 
 [dependencies]
 # Pin both quasar deps to branch = "master" so trait impls resolve consistently.
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]

--- a/tokens/transfer-tokens/quasar/Cargo.toml
+++ b/tokens/transfer-tokens/quasar/Cargo.toml
@@ -22,8 +22,14 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
-quasar-spl = { git = "https://github.com/blueshift-gg/quasar", branch = "master" }
+# quasar pin rationale: master HEAD currently fails to compile because zeropod 0.3.x
+# auto-generates accessor methods that conflict with hand-written ones in quasar-spl
+# (E0592 duplicate definitions for delegate / close_authority / mint_authority /
+# freeze_authority). Upstream fix is on the zeropod branch (skip_accessor + bump),
+# not yet merged to master. 623bb70 is the last working rev on master before zeropod
+# 0.3 was bumped. Unpin (back to branch = "master") once upstream merges the fix.
+quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
+quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "623bb70" }
 solana-instruction = { version = "3.2.0" }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

Pin all `blueshift-gg/quasar` Git deps in this repo to commit `623bb70` because the current `master` HEAD fails to compile (`E0592 duplicate definitions` for `delegate` / `close_authority` / `mint_authority` / `freeze_authority`).

## Root cause (upstream)

Commit [`2be2622`](https://github.com/blueshift-gg/quasar/commit/2be2622) on `blueshift-gg/quasar` master (2026-05-09, "fix(derive): classify const-capacity account Vec fields") bumps `zeropod` from `0.2.0` to `0.3.0` in `lang/Cargo.toml` and `Cargo.lock`.

`zeropod` 0.3.0 starts auto-generating accessor methods for `PodOption<T, PFX=4>` fields. quasar's own `spl/src/token.rs` still carries manual implementations of those accessors with a comment that reads:

> Semantic accessors for COption fields (auto-generated accessors don't cover PFX=4).

That assumption became false the moment zeropod 0.3.0 landed, so the manual impls now collide with the macro-generated ones:

```
error[E0592]: duplicate definitions with name `delegate`
  --> /…/quasar/spl/src/token.rs:16:10
   |
16 | #[derive(quasar_lang::__zeropod::ZeroPod)]
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `delegate`
...
64 |     pub fn delegate(&self) -> Option<&Address> {
   |     ------------------------------------------ other definition for `delegate`
```

Same error for `close_authority`, `mint_authority`, `freeze_authority`. Every `tokens/**/quasar` project here therefore fails to build.

## Fix

Pin all `blueshift-gg/quasar` deps (`quasar-lang`, `quasar-spl`, `quasar-metadata`) to `rev = "623bb70"` — the last working commit on master before the zeropod 0.3.0 bump. Bisected by checking `cargo check` at each candidate revision.

Same source-id (matching `rev`) keeps trait impls consistent across the quasar crates; Cargo treats different `rev`/`branch` specifiers on the same git URL as distinct sources, which previously caused trait-resolution failures here.

Every touched `Cargo.toml` carries a comment explaining the pin and the unpin trigger (upstream zeropod fix landing on master).

## Files

44 `Cargo.toml` files across `basics/**/quasar` and `tokens/**/quasar`. The `basics/**` projects don't pull `quasar-spl` so they weren't actually broken, but pinning them to the same rev keeps the whole quasar dep tree consistent and avoids future drift.

## Verification

Locally ran `cargo check --release --tests` on three representative projects:
- `tokens/escrow/quasar` ✅
- `tokens/token-extensions/transfer-fee/quasar` ✅
- `tokens/spl-token-minter/quasar` ✅ (also exercises the `quasar-metadata` pin)

All compile cleanly (only pre-existing dead-code/cfg warnings).

## Relationship to PR #23

This is a follow-up to [PR #23](https://github.com/quiknode-labs/solana-program-examples/pull/23) ("fix(ci): restrict changed-project detection to exact framework roots"). PR #23 fixes a real workflow bug; once it runs the full-project matrix on workflow-file changes, it exposes this pre-existing quasar regression. PR #23 has been cleaned up to contain only the workflow fix — no `.ghaignore` additions to hide the failures it surfaces.

## Out of scope

`tokens/token-extensions/transfer-hook/block-list/pinocchio` is a WIP port (no `pnpm-lock.yaml`, no `tests/`, no build script). It needs a real port (look at the sibling `block-list/native` or `block-list/anchor` for reference), not a dependency pin or a CI ignore. Tracking separately.