### PR TITLE
fix(token-extensions/group): re-enable group anchor + quasar examples

### DIFF
--- a/.github/.ghaignore
+++ b/.github/.ghaignore
@@ -19,10 +19,6 @@ compression/cnft-vault/anchor
 # builds but need to test on localhost
 compression/cnft-burn/anchor
 
-# not live
-tokens/token-extensions/group/anchor
-tokens/token-extensions/group/quasar
-
 # CPI quasar project uses subdirectories (hand/ and lever/) instead of a root Quasar.toml
 basics/cross-program-invocation/quasar
 

--- a/tokens/token-extensions/group/anchor/programs/group/Cargo.toml
+++ b/tokens/token-extensions/group/anchor/programs/group/Cargo.toml
@@ -22,7 +22,6 @@ custom-panic = []
 [dependencies]
 anchor-lang = "1.0.0"
 anchor-spl = "1.0.0"
-spl-token-group-interface = "0.2.5"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/tokens/token-extensions/group/quasar/src/lib.rs
+++ b/tokens/token-extensions/group/quasar/src/lib.rs
@@ -42,13 +42,14 @@ pub struct InitializeGroup {
     #[account(mut)]
     pub mint_account: Signer,
     pub token_program: Program<Token2022Program>,
-    pub system_program: Program<System>,
+    pub system_program: Program<SystemProgram>,
 }
 
 #[inline(always)]
 fn handle_initialize_group(accounts: &mut InitializeGroup) -> Result<(), ProgramError> {
-    // Mint + GroupPointer extension = 250 bytes
-    let mint_size: u64 = 250;
+    // Mint + GroupPointer extension = 234 bytes
+    // (base mint padded to 165 + account_type byte + GroupPointer TLV [2 type + 2 len + 64 data])
+    let mint_size: u64 = 234;
     let lamports = Rent::get()?.try_minimum_balance(mint_size as usize)?;
 
     accounts
@@ -62,10 +63,11 @@ fn handle_initialize_group(accounts: &mut InitializeGroup) -> Result<(), Program
         )
         .invoke()?;
 
-    // InitializeGroupPointer: opcode 41, sub-opcode 0
-    // Data: [41, 0, authority (32 bytes), group_address (32 bytes)]
+    // InitializeGroupPointer: opcode 40, sub-opcode 0
+    // (opcode 41 is GroupMemberPointer, not GroupPointer)
+    // Data: [40, 0, authority (32 bytes), group_address (32 bytes)]
     let mut ext_data = [0u8; 66];
-    ext_data[0] = 41;
+    ext_data[0] = 40;
     ext_data[1] = 0;
     // authority = mint itself (self-referential PDA pattern)
     ext_data[2..34].copy_from_slice(accounts.mint_account.to_account_view().address().as_ref());


### PR DESCRIPTION
## Summary

Two Token-2022 group examples were excluded in `.github/.ghaignore` as "not live", but the real blockers were build/code bugs (the on-chain GroupPointer extension works fine on the current toolchain). Both are now fixed and verified.

**`tokens/token-extensions/group/anchor`** — `cargo build-sbf` failed to resolve `zeroize`: a dead `spl-token-group-interface = "0.2.5"` dependency (never imported — the `GroupPointer` types come from `anchor_spl::token_2022`) transitively pinned an old `solana-zk-token-sdk` incompatible with `ed25519-dalek 2`. Removed the dead dep → builds, and its LiteSVM test (`test_initialize_group`) passes.

**`tokens/token-extensions/group/quasar`** — three bugs in `src/lib.rs`:
1. `Program<System>` → `Program<SystemProgram>` (compile error E0412).
2. GroupPointer extension opcode `41` → `40` (41 is GroupMember**Pointer**; the runtime log confirmed the wrong instruction was being invoked).
3. Mint account size `250` → `234` bytes (base 82 padded to 165 + 1 account-type byte + GroupPointer TLV of 2+2+64); the wrong size made `InitializeMint2` fail with `InvalidAccountData`.

Both dropped from `.github/.ghaignore` so CI builds and tests them.

Verified locally on the CI toolchain (Solana 3.1.x / platform-tools v1.52): `group/anchor` builds + `cargo test` passes; `group/quasar` builds + both tests pass (logs show `GroupPointerInstruction::Initialize success`, `InitializeMint2 success`).

> Note on the third investigated exclusion, `compression/cnft-burn/anchor`: left excluded — it no longer builds (`ahash = "=0.8.7"` pulls `getrandom 0.2` which `compile_error!`s on SBF) **and** has no test at all; a real test needs Bubblegum + account-compression + noop `.so` fixtures plus Merkle-tree/proof scaffolding. Documented for a future effort.

https://claude.ai/code/session_013dpnF6uSGWXjkJJZseqzcP

---
_Generated by [Claude Code](https://claude.ai/code/session_013dpnF6uSGWXjkJJZseqzcP)_