### PR TITLE
Pin sbpf assembler to specific revision for reproducible builds

### DIFF
--- a/.github/workflows/solana-asm.yml
+++ b/.github/workflows/solana-asm.yml
@@ -199,8 +199,17 @@ jobs:
           # Make the script executable
           chmod +x build_and_test.sh
 
-          # Install sbpf assembler
-          cargo install --git https://github.com/blueshift-gg/sbpf.git
+          # Install sbpf assembler.
+          #
+          # Pin to a specific revision: installing from the branch HEAD makes the
+          # build non-reproducible and breaks CI whenever sbpf changes its output.
+          # On 2026-06-29 sbpf merged its SBPF v3 work (PR #127), switching the
+          # emitted ELF to the v3 / 0x03 OS-ABI format. litesvm 0.11.0's loader
+          # rejects that format, so every asm test started failing at
+          # `svm.add_program(...).unwrap()` with Instruction(InvalidAccountData).
+          # This rev is the last commit before the v3 changes and matches the
+          # toolchain from the last green run; bump it together with litesvm.
+          cargo install --git https://github.com/blueshift-gg/sbpf.git --rev 0223df0e7ba622d4956b4ecf3cf2397f6945b76b
       - name: Setup Solana Stable
         uses: heyAyushh/setup-solana@v5.9
         with:


### PR DESCRIPTION
## Summary
Pin the sbpf assembler installation to a specific git revision instead of building from the latest branch HEAD. This ensures reproducible builds and prevents CI failures when sbpf makes breaking changes to its output format.

## Changes
- Updated the `cargo install` command for sbpf to use `--rev 0223df0e7ba622d4956b4ecf3cf2397f6945b76b`
- Added detailed comments explaining why pinning is necessary:
  - Building from HEAD makes builds non-reproducible
  - sbpf merged SBPF v3 changes (PR #127) on 2026-06-29 that switched to the v3/0x03 OS-ABI ELF format
  - litesvm 0.11.0's loader rejects the v3 format, causing all asm tests to fail
  - The pinned revision is the last commit before v3 changes and matches the last successful CI run
  - The pin should be bumped together with litesvm upgrades

## Implementation Details
The selected revision ensures compatibility with the current litesvm version while maintaining build reproducibility. This approach prevents unexpected CI failures from upstream sbpf changes until litesvm is updated to support the newer ELF format.

https://claude.ai/code/session_015ZgWN7hk3QzLuoDUPYrvdj