### PR TITLE
Remove dead clockwork tool

### DIFF
--- a/tools/clockwork/README.md
+++ b/tools/clockwork/README.md
@@ -1,5 +1,0 @@
-# Clockwork
-
-[Clockwork](https://github.com/clockwork-xyz/clockwork) is automation infrastructure for Solana. It lets you schedule transactions and build automated, event-driven [programs](https://solana.com/docs/terminology#program).
-
-See the upstream [Clockwork repository](https://github.com/clockwork-xyz/clockwork) for examples and documentation.


### PR DESCRIPTION
## Summary

Removes `tools/clockwork`, which was dead. The directory only contained a `README.md` pointing to the upstream [Clockwork](https://github.com/clockwork-xyz/clockwork) project, which has been discontinued. No other files in the repo referenced it.

## Changes
- Deleted `tools/clockwork/README.md` (and the now-empty directory)

https://claude.ai/code/session_01WuKWKoEMzigGZZefV3rYNm

---
_Generated by [Claude Code](https://claude.ai/code/session_01WuKWKoEMzigGZZefV3rYNm)_