### PR TITLE
docs: add CLAUDE.md memory — always watch CI after opening a PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# Project memory
+
+Persistent instructions for AI agents working in this repository. This file is
+loaded automatically at the start of each session.
+
+## Always watch CI after opening a PR
+
+After creating **any** pull request, immediately subscribe to its CI/activity
+and follow it through to a result — do not consider the work done at "PR
+opened":
+
+- Call `subscribe_pr_activity` for the new PR so CI failures and review
+  comments are delivered into the session.
+- CI **failures** arrive as webhook events; CI **success** and your own pushes
+  do **not**, so proactively re-check the PR's check runs
+  (`pull_request_read` → `get_check_runs`) until they are green.
+- On failure, pull the failing job logs (`get_job_logs`), diagnose, fix, push,
+  and re-check — repeat until green or genuinely blocked (then report).
+
+The goal: never hand back a PR that is silently red.


### PR DESCRIPTION
## Summary

Adds a `CLAUDE.md` project-memory file so the instruction **"always watch CI after opening a PR"** persists across sessions (Claude Code loads `CLAUDE.md` automatically at session start; this environment's containers are ephemeral, so committing it to the repo is what makes it durable).

The rule: after opening any PR, subscribe to its activity, proactively re-check the check runs until green (CI success / own pushes aren't delivered as webhooks), and fix-and-re-check on failure rather than handing back a silently-red PR.

Once this is on `main`, future sessions working in this repo will pick it up automatically.

https://claude.ai/code/session_013dpnF6uSGWXjkJJZseqzcP

---
_Generated by [Claude Code](https://claude.ai/code/session_013dpnF6uSGWXjkJJZseqzcP)_