### PR TITLE
ci: clean up stale .ghaignore entries + re-enable 3 working anchor examples

### DIFF
--- a/.github/.ghaignore
+++ b/.github/.ghaignore
@@ -48,26 +48,3 @@ tokens/token-extensions/nft-meta-data-pointer/anchor-example/anchor
 tokens/token-extensions/mint-close-authority/native
 tokens/token-extensions/transfer-fee/native
 tokens/token-extensions/non-transferable/native
-
-# all steel projects
-
-basics/account-data/steel
-basics/checking-accounts/steel
-basics/close-account/steel
-basics/counter/steel
-basics/create-account/steel
-basics/cross-program-invocation/steel
-basics/favorites/steel
-basics/pda-rent-payer/steel
-basics/processing-instructions/steel
-basics/program-derived-addresses/steel
-basics/realloc/steel
-basics/rent/steel
-basics/transfer-sol/steel
-
-finance/escrow/steel
-
-tokens/pda-mint-authority/steel
-tokens/token-minter/steel
-finance/token-swap/steel
-tokens/transfer-tokens/steel

--- a/.github/.ghaignore
+++ b/.github/.ghaignore
@@ -12,9 +12,9 @@ tokens/transfer-tokens/native
 tokens/token-minter/native
 tokens/create-token/native
 
-finance/token-swap/anchor
-
-# not building
+# not building: pyth-solana-receiver-sdk 1.1.0 pulls a borsh version that
+# conflicts with Anchor 1.0 / Solana 3.x (PriceUpdateV2 fails BorshDeserialize).
+# Blocked on an upstream SDK release compatible with solana 3.x.
 basics/pyth/anchor
 
 # not building
@@ -23,10 +23,6 @@ compression/cnft-vault/anchor
 # builds but need to test on localhost
 compression/cnft-burn/anchor
 
-# test failing
-# https://github.com/solana-developers/helpers/issues/40
-finance/escrow/anchor
-
 # not live
 tokens/token-extensions/group/anchor
 tokens/token-extensions/group/quasar
@@ -34,10 +30,6 @@ tokens/token-extensions/group/quasar
 # CPI quasar project uses subdirectories (hand/ and lever/) instead of a root Quasar.toml
 basics/cross-program-invocation/quasar
 
-
-
-# error in tests
-tokens/external-delegate-token-master/anchor
 
 # build failed - program outdated
 tokens/token-extensions/metadata/anchor


### PR DESCRIPTION
## Summary

Scoped-down audit of `.github/.ghaignore`. Removes entries whose exclusion reasons are stale, and re-enables three Anchor examples verified to pass locally.

> **Scope note:** this PR originally also included a native-test-harness fix + re-enabling native examples. CI revealed that surfacing real native results exposes a **pre-existing, repo-wide** breakage (see below), so that work has been split out into a follow-up. This PR is limited to changes that are green-able today.

## Changes

**1. Remove 14 stale `steel` entries** — every `steel` directory was already deleted from the repo; the ignore entries were dead.

**2. Re-enable 3 Anchor examples** (verified locally with Anchor 1.0.0 + Solana CLI + surfpool, full `anchor build` + `anchor test`):
- `finance/escrow/anchor` — old reason was a JS-helpers bug (#40); the test is pure Rust now. **4/4 pass.**
- `finance/token-swap/anchor` — **18/18 pass.**
- `tokens/external-delegate-token-master/anchor` — **3/3 pass.**

Also documented the real reason `basics/pyth/anchor` stays ignored (`pyth-solana-receiver-sdk` 1.1.0 pulls a `borsh` incompatible with Anchor 1.0 / Solana 3.x).

## Follow-up (split out of this PR): native bankrun tests are broken repo-wide

While verifying a test-harness fix, I found that the native `node:test` files were being run through `ts-mocha`, which sees **zero** mocha tests, prints "0 passing", and exits 0 — so `pnpm test` (and the Native workflow) reported success even when the in-process `node:test` bankrun tests failed. Every native bankrun suite has effectively been **unverified** (false-green).

Switching the runner to `node --import tsx --test` (so failures actually propagate) reveals the real problem: **`solana-bankrun` cannot execute programs built by the repo's pinned Solana 3.1.14 toolchain.** Every native bankrun example fails identically with:

```
Program failed to complete: unsupported BPF instruction
```

Confirmed it is **not** caused by my changes and **not** trivially fixable:
- Reproduces with the exact CI toolchain (Solana 3.1.14 / platform-tools v1.52).
- Not fixed by bumping `solana-bankrun` 0.3.1 → 0.4.0 (latest).
- Not fixed by building with `--arch v0/v1/v2/v3`.
- The Rust-side `cargo test` (litesvm 0.11.0) path **passes** for the same programs — so the programs are fine; only the JS bankrun runtime is incompatible.

This needs a dedicated effort (likely migrating native tests onto the working Rust/litesvm path, or finding a compatible SVM/toolchain) and will land separately.

## Still excluded (other follow-ups)
- `compression/{cutils,cnft-vault,cnft-burn}/anchor` — migrated but have no tests.
- `basics/pyth/anchor` — upstream SDK/borsh incompatibility.
- Metaplex native token examples — need devnet→bankrun test rewrites.
- `tokens/token-extensions/{metadata,nft-meta-data-pointer}/anchor`, `tools/shank-and-solita/native` — dep bumps.

https://claude.ai/code/session_013dpnF6uSGWXjkJJZseqzcP