### PR TITLE
Lending: fix stale LendingMarket seed docs in both READMEs

### DIFF
--- a/finance/lending/anchor/README.md
+++ b/finance/lending/anchor/README.md
@@ -32,10 +32,11 @@ crosses the liquidation threshold and a liquidator can close part of the positio
 ### Accounts
 
 - **`LendingMarket`** — top-level config (owner, quote-currency mint). PDA seeds
-  `["lending_market", owner, market_id]`, where `market_id` is a per-owner `u64`
-  index. Seeding by an index (not the owner alone) lets one owner run several
-  independent, risk-isolated markets — their market 0, 1, 2 … — with no
-  cross-owner collisions.
+  `["lending_market", market_id]`, where `market_id` is a `u64` index. Seeding by
+  an index alone (owner is stored as a field for authorization, not baked into the
+  address) lets one owner run several independent, risk-isolated markets — their
+  market 0, 1, 2 … — with no cross-owner collisions and no individual's key in a
+  shared struct's address.
 - **`Reserve`** — one per asset. Owns a program-controlled liquidity vault and a
   share-token mint, and stores the interest-rate config, the cumulative borrow-
   rate index, available liquidity, and scaled total debt. PDA seeds

--- a/finance/lending/quasar/README.md
+++ b/finance/lending/quasar/README.md
@@ -29,8 +29,10 @@ Everything else mirrors the Anchor version.
 ## Major concepts
 
 - **`LendingMarket`** — market config (owner, quote-currency mint). PDA:
-  `["lending_market", owner, market_id]`, where `market_id` is a per-owner `u64`
-  index, so one owner can run several isolated markets (their market 0, 1, 2 …).
+  `["lending_market", market_id]`, where `market_id` is a `u64` index. Owner is
+  stored as a field for authorization, not baked into the address, so one owner
+  can run several isolated markets (their market 0, 1, 2 …) with no individual's
+  key in a shared struct's address.
 - **`Reserve`** — one asset's pool. Owns a program-controlled liquidity vault and
   a share-token mint (both PDAs, authority = the reserve), and stores the
   interest-rate config, the cumulative borrow-rate index, available liquidity, and


### PR DESCRIPTION
Follow-up to #73 (merged). The code there changed the `LendingMarket` PDA seed to `["lending_market", market_id]` — no owner in the seed — but the Anchor and Quasar README prose still described the old `["lending_market", owner, market_id]` seed. This brings the docs into agreement with the code.

## Changes

- Both READMEs now describe the market PDA seed as `["lending_market", market_id]` (a `u64` index).
- Makes the rationale explicit: `owner` is stored as a field for `has_one` authorization, **not** baked into the address, so no individual's public key appears in a shared struct's address.

Docs-only; no code or tests changed. (The price-feed seed prose was already correct.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RwE8f8ahP5S6SDNTsXmpj9

---
_Generated by [Claude Code](https://claude.ai/code/session_01RwE8f8ahP5S6SDNTsXmpj9)_