### PR TITLE
Handle two-line anchor version output breaking CI

### DIFF
--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -169,12 +169,44 @@ jobs:
           restore-keys: |
             cargo-${{ runner.os }}-
       - uses: pnpm/action-setup@v4
-      - uses: heyAyushh/setup-anchor@v4.999
+      # Replaces heyAyushh/setup-anchor@v4.999. That action's version-detection step
+      # runs `anchor --version | awk '{print $2}'` and writes the result straight to
+      # $GITHUB_OUTPUT. `anchor --version` now prints more than one line, so the value
+      # becomes multi-line and the step dies with "Invalid format", aborting the whole
+      # job before any project is built. These steps install the same toolchain (Solana
+      # via the Anza installer, Anchor via avm) and read the version from the first line
+      # only. The other workflows that use setup-anchor (native, quasar, pinocchio,
+      # solana-asm) hit the same latent bug once their matrices run; migrate them the
+      # same way once this is confirmed green.
+      - uses: actions/setup-node@v4
         with:
+          node-version: lts/*
+      - name: Install Solana CLI
+        run: |
+          sh -c "$(curl -sSfL https://release.anza.xyz/v3.1.14/install)"
+          echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
+      - name: Cache Anchor toolchain
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/anchor
+            ~/.cargo/bin/avm
+            ~/.avm
           # Pinned to match the anchor-lang/anchor-spl crate version the programs depend on.
-          anchor-version: 1.1.2
-          # setup-anchor resolves tags like stable by querying GitHub API for latest release which can fail with 429 errors
-          solana-cli-version: 3.1.14
+          key: anchor-toolchain-${{ runner.os }}-1.1.2
+      - name: Install Anchor 1.1.2
+        run: |
+          export PATH="$HOME/.cargo/bin:$HOME/.avm/bin:$PATH"
+          # `anchor --version` can emit more than one line; read the first line only so
+          # a multi-line value never reaches downstream parsing.
+          current="$(anchor --version 2>/dev/null | head -n1 | awk '{print $2}' || true)"
+          if [ "$current" != "1.1.2" ]; then
+            cargo install --git https://github.com/coral-xyz/anchor avm --force
+            avm install 1.1.2
+            avm use 1.1.2
+          fi
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.avm/bin" >> "$GITHUB_PATH"
       - name: Install Surfpool
         run: curl -sL https://run.surfpool.run/ | bash
       - name: Display Versions


### PR DESCRIPTION
## Problem

The Anchor workflow aborts at toolchain setup, before any project is built:

```
Found existing Anchor installation: 3.1.10
1.1.2
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format '1.1.2'
```

`heyAyushh/setup-anchor@v4.999` detects an existing install with:

```bash
installed_version=$(anchor --version | awk '{print $2}')
echo "installed_version=$installed_version" >> $GITHUB_OUTPUT
```

`anchor --version` now emits **more than one line**, so `awk '{print $2}'` returns a multi-line value, and writing a multi-line value to `$GITHUB_OUTPUT` fails with `Invalid format`. That kills every matrix group at setup.

It only surfaces when the Anchor matrix actually runs (a change touches an Anchor project). `main` looks green because its last run changed no Anchor projects, so the matrix was skipped and `setup-anchor` never ran — the bug is latent, not absent.

## Fix

Replace `setup-anchor` in `anchor.yml` with the same install steps it performs — Solana via the Anza installer, Anchor via `avm` — plus toolchain caching, and read the Anchor version from the **first line only** (`head -n1`) so a multi-line `anchor --version` can never break parsing again.

The action's own master branch still has the buggy `awk '{print $2}'`, so pinning to another tag would not help.

## Scope / follow-up

- This changes **only `anchor.yml`**. Editing the workflow file triggers a full-matrix run, so this PR's own CI exercises the new setup across every Anchor project.
- `native.yml`, `quasar.yml`, `pinocchio.yml`, and `solana-asm.yml` use the same action and share the latent bug; they can be migrated the same way once this is confirmed green.

## Validation

GitHub Actions changes can't be run locally — this relies on the PR's own CI to confirm the full Anchor matrix installs the toolchain and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4poAxV8XHWn5qcQXb9JPF)_