### PR TITLE
fix(quasar): use transfer_checked in finance programs

### DIFF
--- a/finance/escrow/quasar/src/instructions/cancel_offer.rs
+++ b/finance/escrow/quasar/src/instructions/cancel_offer.rs
@@ -51,11 +51,13 @@ pub fn handle_withdraw_tokens_and_close_cancel_offer(
 
     accounts
         .token_program
-        .transfer(
+        .transfer_checked(
             &accounts.vault,
+            &accounts.token_mint_a,
             &accounts.maker_token_account_a,
             &accounts.offer,
             accounts.vault.amount(),
+            accounts.token_mint_a.decimals(),
         )
         .invoke_signed(&seeds)?;
 

--- a/finance/escrow/quasar/src/instructions/make_offer.rs
+++ b/finance/escrow/quasar/src/instructions/make_offer.rs
@@ -61,11 +61,13 @@ pub fn handle_deposit_tokens(
 ) -> Result<(), ProgramError> {
     accounts
         .token_program
-        .transfer(
+        .transfer_checked(
             &accounts.maker_token_account_a,
+            &accounts.token_mint_a,
             &accounts.vault,
             &accounts.maker,
             amount,
+            accounts.token_mint_a.decimals(),
         )
         .invoke()
 }

--- a/finance/escrow/quasar/src/instructions/take_offer.rs
+++ b/finance/escrow/quasar/src/instructions/take_offer.rs
@@ -52,11 +52,13 @@ pub fn handle_transfer_tokens(
 ) -> Result<(), ProgramError> {
     accounts
         .token_program
-        .transfer(
+        .transfer_checked(
             &accounts.taker_token_account_b,
+            &accounts.token_mint_b,
             &accounts.maker_token_account_b,
             &accounts.taker,
             accounts.offer.receive,
+            accounts.token_mint_b.decimals(),
         )
         .invoke()
 }
@@ -77,11 +79,13 @@ pub fn handle_withdraw_tokens_and_close_take(
 
     accounts
         .token_program
-        .transfer(
+        .transfer_checked(
             &accounts.vault,
+            &accounts.token_mint_a,
             &accounts.taker_token_account_a,
             &accounts.offer,
             accounts.vault.amount(),
+            accounts.token_mint_a.decimals(),
         )
         .invoke_signed(&seeds)?;
 

--- a/finance/perpetual-futures/quasar/src/instructions/add_liquidity.rs
+++ b/finance/perpetual-futures/quasar/src/instructions/add_liquidity.rs
@@ -101,11 +101,13 @@ pub fn handle_add_liquidity(
 
     accounts
         .token_program
-        .transfer(
+        .transfer_checked(
             &accounts.provider_collateral,
+            &accounts.collateral_mint,
             &accounts.custody_vault,
             &accounts.provider,
             amount,
+            accounts.collateral_mint.decimals(),
         )
         .invoke()?;
 

--- a/finance/perpetual-futures/quasar/src/instructions/close_position.rs
+++ b/finance/perpetual-futures/quasar/src/instructions/close_position.rs
@@ -135,11 +135,13 @@ pub fn handle_close_position(
     ];
     accounts
         .token_program
-        .transfer(
+        .transfer_checked(
             &accounts.custody_vault,
+            &accounts.collateral_mint,
             &accounts.trader_collateral,
             &accounts.pool_authority,
             payout,
+            accounts.collateral_mint.decimals(),
         )
         .invoke_signed(seeds)?;
 

--- a/finance/perpetual-futures/quasar/src/instructions/collect_fees.rs
+++ b/finance/perpetual-futures/quasar/src/instructions/collect_fees.rs
@@ -56,11 +56,13 @@ pub fn handle_collect_fees(
     ];
     accounts
         .token_program
-        .transfer(
+        .transfer_checked(
             &accounts.custody_vault,
+            &accounts.collateral_mint,
             &accounts.authority_collateral,
             &accounts.pool_authority,
             amount,
+            accounts.collateral_mint.decimals(),
         )
         .invoke_signed(seeds)?;
 

--- a/finance/perpetual-futures/quasar/src/instructions/liquidate_position.rs
+++ b/finance/perpetual-futures/quasar/src/instructions/liquidate_position.rs
@@ -140,22 +140,26 @@ pub fn handle_liquidate_position(
     if liquidator_payout > 0 {
         accounts
             .token_program
-            .transfer(
+            .transfer_checked(
                 &accounts.custody_vault,
+                &accounts.collateral_mint,
                 &accounts.liquidator_collateral,
                 &accounts.pool_authority,
                 liquidator_payout,
+                accounts.collateral_mint.decimals(),
             )
             .invoke_signed(seeds)?;
     }
     if trader_refund > 0 {
         accounts
             .token_program
-            .transfer(
+            .transfer_checked(
                 &accounts.custody_vault,
+                &accounts.collateral_mint,
                 &accounts.trader_collateral,
                 &accounts.pool_authority,
                 trader_refund,
+                accounts.collateral_mint.decimals(),
             )
             .invoke_signed(seeds)?;
     }

--- a/finance/perpetual-futures/quasar/src/instructions/open_position.rs
+++ b/finance/perpetual-futures/quasar/src/instructions/open_position.rs
@@ -168,11 +168,13 @@ pub fn handle_open_position(
 
     accounts
         .token_program
-        .transfer(
+        .transfer_checked(
             &accounts.trader_collateral,
+            &accounts.collateral_mint,
             &accounts.custody_vault,
             &accounts.owner,
             collateral_amount,
+            accounts.collateral_mint.decimals(),
         )
         .invoke()?;
 

--- a/finance/perpetual-futures/quasar/src/instructions/remove_liquidity.rs
+++ b/finance/perpetual-futures/quasar/src/instructions/remove_liquidity.rs
@@ -120,11 +120,13 @@ pub fn handle_remove_liquidity(
     ];
     accounts
         .token_program
-        .transfer(
+        .transfer_checked(
             &accounts.custody_vault,
+            &accounts.collateral_mint,
             &accounts.provider_collateral,
             &accounts.pool_authority,
             amount_out,
+            accounts.collateral_mint.decimals(),
         )
         .invoke_signed(seeds)?;
 

--- a/finance/token-fundraiser/quasar/src/instructions/check_contributions.rs
+++ b/finance/token-fundraiser/quasar/src/instructions/check_contributions.rs
@@ -13,6 +13,7 @@ pub struct CheckContributionsAccountConstraints {
         mut,
         has_one(maker),
         has_one(vault),
+        has_one(mint_to_raise),
         close(dest = maker),
         address = Fundraiser::seeds(maker.address()),
     )]
@@ -23,6 +24,10 @@ pub struct CheckContributionsAccountConstraints {
 
     #[account(mut)]
     pub maker_ta: Account<Token>,
+
+    // Bound to fundraiser.mint_to_raise by has_one above; carries the decimals
+    // that transfer_checked validates against the vault and maker_ta.
+    pub mint_to_raise: Account<Mint>,
 
     pub token_program: Program<TokenProgram>,
 }
@@ -51,11 +56,13 @@ pub fn handle_check_contributions(
     let vault_amount = accounts.vault.amount();
     accounts
         .token_program
-        .transfer(
+        .transfer_checked(
             &accounts.vault,
+            &accounts.mint_to_raise,
             &accounts.maker_ta,
             &accounts.fundraiser,
             vault_amount,
+            accounts.mint_to_raise.decimals(),
         )
         .invoke_signed(&seeds)?;
 

--- a/finance/token-fundraiser/quasar/src/instructions/contribute.rs
+++ b/finance/token-fundraiser/quasar/src/instructions/contribute.rs
@@ -18,6 +18,7 @@ pub struct ContributeAccountConstraints {
         mut,
         has_one(maker),
         has_one(vault),
+        has_one(mint_to_raise),
         address = Fundraiser::seeds(maker.address()),
     )]
     pub fundraiser: Account<Fundraiser>,
@@ -35,6 +36,10 @@ pub struct ContributeAccountConstraints {
 
     #[account(mut)]
     pub vault: Account<Token>,
+
+    // Bound to fundraiser.mint_to_raise by has_one above; carries the decimals
+    // that transfer_checked validates against contributor_ta and vault.
+    pub mint_to_raise: Account<Mint>,
 
     pub token_program: Program<TokenProgram>,
 
@@ -77,11 +82,13 @@ pub fn handle_contribute(
 
     accounts
         .token_program
-        .transfer(
+        .transfer_checked(
             &accounts.contributor_ta,
+            &accounts.mint_to_raise,
             &accounts.vault,
             &accounts.contributor,
             amount,
+            accounts.mint_to_raise.decimals(),
         )
         .invoke()?;
 

--- a/finance/token-fundraiser/quasar/src/instructions/refund.rs
+++ b/finance/token-fundraiser/quasar/src/instructions/refund.rs
@@ -18,6 +18,7 @@ pub struct RefundAccountConstraints {
         mut,
         has_one(maker),
         has_one(vault),
+        has_one(mint_to_raise),
         address = Fundraiser::seeds(maker.address()),
     )]
     pub fundraiser: Account<Fundraiser>,
@@ -34,6 +35,10 @@ pub struct RefundAccountConstraints {
 
     #[account(mut)]
     pub vault: Account<Token>,
+
+    // Bound to fundraiser.mint_to_raise by has_one above; carries the decimals
+    // that transfer_checked validates against the vault and contributor_ta.
+    pub mint_to_raise: Account<Mint>,
 
     pub token_program: Program<TokenProgram>,
 }
@@ -76,11 +81,13 @@ pub fn handle_refund(accounts: &mut RefundAccountConstraints, bumps: &RefundAcco
 
     accounts
         .token_program
-        .transfer(
+        .transfer_checked(
             &accounts.vault,
+            &accounts.mint_to_raise,
             &accounts.contributor_ta,
             &accounts.fundraiser,
             refund_amount,
+            accounts.mint_to_raise.decimals(),
         )
         .invoke_signed(&seeds)?;
 

--- a/finance/token-fundraiser/quasar/src/tests.rs
+++ b/finance/token-fundraiser/quasar/src/tests.rs
@@ -227,6 +227,7 @@ fn contribute_instruction(fixture: &Fixture, amount: u64) -> Instruction {
         contributor_account: fixture.contributor_account,
         contributor_ta: fixture.contributor_ta,
         vault: fixture.vault,
+        mint_to_raise: fixture.mint,
         token_program: quasar_svm::SPL_TOKEN_PROGRAM_ID,
         system_program: quasar_svm::system_program::ID,
         amount,
@@ -266,6 +267,7 @@ fn refund_instruction(fixture: &Fixture) -> Instruction {
         contributor_account: fixture.contributor_account,
         contributor_ta: fixture.contributor_ta,
         vault: fixture.vault,
+        mint_to_raise: fixture.mint,
         token_program: quasar_svm::SPL_TOKEN_PROGRAM_ID,
     }
     .into()
@@ -520,6 +522,7 @@ fn test_check_contributions_pays_maker_when_target_met() {
         fundraiser: fixture.fundraiser,
         vault: fixture.vault,
         maker_ta,
+        mint_to_raise: fixture.mint,
         token_program: quasar_svm::SPL_TOKEN_PROGRAM_ID,
     }
     .into();
@@ -547,6 +550,7 @@ fn test_check_contributions_rejected_below_target() {
         fundraiser: fixture.fundraiser,
         vault: fixture.vault,
         maker_ta,
+        mint_to_raise: fixture.mint,
         token_program: quasar_svm::SPL_TOKEN_PROGRAM_ID,
     }
     .into();

--- a/finance/token-swap/quasar/src/instructions/claim_admin_fees.rs
+++ b/finance/token-swap/quasar/src/instructions/claim_admin_fees.rs
@@ -91,11 +91,13 @@ pub fn handle_claim_admin_fees(
     if owed_a > 0 {
         accounts
             .token_program
-            .transfer(
+            .transfer_checked(
                 &accounts.pool_a,
+                &accounts.mint_a,
                 &accounts.admin_token_a,
                 &accounts.pool_authority,
                 owed_a,
+                accounts.mint_a.decimals(),
             )
             .invoke_signed(seeds)?;
     }
@@ -103,11 +105,13 @@ pub fn handle_claim_admin_fees(
     if owed_b > 0 {
         accounts
             .token_program
-            .transfer(
+            .transfer_checked(
                 &accounts.pool_b,
+                &accounts.mint_b,
                 &accounts.admin_token_b,
                 &accounts.pool_authority,
                 owed_b,
+                accounts.mint_b.decimals(),
             )
             .invoke_signed(seeds)?;
     }

--- a/finance/token-swap/quasar/src/instructions/deposit_liquidity.rs
+++ b/finance/token-swap/quasar/src/instructions/deposit_liquidity.rs
@@ -213,12 +213,12 @@ pub fn handle_deposit_liquidity(
 
     // Transfer token A to the pool.
     accounts.token_program
-        .transfer(&accounts.token_a, &accounts.pool_a, &accounts.depositor, amount_a)
+        .transfer_checked(&accounts.token_a, &accounts.mint_a, &accounts.pool_a, &accounts.depositor, amount_a, accounts.mint_a.decimals())
         .invoke()?;
 
     // Transfer token B to the pool.
     accounts.token_program
-        .transfer(&accounts.token_b, &accounts.pool_b, &accounts.depositor, amount_b)
+        .transfer_checked(&accounts.token_b, &accounts.mint_b, &accounts.pool_b, &accounts.depositor, amount_b, accounts.mint_b.decimals())
         .invoke()?;
 
     // Mint LP tokens to the depositor (signed by pool authority).

--- a/finance/token-swap/quasar/src/instructions/swap_tokens.rs
+++ b/finance/token-swap/quasar/src/instructions/swap_tokens.rs
@@ -190,20 +190,20 @@ pub fn handle_swap_tokens(
     if input_is_token_a {
         // Trader sends token A to pool.
         accounts.token_program
-            .transfer(&accounts.token_a, &accounts.pool_a, &accounts.trader, input)
+            .transfer_checked(&accounts.token_a, &accounts.mint_a, &accounts.pool_a, &accounts.trader, input, accounts.mint_a.decimals())
             .invoke()?;
         // Pool sends token B to trader (signed).
         accounts.token_program
-            .transfer(&accounts.pool_b, &accounts.token_b, &accounts.pool_authority, output)
+            .transfer_checked(&accounts.pool_b, &accounts.mint_b, &accounts.token_b, &accounts.pool_authority, output, accounts.mint_b.decimals())
             .invoke_signed(seeds)?;
     } else {
         // Pool sends token A to trader (signed).
         accounts.token_program
-            .transfer(&accounts.pool_a, &accounts.token_a, &accounts.pool_authority, output)
+            .transfer_checked(&accounts.pool_a, &accounts.mint_a, &accounts.token_a, &accounts.pool_authority, output, accounts.mint_a.decimals())
             .invoke_signed(seeds)?;
         // Trader sends token B to pool.
         accounts.token_program
-            .transfer(&accounts.token_b, &accounts.pool_b, &accounts.trader, input)
+            .transfer_checked(&accounts.token_b, &accounts.mint_b, &accounts.pool_b, &accounts.trader, input, accounts.mint_b.decimals())
             .invoke()?;
     }
 

--- a/finance/token-swap/quasar/src/instructions/withdraw_liquidity.rs
+++ b/finance/token-swap/quasar/src/instructions/withdraw_liquidity.rs
@@ -127,12 +127,12 @@ pub fn handle_withdraw_liquidity(
 
     // Transfer token A from pool to depositor.
     accounts.token_program
-        .transfer(&accounts.pool_a, &accounts.token_a, &accounts.pool_authority, amount_a)
+        .transfer_checked(&accounts.pool_a, &accounts.mint_a, &accounts.token_a, &accounts.pool_authority, amount_a, accounts.mint_a.decimals())
         .invoke_signed(seeds)?;
 
     // Transfer token B from pool to depositor.
     accounts.token_program
-        .transfer(&accounts.pool_b, &accounts.token_b, &accounts.pool_authority, amount_b)
+        .transfer_checked(&accounts.pool_b, &accounts.mint_b, &accounts.token_b, &accounts.pool_authority, amount_b, accounts.mint_b.decimals())
         .invoke_signed(seeds)?;
 
     // Burn LP tokens.


### PR DESCRIPTION
## What

The Quasar finance programs moved tokens with raw `.transfer()`, which omits the mint and decimals from the CPI. `transfer_checked` carries both, so a wrong-mint or wrong-decimals token account fails the CPI instead of being caught only by downstream balance checks (or not at all). This matches the Anchor twins and the `lending/quasar` program, which already used `transfer_checked`.

Converted all raw token transfers in:

- **escrow** — make_offer / take_offer (×2) / cancel_offer
- **token-swap** — deposit_liquidity, withdraw_liquidity, swap_tokens (×4), claim_admin_fees (×2)
- **perpetual-futures** — add/remove liquidity, open/close position, liquidate (×2), collect_fees (all in the single `collateral_mint`)
- **token-fundraiser** — contribute / refund / check_contributions

Each call now passes the mint whose token accounts are being moved and its `.decimals()`. `.burn` / `.mint_to` / `.close_account` CPIs are untouched.

### token-fundraiser needed an account added

Its contribute/refund/check_contributions instructions had no mint in scope, so each gained a `mint_to_raise: Account<Mint>` bound to `Fundraiser.mint_to_raise` via `has_one` (validated against stored state, not caller-supplied). The generated client picks up the new account automatically; the LiteSVM tests pass it via `fixture.mint`.

## Verification

`cargo check` passes on all four crates (token-fundraiser via `--lib`, since its tests depend on the `quasar build`-generated client). The Quasar CI (`quasar build` + `cargo test` under QuasarSVM) exercises the full behavior — token conservation and vault invariants are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)