### PR TITLE
ci: build all Quasar projects when .ghaignore is empty

### DIFF
--- a/.github/workflows/quasar.yml
+++ b/.github/workflows/quasar.yml
@@ -57,7 +57,14 @@ jobs:
           # that by construction — no substring matching, no path-segment trickery,
           # so siblings like "quasar-example/" can never enter the build list.
           function get_projects() {
-            find . -type d -name "quasar" | grep -vE "$ignore_pattern" | sort
+            # An empty .ghaignore makes ignore_pattern empty, and `grep -vE ""`
+            # matches everything, silently emptying the project list - only
+            # filter when there is actually a pattern.
+            if [[ -n "$ignore_pattern" ]]; then
+              find . -type d -name "quasar" | grep -vE "$ignore_pattern" | sort
+            else
+              find . -type d -name "quasar" | sort
+            fi
           }
 
           # Filter the full project list down to projects touched by the given


### PR DESCRIPTION
## Summary

`quasar.yml` had the same latent bug fixed in `anchor.yml` during the Anchor 1.1.2 upgrade (#84): it computed its project list with `find … | grep -vE "$ignore_pattern"`. Now that `.ghaignore` is empty, `ignore_pattern` is empty and `grep -vE ""` matches every line, so the inverted match drops **all** projects — the build matrix is empty and the workflow reports success without building or testing anything.

This guards the filter so it only runs when a pattern actually exists, matching the fix already present in `anchor.yml`, `native.yml`, `pinocchio.yml`, and `solana-asm.yml`. All five framework workflows are now consistent.

## Changes

- `.github/workflows/quasar.yml`: only apply the `.ghaignore` filter when `ignore_pattern` is non-empty; otherwise list all `quasar` project directories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqvaHcTCYBFBoj2JUSfskR)_