### PR TITLE
Upgrade Anchor programs to 1.1.2

### DIFF
--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -56,7 +56,14 @@ jobs:
           # so siblings like "anchor-example/" or nested files such as
           # "anchor-example/app/pages/api/foo.ts" can never enter the build list.
           function get_projects() {
-            find . -type d -name "anchor" | grep -vE "$ignore_pattern" | sort
+            # An empty .ghaignore makes ignore_pattern empty, and `grep -vE ""`
+            # matches everything, silently emptying the project list - only
+            # filter when there is actually a pattern.
+            if [[ -n "$ignore_pattern" ]]; then
+              find . -type d -name "anchor" | grep -vE "$ignore_pattern" | sort
+            else
+              find . -type d -name "anchor" | sort
+            fi
           }
 
           # Filter the full project list down to projects touched by the given

--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -164,7 +164,8 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: heyAyushh/setup-anchor@v4.999
         with:
-          anchor-version: 1.0.0
+          # Pinned to match the anchor-lang/anchor-spl crate version the programs depend on.
+          anchor-version: 1.1.2
           # setup-anchor resolves tags like stable by querying GitHub API for latest release which can fail with 429 errors
           solana-cli-version: 3.1.14
       - name: Install Surfpool
@@ -195,7 +196,7 @@ jobs:
               return 1
             fi
 
-            # Sync program IDs (Anchor 1.0.0 requires keypair and declare_id! to match)
+            # Sync program IDs (Anchor 1.0+ requires keypair and declare_id! to match)
             anchor keys sync
 
             # Update IDL address fields to match the synced keys.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this repository are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2026-06-30] - Anchor 1.1.2
+
+### Changed
+
+- Upgraded every Anchor program from `anchor-lang`/`anchor-spl` `1.0.0` to the latest stable `1.1.2`, and bumped the Anchor CLI used by `anchor.yml` CI to match (`anchor-version: 1.1.2`).
+
 ## [2026-06-12] - Rust + LiteSVM tests everywhere
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Upgraded every Anchor program from `anchor-lang`/`anchor-spl` `1.0.0` to the latest stable `1.1.2`, and bumped the Anchor CLI used by `anchor.yml` CI to match (`anchor-version: 1.1.2`).
 
