### PR TITLE
ci(quasar): support multi-program projects; re-enable cross-program-invocation/quasar

### DIFF
--- a/.github/.ghaignore
+++ b/.github/.ghaignore
@@ -12,8 +12,6 @@ compression/cnft-vault/anchor
 # builds but need to test on localhost
 compression/cnft-burn/anchor
 
-# CPI quasar project uses subdirectories (hand/ and lever/) instead of a root Quasar.toml
-basics/cross-program-invocation/quasar
 
 
 # build failed - program outdated

--- a/.github/workflows/quasar.yml
+++ b/.github/workflows/quasar.yml
@@ -171,21 +171,48 @@ jobs:
             echo "Building and Testing $project with Solana $solana_version"
             cd "$project" || return 1
 
-            # Build with quasar CLI
-            if ! quasar build; then
-              echo "::error::quasar build failed for $project"
-              echo "$project: quasar build failed with $solana_version" >> $GITHUB_WORKSPACE/failed_projects.txt
+            # Determine the quasar program directories for this project. Normally
+            # the project dir itself holds the Quasar.toml. Some examples (e.g. the
+            # cross-program-invocation CPI demo) instead contain several program
+            # subdirectories (hand/, lever/), each its own Quasar project. In that
+            # case build them all *first*, then test them all, so a program whose
+            # tests load a sibling program's compiled .so (the CPI callee) has it
+            # available regardless of directory order.
+            local prog_dirs=()
+            if [ -f Quasar.toml ]; then
+              prog_dirs=(".")
+            else
+              for d in */; do
+                [ -f "${d}Quasar.toml" ] && prog_dirs+=("${d%/}")
+              done
+            fi
+
+            if [ ${#prog_dirs[@]} -eq 0 ]; then
+              echo "::error::no Quasar.toml found for $project"
+              echo "$project: no Quasar.toml found with $solana_version" >> $GITHUB_WORKSPACE/failed_projects.txt
               cd - > /dev/null
               return 1
             fi
 
-            # Run Rust tests (quasar examples use cargo test with quasar-svm)
-            if ! cargo test; then
-              echo "::error::cargo test failed for $project"
-              echo "$project: cargo test failed with $solana_version" >> $GITHUB_WORKSPACE/failed_projects.txt
-              cd - > /dev/null
-              return 1
-            fi
+            # Build every program first.
+            for d in "${prog_dirs[@]}"; do
+              if ! ( cd "$d" && quasar build ); then
+                echo "::error::quasar build failed for $project ($d)"
+                echo "$project: quasar build failed with $solana_version" >> $GITHUB_WORKSPACE/failed_projects.txt
+                cd - > /dev/null
+                return 1
+              fi
+            done
+
+            # Then run Rust tests (quasar examples use cargo test with quasar-svm).
+            for d in "${prog_dirs[@]}"; do
+              if ! ( cd "$d" && cargo test ); then
+                echo "::error::cargo test failed for $project ($d)"
+                echo "$project: cargo test failed with $solana_version" >> $GITHUB_WORKSPACE/failed_projects.txt
+                cd - > /dev/null
+                return 1
+              fi
+            done
 
             echo "Build and tests succeeded for $project with $solana_version version."
             cd - > /dev/null


### PR DESCRIPTION
## Summary

`basics/cross-program-invocation/quasar` was excluded because it contains **two** separate Quasar programs (`hand/` and `lever/`) instead of a single program with a root `Quasar.toml`. The Quasar workflow ran `quasar build && cargo test` directly in the project dir, but `quasar build` requires `./src/lib.rs` and is single-program only, so it failed.

The example itself is fine (builds + tests pass locally — `hand` calls `lever` via CPI and its test loads lever's compiled `.so`). The only problem was CI integration.

## Fix (workflow only — example unchanged)

Teach `quasar.yml`'s `build_and_test` to detect a project's program directories:
- if the project dir has a `Quasar.toml`, use it as-is (**unchanged behavior for all 46 existing quasar examples**);
- otherwise, use its immediate subdirectories that each contain a `Quasar.toml` (the CPI example's `hand/` + `lever/`).

It then **builds all** of a project's programs first, **then tests all** of them — so `hand`'s test, which loads `lever`'s freshly-built `.so` to exercise the CPI, finds it regardless of order. (Order matters because the 47 quasar projects shard across parallel jobs, so cross-project build order can't be relied on; building both before testing within the one project makes it deterministic.)

Then drop the example from `.github/.ghaignore`.

## Verification

Locally with the quasar CLI (v0.0.0) on the CI toolchain, simulating the new workflow logic against the project: detects `hand` + `lever`, builds both, and `cargo test` passes for both (`hand` 3 tests, `lever` 4). `quasar.yml` validated as well-formed YAML; confirmed normal single-program projects still resolve to the `.` path (no behavior change).

https://claude.ai/code/session_013dpnF6uSGWXjkJJZseqzcP

---
_Generated by [Claude Code](https://claude.ai/code/session_013dpnF6uSGWXjkJJZseqzcP)_