+### Fixed
+
+- `anchor.yml` built no projects when `.ghaignore` was empty: `find … | grep -vE "$ignore_pattern"` treated the empty pattern as "match everything" and dropped the whole list, so the workflow passed without building anything. Guarded the filter (as `native.yml`, `pinocchio.yml` and `solana-asm.yml` already do).
+- `vault-strategy` and `perpetual-futures` LiteSVM tests loaded their sibling mock program's `.so` with `include_bytes!`, which is evaluated at compile time. Anchor's IDL build compiles the tests before that sibling `.so` is built, so the build failed. They now read the sibling `.so` at runtime with `std::fs::read`, matching the existing `cross-program-invocation/hand` test.
+
 ## [2026-06-12] - Rust + LiteSVM tests everywhere
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -66,7 +66,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -182,66 +182,66 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anchor-attribute-access-control"
-version = "1.0.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b972f5fbd02524c92e4eb487c3c648904572702670f3d6fc81aef5f1751b1569"
+checksum = "9fc4b6b3c3f3e37a0b7d537e03a36bfb0415ee11b4443fa4190437cf26a874b6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "anchor-attribute-account"
-version = "1.0.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9acfcb07a92084bcfa9f6cc49a5c2e8e0e986f25f4b7caa184b7a2c9c9e561c2"
+checksum = "48e8b1468add67e6a69732883e58d23a18be51538994adaae69c9b3fe967e6be"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "anchor-attribute-constant"
-version = "1.0.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f46cc38f819377f07663b8eb492a701427950065e79d2d7b622a782443deb7a"
+checksum = "80e1e3ade39ba05716ddc3b792859d838cccf43f5f4913ae8a163de7a2ed7f7e"
 dependencies = [
  "anchor-syn",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "anchor-attribute-error"
-version = "1.0.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c34748789107c9838329e058ca7b253e67f37b39ceae5a0a6c8d99f5d1bf1fe"
+checksum = "d4e026f0ff09d740fd1821bbf97d9ac649c123ff92f04b9197b002494af4acf1"
 dependencies = [
  "anchor-syn",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "anchor-attribute-event"
-version = "1.0.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a28a3e5eefa03d9c5ef02b2139198f652547d38dddafc9c5545152dfba54556"
+checksum = "7aafc8e26eb16a0c4129661f6857c42f301859fc2ee10f4e5287d571f0ea07f5"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "anchor-attribute-program"
-version = "1.0.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfaa03865053cb168bfc4debe5992be87f397aa027dd81b69a2e44f2e5bae1c5"
+checksum = "6844e657ffe049b073389efb843bb281d08579b8a47ef294365f729b35ed3dca"
 dependencies = [
  "anchor-lang-idl",
  "anchor-syn",
@@ -249,49 +249,49 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "anchor-derive-accounts"
-version = "1.0.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef330db08f9ceee45c18ef96b15b869883d280c0ab5c6ff5d2e2f6481da7911"
+checksum = "2c87a6769d7cf2deed8d3351d6d1d8aa05a3a07751f1418ab6b34aaa307bd34b"
 dependencies = [
  "anchor-syn",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "anchor-derive-serde"
-version = "1.0.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0e80ff4e3ddb8c85aafd37926335c28f820516311e7106e5b7482b42e798aaa"
+checksum = "1f014d99530ae48a81f710f150688c5c542fdeee3af8998010e147a64d7a697c"
 dependencies = [
  "anchor-syn",
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "anchor-derive-space"
-version = "1.0.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2672af0ef4dfd5f5b6199355867b580cd8b4048093ef5208dd2b441305c15b8b"
+checksum = "33ba30c2d844e7440c491ad5f3e25f93115c6c9319df480eda460ce96030832b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "anchor-lang"
-version = "1.0.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de9dce227fa0c08be20fef008c5b04681e1e0a15cb396e9619a9a1f800ff6cd"
+checksum = "aa6708f356398752b8d7a08fb701c9c17395e103786fb1b33615a7267a6f4774"
 dependencies = [
  "anchor-attribute-access-control",
  "anchor-attribute-account",
@@ -302,6 +302,7 @@ dependencies = [
  "anchor-derive-accounts",
  "anchor-derive-serde",
  "anchor-derive-space",
+ "anchor-lang-error",
  "anchor-lang-idl",
  "base64 0.21.7",
  "bincode",
@@ -333,10 +334,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "anchor-lang-idl"
-version = "0.1.2"
+name = "anchor-lang-error"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e8599d21995f68e296265aa5ab0c3cef582fd58afec014d01bd0bce18a4418"
+checksum = "20760a8d5b7ddd1aea7a347c43c702ea4e962ccb7b9908c952e4b372b2d9e1f7"
+dependencies = [
+ "anchor-attribute-error",
+ "borsh 1.6.1",
+ "solana-msg 3.1.0",
+ "solana-program-error 3.0.1",
+ "solana-pubkey 3.0.0",
+]
+
+[[package]]
+name = "anchor-lang-idl"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47914b4290ae2bdf4ec203aa821e6eba86d7c78ef497918938038dcc6919f953"
 dependencies = [
  "anchor-lang-idl-spec",
  "anyhow",
@@ -371,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-spl"
-version = "1.0.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300e2e8058e674e8d6ea7c72dfb8be4349609dd9c3760ce729fc6406199624fe"
+checksum = "2f698a45d424351ff695df413adcb3fa603f2c791a0b4a937ebcd2e93a052c77"
 dependencies = [
  "anchor-lang",
  "spl-associated-token-account-interface",
@@ -386,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-syn"
-version = "1.0.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62f42cb7e348c033bd9bfba59979bcd66431c026ba23490af94045aa357a950"
+checksum = "f8f6c61ef5b47db60700087bb6e419284b3461ba8f59040e1f6827aa9e9a5bc4"
 dependencies = [
  "anyhow",
  "bs58",
@@ -397,8 +411,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "sha2 0.10.9",
- "syn 1.0.109",
+ "sha2 0.11.0",
+ "syn 2.0.117",
  "thiserror 1.0.69",
 ]
 
@@ -752,7 +766,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -772,6 +786,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -937,12 +960,12 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cargo_toml"
-version = "0.19.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98356df42a2eb1bd8f1793ae4ee4de48e384dd974ce5eac8eee802edb7492be"
+checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
 dependencies = [
  "serde",
- "toml 0.8.23",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -1051,7 +1074,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -1151,6 +1174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,6 +1236,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1338,6 +1376,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1353,7 +1400,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -1450,7 +1497,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -1487,9 +1534,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
- "crypto-common",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1906,6 +1964,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2002,7 +2069,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -2598,7 +2665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -2627,7 +2694,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.8+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -3125,11 +3192,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3162,7 +3229,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -3174,8 +3241,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -6126,23 +6204,26 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "serde",
+ "indexmap",
+ "serde_core",
  "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -6152,20 +6233,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
 ]
 
 [[package]]
@@ -6190,10 +6257,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "transfer-sol"
@@ -6259,9 +6326,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -6281,7 +6348,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -6478,9 +6545,6 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/basics/account-data/anchor/programs/anchor-program-example/Cargo.toml
+++ b/basics/account-data/anchor/programs/anchor-program-example/Cargo.toml
@@ -20,7 +20,7 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
+anchor-lang = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/basics/checking-accounts/anchor/programs/anchor-program-example/Cargo.toml
+++ b/basics/checking-accounts/anchor/programs/anchor-program-example/Cargo.toml
@@ -20,7 +20,7 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
+anchor-lang = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/basics/close-account/anchor/programs/close-account/Cargo.toml
+++ b/basics/close-account/anchor/programs/close-account/Cargo.toml
@@ -20,7 +20,7 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
+anchor-lang = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/basics/counter/anchor/programs/counter_anchor/Cargo.toml
+++ b/basics/counter/anchor/programs/counter_anchor/Cargo.toml
@@ -20,7 +20,7 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
+anchor-lang = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/basics/create-account/anchor/programs/create-system-account/Cargo.toml
+++ b/basics/create-account/anchor/programs/create-system-account/Cargo.toml
@@ -20,7 +20,7 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
+anchor-lang = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/basics/cross-program-invocation/anchor/programs/hand/Cargo.toml
+++ b/basics/cross-program-invocation/anchor/programs/hand/Cargo.toml
@@ -20,7 +20,7 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
+anchor-lang = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/basics/cross-program-invocation/anchor/programs/lever/Cargo.toml
+++ b/basics/cross-program-invocation/anchor/programs/lever/Cargo.toml
@@ -20,7 +20,7 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
+anchor-lang = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/basics/favorites/anchor/programs/favorites/Cargo.toml
+++ b/basics/favorites/anchor/programs/favorites/Cargo.toml
@@ -20,7 +20,7 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = {version = "1.0.0", features = ["init-if-needed"]}
+anchor-lang = {version = "1.1.2", features = ["init-if-needed"]}
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/basics/hello-solana/anchor/programs/hello-solana/Cargo.toml
+++ b/basics/hello-solana/anchor/programs/hello-solana/Cargo.toml
@@ -20,7 +20,7 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
+anchor-lang = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/basics/pda-rent-payer/anchor/programs/anchor-program-example/Cargo.toml
+++ b/basics/pda-rent-payer/anchor/programs/anchor-program-example/Cargo.toml
@@ -20,7 +20,7 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
+anchor-lang = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/basics/processing-instructions/anchor/programs/processing-instructions/Cargo.toml
+++ b/basics/processing-instructions/anchor/programs/processing-instructions/Cargo.toml
@@ -20,7 +20,7 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
+anchor-lang = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/basics/program-derived-addresses/anchor/programs/anchor-program-example/Cargo.toml
+++ b/basics/program-derived-addresses/anchor/programs/anchor-program-example/Cargo.toml
@@ -20,7 +20,7 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
+anchor-lang = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/basics/pyth/anchor/programs/pythexample/Cargo.toml
+++ b/basics/pyth/anchor/programs/pythexample/Cargo.toml
@@ -21,7 +21,7 @@ custom-panic = []
 
 
 [dependencies]
-anchor-lang = "1.0.0"
+anchor-lang = "1.1.2"
 
 [dev-dependencies]
 # Self-dependency with no-entrypoint: host test builds otherwise export a

--- a/basics/realloc/anchor/programs/anchor-realloc/Cargo.toml
+++ b/basics/realloc/anchor/programs/anchor-realloc/Cargo.toml
@@ -20,7 +20,7 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
+anchor-lang = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/basics/rent/anchor/programs/rent-example/Cargo.toml
+++ b/basics/rent/anchor/programs/rent-example/Cargo.toml
@@ -20,7 +20,7 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
+anchor-lang = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/basics/repository-layout/anchor/programs/carnival/Cargo.toml
+++ b/basics/repository-layout/anchor/programs/carnival/Cargo.toml
@@ -20,7 +20,7 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
+anchor-lang = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/basics/transfer-sol/anchor/programs/transfer-sol/Cargo.toml
+++ b/basics/transfer-sol/anchor/programs/transfer-sol/Cargo.toml
@@ -20,7 +20,7 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
+anchor-lang = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/compression/cnft-burn/anchor/programs/cnft-burn/Cargo.toml
+++ b/compression/cnft-burn/anchor/programs/cnft-burn/Cargo.toml
@@ -20,7 +20,7 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
+anchor-lang = "1.1.2"
 # mpl-bubblegum and spl-account-compression removed: they depend on solana-program 2.x
 # which is incompatible with Anchor 1.0's solana 3.x types. CPI calls are built manually
 # using raw invoke() with hardcoded program IDs and discriminators.

--- a/compression/cnft-vault/anchor/programs/cnft-vault/Cargo.toml
+++ b/compression/cnft-vault/anchor/programs/cnft-vault/Cargo.toml
@@ -20,7 +20,7 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
+anchor-lang = "1.1.2"
 # mpl-bubblegum and spl-account-compression removed: they depend on solana-program 2.x
 # which is incompatible with Anchor 1.0's solana 3.x types. CPI calls are built manually
 # using raw invoke_signed() with hardcoded program IDs and discriminators.

--- a/compression/cutils/anchor/programs/cutils/Cargo.toml
+++ b/compression/cutils/anchor/programs/cutils/Cargo.toml
@@ -20,7 +20,7 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
+anchor-lang = "1.1.2"
 # mpl-bubblegum and spl-account-compression removed: they depend on solana-program 2.x
 # which is incompatible with Anchor 1.0's solana 3.x types. CPI calls are built manually
 # using raw invoke() with hardcoded program IDs and discriminators. Bubblegum types

--- a/finance/betting-market/anchor/programs/betting-market/Cargo.toml
+++ b/finance/betting-market/anchor/programs/betting-market/Cargo.toml
@@ -21,8 +21,8 @@ custom-panic = []
 
 [dependencies]
 # init-if-needed: place_bet and the lazy User index create accounts only on first use.
-anchor-lang = { version = "1.0.0", features = ["init-if-needed"] }
-anchor-spl = "1.0.0"
+anchor-lang = { version = "1.1.2", features = ["init-if-needed"] }
+anchor-spl = "1.1.2"
 
 [dev-dependencies]
 # no-entrypoint: solana-kite pulls these SPL program crates into the host test

--- a/finance/escrow/anchor/programs/escrow/Cargo.toml
+++ b/finance/escrow/anchor/programs/escrow/Cargo.toml
@@ -20,8 +20,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = { version = "1.0.0", features = ["init-if-needed"]}
-anchor-spl = "1.0.0"
+anchor-lang = { version = "1.1.2", features = ["init-if-needed"]}
+anchor-spl = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/finance/lending/anchor/programs/lending/Cargo.toml
+++ b/finance/lending/anchor/programs/lending/Cargo.toml
@@ -21,8 +21,8 @@ custom-panic = []
 
 [dependencies]
 # init-if-needed: the obligation share vault and the test price feed are created lazily.
-anchor-lang = { version = "1.0.0", features = ["init-if-needed"] }
-anchor-spl = "1.0.0"
+anchor-lang = { version = "1.1.2", features = ["init-if-needed"] }
+anchor-spl = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/finance/order-book/anchor/programs/order-book/Cargo.toml
+++ b/finance/order-book/anchor/programs/order-book/Cargo.toml
@@ -20,8 +20,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
-anchor-spl = "1.0.0"
+anchor-lang = "1.1.2"
+anchor-spl = "1.1.2"
 # Used by the ported Openbook slab - `bytemuck::Pod` / `Zeroable` on every node
 # variant + `min_const_generics` so `[AnyNode; 1024]` can derive Pod without
 # hitting bytemuck's default-32 array cap. `static_assertions` keeps the slab

--- a/finance/perpetual-futures/anchor/programs/mock-switchboard/Cargo.toml
+++ b/finance/perpetual-futures/anchor/programs/mock-switchboard/Cargo.toml
@@ -20,7 +20,7 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
+anchor-lang = "1.1.2"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_os, values("solana"))'] }

--- a/finance/perpetual-futures/anchor/programs/perpetual-futures/Cargo.toml
+++ b/finance/perpetual-futures/anchor/programs/perpetual-futures/Cargo.toml
@@ -23,8 +23,8 @@ custom-panic = []
 # init-if-needed lets add_liquidity create the provider's liquidity-provider
 # token account on their first deposit. The provider is the payer, so this does
 # not let one party fund another's rent.
-anchor-lang = { version = "1.0.0", features = ["init-if-needed"] }
-anchor-spl = "1.0.0"
+anchor-lang = { version = "1.1.2", features = ["init-if-needed"] }
+anchor-spl = "1.1.2"
 # Not used directly. Declared so Cargo feature unification turns on
 # `no-entrypoint` for the spl-token that anchor-spl pulls in; without it the
 # integration-test binary links two `entrypoint` symbols (this program's and

--- a/finance/perpetual-futures/anchor/programs/perpetual-futures/tests/test_perpetual_futures.rs
+++ b/finance/perpetual-futures/anchor/programs/perpetual-futures/tests/test_perpetual_futures.rs
@@ -88,11 +88,16 @@ impl Market {
             include_bytes!("../../../target/deploy/perpetual_futures.so"),
         )
         .unwrap();
-        svm.add_program(
-            mock_switchboard::id(),
-            include_bytes!("../../../target/deploy/mock_switchboard.so"),
-        )
-        .unwrap();
+        // Use std::fs::read() instead of include_bytes!() for the switchboard program because
+        // include_bytes!() runs at compile time, and during `anchor build` the IDL generation
+        // step compiles tests before the .so files exist. Since this is a cross-program
+        // dependency (not our own program), mock_switchboard.so may not be built yet at compile time.
+        let switchboard_bytes = std::fs::read(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../target/deploy/mock_switchboard.so"
+        ))
+        .expect("mock_switchboard.so not found - run `anchor build` first");
+        svm.add_program(mock_switchboard::id(), &switchboard_bytes).unwrap();
 
         let payer = create_wallet(&mut svm, 100_000_000_000).unwrap();
         let admin = create_wallet(&mut svm, 100_000_000_000).unwrap();

--- a/finance/token-fundraiser/anchor/programs/fundraiser/Cargo.toml
+++ b/finance/token-fundraiser/anchor/programs/fundraiser/Cargo.toml
@@ -20,8 +20,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = { version = "1.0.0", features = ["init-if-needed"] }
-anchor-spl = "1.0.0"
+anchor-lang = { version = "1.1.2", features = ["init-if-needed"] }
+anchor-spl = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/finance/token-swap/anchor/programs/token-swap/Cargo.toml
+++ b/finance/token-swap/anchor/programs/token-swap/Cargo.toml
@@ -20,8 +20,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = { version = "1.0.0", features = ["init-if-needed"] }
-anchor-spl = { version = "1.0.0", features = ["metadata", "spl-token-interface"] }
+anchor-lang = { version = "1.1.2", features = ["init-if-needed"] }
+anchor-spl = { version = "1.1.2", features = ["metadata", "spl-token-interface"] }
 # `fixed` removed: all financial math is now u128 + checked_*, matching how
 # production Solana AMMs (Orca, Raydium, Meteora, Saber) do it. Floats /
 # fixed-point types are not used for money in this program.

--- a/finance/vault-strategy/anchor/programs/mock-swap-router/Cargo.toml
+++ b/finance/vault-strategy/anchor/programs/mock-swap-router/Cargo.toml
@@ -20,8 +20,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = { version = "1.0.0", features = ["init-if-needed"] }
-anchor-spl = "1.0.0"
+anchor-lang = { version = "1.1.2", features = ["init-if-needed"] }
+anchor-spl = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/finance/vault-strategy/anchor/programs/vault-strategy/Cargo.toml
+++ b/finance/vault-strategy/anchor/programs/vault-strategy/Cargo.toml
@@ -20,8 +20,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = { version = "1.0.0", features = ["init-if-needed"] }
-anchor-spl = "1.0.0"
+anchor-lang = { version = "1.1.2", features = ["init-if-needed"] }
+anchor-spl = "1.1.2"
 mock-swap-router = { path = "../mock-swap-router", features = ["cpi"] }
 
 [dev-dependencies]

--- a/finance/vault-strategy/anchor/programs/vault-strategy/tests/vault_strategy.rs
+++ b/finance/vault-strategy/anchor/programs/vault-strategy/tests/vault_strategy.rs
@@ -140,11 +140,16 @@ fn setup_full() -> TestContext {
         include_bytes!("../../../target/deploy/vault_strategy.so"),
     )
     .unwrap();
-    svm.add_program(
-        router_program_id,
-        include_bytes!("../../../target/deploy/mock_swap_router.so"),
-    )
-    .unwrap();
+    // Use std::fs::read() instead of include_bytes!() for the router program because
+    // include_bytes!() runs at compile time, and during `anchor build` the IDL generation
+    // step compiles tests before the .so files exist. Since this is a cross-program
+    // dependency (not our own program), mock_swap_router.so may not be built yet at compile time.
+    let router_bytes = std::fs::read(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../target/deploy/mock_swap_router.so"
+    ))
+    .expect("mock_swap_router.so not found - run `anchor build` first");
+    svm.add_program(router_program_id, &router_bytes).unwrap();
 
     svm.set_sysvar(&Clock {
         slot: 1,

--- a/tokens/create-token/anchor/programs/create-token/Cargo.toml
+++ b/tokens/create-token/anchor/programs/create-token/Cargo.toml
@@ -21,8 +21,8 @@ custom-panic = []
 
 
 [dependencies]
-anchor-lang = "1.0.0"
-anchor-spl = { version = "1.0.0", features = ["metadata"] }
+anchor-lang = "1.1.2"
+anchor-spl = { version = "1.1.2", features = ["metadata"] }
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/tokens/external-delegate-token-master/anchor/programs/external-delegate-token-master/Cargo.toml
+++ b/tokens/external-delegate-token-master/anchor/programs/external-delegate-token-master/Cargo.toml
@@ -20,8 +20,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = { version = "1.0.0", features = ["init-if-needed"] }
-anchor-spl = { version = "1.0.0", features = ["metadata"] }
+anchor-lang = { version = "1.1.2", features = ["init-if-needed"] }
+anchor-spl = { version = "1.1.2", features = ["metadata"] }
 sha3 = "0.10.8"
 solana-secp256k1-recover = "2.0.0"
 

--- a/tokens/nft-minter/anchor/programs/nft-minter/Cargo.toml
+++ b/tokens/nft-minter/anchor/programs/nft-minter/Cargo.toml
@@ -20,8 +20,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = { version = "1.0.0", features = ["init-if-needed"] }
-anchor-spl = { version = "1.0.0", features = ["metadata"] }
+anchor-lang = { version = "1.1.2", features = ["init-if-needed"] }
+anchor-spl = { version = "1.1.2", features = ["metadata"] }
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/tokens/nft-operations/anchor/programs/mint-nft/Cargo.toml
+++ b/tokens/nft-operations/anchor/programs/mint-nft/Cargo.toml
@@ -20,8 +20,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = { version = "1.0.0", features = ["init-if-needed"] }
-anchor-spl = { version = "1.0.0", features = ["metadata"] }
+anchor-lang = { version = "1.1.2", features = ["init-if-needed"] }
+anchor-spl = { version = "1.1.2", features = ["metadata"] }
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/tokens/pda-mint-authority/anchor/programs/token-minter/Cargo.toml
+++ b/tokens/pda-mint-authority/anchor/programs/token-minter/Cargo.toml
@@ -20,8 +20,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = { version = "1.0.0", features = ["init-if-needed"] }
-anchor-spl = { version = "1.0.0", features = ["metadata"] }
+anchor-lang = { version = "1.1.2", features = ["init-if-needed"] }
+anchor-spl = { version = "1.1.2", features = ["metadata"] }
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/tokens/token-extensions/basics/anchor/programs/basics/Cargo.toml
+++ b/tokens/token-extensions/basics/anchor/programs/basics/Cargo.toml
@@ -20,8 +20,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-spl = "1.0.0"
-anchor-lang = { version = "1.0.0", features= ["init-if-needed"]}
+anchor-spl = "1.1.2"
+anchor-lang = { version = "1.1.2", features= ["init-if-needed"]}
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/tokens/token-extensions/cpi-guard/anchor/programs/cpi-guard/Cargo.toml
+++ b/tokens/token-extensions/cpi-guard/anchor/programs/cpi-guard/Cargo.toml
@@ -20,8 +20,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = { version = "1.0.0", features = ["init-if-needed"] }
-anchor-spl = "1.0.0"
+anchor-lang = { version = "1.1.2", features = ["init-if-needed"] }
+anchor-spl = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/tokens/token-extensions/default-account-state/anchor/programs/default-account-state/Cargo.toml
+++ b/tokens/token-extensions/default-account-state/anchor/programs/default-account-state/Cargo.toml
@@ -20,8 +20,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
-anchor-spl = "1.0.0"
+anchor-lang = "1.1.2"
+anchor-spl = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/tokens/token-extensions/group/anchor/programs/group/Cargo.toml
+++ b/tokens/token-extensions/group/anchor/programs/group/Cargo.toml
@@ -20,8 +20,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
-anchor-spl = "1.0.0"
+anchor-lang = "1.1.2"
+anchor-spl = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/tokens/token-extensions/immutable-owner/anchor/programs/immutable-owner/Cargo.toml
+++ b/tokens/token-extensions/immutable-owner/anchor/programs/immutable-owner/Cargo.toml
@@ -20,8 +20,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
-anchor-spl = "1.0.0"
+anchor-lang = "1.1.2"
+anchor-spl = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/tokens/token-extensions/interest-bearing/anchor/programs/interest-bearing/Cargo.toml
+++ b/tokens/token-extensions/interest-bearing/anchor/programs/interest-bearing/Cargo.toml
@@ -21,8 +21,8 @@ custom-panic = []
 
 
 [dependencies]
-anchor-lang = "1.0.0"
-anchor-spl = "1.0.0"
+anchor-lang = "1.1.2"
+anchor-spl = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/tokens/token-extensions/memo-transfer/anchor/programs/memo-transfer/Cargo.toml
+++ b/tokens/token-extensions/memo-transfer/anchor/programs/memo-transfer/Cargo.toml
@@ -20,8 +20,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
-anchor-spl = "1.0.0"
+anchor-lang = "1.1.2"
+anchor-spl = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/tokens/token-extensions/metadata/anchor/programs/metadata/Cargo.toml
+++ b/tokens/token-extensions/metadata/anchor/programs/metadata/Cargo.toml
@@ -20,8 +20,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
-anchor-spl = "1.0.0"
+anchor-lang = "1.1.2"
+anchor-spl = "1.1.2"
 spl-token-metadata-interface = "0.8.0"
 spl-type-length-value = "0.9.1"
 

--- a/tokens/token-extensions/mint-close-authority/anchor/programs/mint-close-authority/Cargo.toml
+++ b/tokens/token-extensions/mint-close-authority/anchor/programs/mint-close-authority/Cargo.toml
@@ -17,8 +17,8 @@ no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 
 [dependencies]
-anchor-lang = "1.0.0"
-anchor-spl = "1.0.0"
+anchor-lang = "1.1.2"
+anchor-spl = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/tokens/token-extensions/nft-meta-data-pointer/anchor-example/anchor/programs/extension_nft/Cargo.toml
+++ b/tokens/token-extensions/nft-meta-data-pointer/anchor-example/anchor/programs/extension_nft/Cargo.toml
@@ -21,8 +21,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = { version = "1.0.0", features = ["init-if-needed"] }
-anchor-spl = { version = "1.0.0" }
+anchor-lang = { version = "1.1.2", features = ["init-if-needed"] }
+anchor-spl = { version = "1.1.2" }
 # session-keys 3.1.1 is the first release that supports Anchor >=0.28,<2.0
 # (so it builds against Anchor 1.0). Earlier 2.x releases pin Anchor <=0.30
 # and fail to compile against the Anchor 1.0 / Solana 3.x API. Provides the

--- a/tokens/token-extensions/non-transferable/anchor/programs/non-transferable/Cargo.toml
+++ b/tokens/token-extensions/non-transferable/anchor/programs/non-transferable/Cargo.toml
@@ -17,8 +17,8 @@ no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 
 [dependencies]
-anchor-lang = "1.0.0"
-anchor-spl = "1.0.0"
+anchor-lang = "1.1.2"
+anchor-spl = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/tokens/token-extensions/permanent-delegate/anchor/programs/permanent-delegate/Cargo.toml
+++ b/tokens/token-extensions/permanent-delegate/anchor/programs/permanent-delegate/Cargo.toml
@@ -21,8 +21,8 @@ custom-panic = []
 
 
 [dependencies]
-anchor-lang = "1.0.0"
-anchor-spl = "1.0.0"
+anchor-lang = "1.1.2"
+anchor-spl = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/tokens/token-extensions/transfer-fee/anchor/programs/transfer-fee/Cargo.toml
+++ b/tokens/token-extensions/transfer-fee/anchor/programs/transfer-fee/Cargo.toml
@@ -17,8 +17,8 @@ no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 
 [dependencies]
-anchor-lang = { version = "1.0.0", features = ["init-if-needed"] }
-anchor-spl = "1.0.0"
+anchor-lang = { version = "1.1.2", features = ["init-if-needed"] }
+anchor-spl = "1.1.2"
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/tokens/token-extensions/transfer-hook/account-data-as-seed/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/account-data-as-seed/anchor/programs/transfer-hook/Cargo.toml
@@ -20,8 +20,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
-anchor-spl = "1.0.0"
+anchor-lang = "1.1.2"
+anchor-spl = "1.1.2"
 spl-discriminator = "0.4.1"
 spl-tlv-account-resolution = "0.9.0"
 spl-transfer-hook-interface = "0.9.0"

--- a/tokens/token-extensions/transfer-hook/allow-block-list-token/anchor/programs/abl-token/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/allow-block-list-token/anchor/programs/abl-token/Cargo.toml
@@ -22,8 +22,8 @@ custom-panic = []
 
 [dependencies]
 # interface-instructions feature removed in Anchor 1.0
-anchor-lang = "1.0.0"
-anchor-spl = { version = "1.0.0", features = [
+anchor-lang = "1.1.2"
+anchor-spl = { version = "1.1.2", features = [
     "token_2022_extensions",
     "token_2022",
 ] }

--- a/tokens/token-extensions/transfer-hook/counter/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/counter/anchor/programs/transfer-hook/Cargo.toml
@@ -20,8 +20,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
-anchor-spl = "1.0.0"
+anchor-lang = "1.1.2"
+anchor-spl = "1.1.2"
 spl-discriminator = "0.4.1"
 spl-tlv-account-resolution = "0.9.0"
 spl-transfer-hook-interface = "0.9.0"

--- a/tokens/token-extensions/transfer-hook/hello-world/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/hello-world/anchor/programs/transfer-hook/Cargo.toml
@@ -20,8 +20,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
-anchor-spl = "1.0.0"
+anchor-lang = "1.1.2"
+anchor-spl = "1.1.2"
 spl-discriminator = "0.4.1"
 spl-tlv-account-resolution = "0.9.0"
 spl-transfer-hook-interface = "0.9.0"

--- a/tokens/token-extensions/transfer-hook/transfer-cost/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/transfer-cost/anchor/programs/transfer-hook/Cargo.toml
@@ -20,8 +20,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
-anchor-spl = "1.0.0"
+anchor-lang = "1.1.2"
+anchor-spl = "1.1.2"
 # SPL crates v3.x-compatible - uses solana-program-error 3.x matching anchor-lang 1.0
 spl-discriminator = "0.5.2"
 spl-tlv-account-resolution = "0.11.1"

--- a/tokens/token-extensions/transfer-hook/transfer-switch/anchor/programs/transfer-switch/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/transfer-switch/anchor/programs/transfer-switch/Cargo.toml
@@ -20,8 +20,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = { version = "1.0.0", features = ["init-if-needed"] }
-anchor-spl = "1.0.0"
+anchor-lang = { version = "1.1.2", features = ["init-if-needed"] }
+anchor-spl = "1.1.2"
 spl-discriminator = "0.4.1"
 spl-tlv-account-resolution = "0.9.0"
 spl-transfer-hook-interface = "0.9.0"

--- a/tokens/token-extensions/transfer-hook/whitelist/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/whitelist/anchor/programs/transfer-hook/Cargo.toml
@@ -20,8 +20,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = { version = "1.0.0", features = ["init-if-needed"] }
-anchor-spl = "1.0.0"
+anchor-lang = { version = "1.1.2", features = ["init-if-needed"] }
+anchor-spl = "1.1.2"
 spl-discriminator = "0.4.1"
 spl-tlv-account-resolution = "0.9.0"
 spl-transfer-hook-interface = "0.9.0"

--- a/tokens/token-minter/anchor/programs/token-minter/Cargo.toml
+++ b/tokens/token-minter/anchor/programs/token-minter/Cargo.toml
@@ -20,8 +20,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = { version = "1.0.0", features = ["init-if-needed"] }
-anchor-spl = { version = "1.0.0", features = ["metadata"] }
+anchor-lang = { version = "1.1.2", features = ["init-if-needed"] }
+anchor-spl = { version = "1.1.2", features = ["metadata"] }
 
 [dev-dependencies]
 litesvm = "0.11.0"

--- a/tokens/transfer-tokens/anchor/programs/transfer-tokens/Cargo.toml
+++ b/tokens/transfer-tokens/anchor/programs/transfer-tokens/Cargo.toml
@@ -20,8 +20,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = { version = "1.0.0", features = ["init-if-needed"] }
-anchor-spl = { version = "1.0.0", features = ["metadata"] }
+anchor-lang = { version = "1.1.2", features = ["init-if-needed"] }
+anchor-spl = { version = "1.1.2", features = ["metadata"] }
 
 [dev-dependencies]
 litesvm = "0.11.0"


### PR DESCRIPTION
## Summary

Upgrades every Anchor program to the latest stable Anchor, **1.1.2** (up from `1.0.0`).

At the time of writing crates.io lists `1.1.2` as `max_stable_version` (the highest semver) and `1.0.3` as the most recent patch on the 1.0.x line. Since a 1.0 → 1.1 bump is backward-compatible under semver, this standardizes on `1.1.2` — the genuine latest stable.

## Changes

- Bumped `anchor-lang` and `anchor-spl` from `1.0.0` to `1.1.2` across all 57 Anchor program `Cargo.toml` manifests.
- Updated the workspace `Cargo.lock` so the Anchor crate tree resolves to `1.1.2`.
- Pinned the Anchor CLI in `.github/workflows/anchor.yml` (`anchor-version: 1.1.2`) so the build tooling matches the crate version, with a comment explaining the pin.
- Added a CHANGELOG entry.

## Verification

`cargo metadata` resolves the workspace cleanly against the updated lock. Full `anchor build` / `anchor test` for all programs runs in CI — I'm watching the Anchor workflow and will fix any failures the version bump surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqvaHcTCYBFBoj2JUSfskR)_