### PR TITLE
ci: fix stale setup-anchor comment referencing the wrong action

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -253,7 +253,7 @@ jobs:
       - name: Setup Solana Stable
         uses: heyAyushh/setup-solana@v5.9
         with:
-          # setup-anchor resolves tags like stable by querying GitHub API for latest release which can fail with 429 errors
+          # Pin an exact version rather than a tag like "stable", which setup-solana resolves via the GitHub API (can fail with 429).
           solana-cli-version: 3.1.14
       - name: Build and Test with Stable
         run: |

--- a/.github/workflows/pinocchio.yml
+++ b/.github/workflows/pinocchio.yml
@@ -269,7 +269,7 @@ jobs:
       - name: Setup Solana Stable
         uses: heyAyushh/setup-solana@v5.9
         with:
-          # setup-anchor resolves tags like stable by querying GitHub API for latest release which can fail with 429 errors
+          # Pin an exact version rather than a tag like "stable", which setup-solana resolves via the GitHub API (can fail with 429).
           solana-cli-version: 3.1.14
       - name: Build and Test with Stable
         run: |

--- a/.github/workflows/quasar.yml
+++ b/.github/workflows/quasar.yml
@@ -256,7 +256,7 @@ jobs:
       - name: Setup Solana Stable
         uses: heyAyushh/setup-solana@v5.9
         with:
-          # setup-anchor resolves tags like stable by querying GitHub API for latest release which can fail with 429 errors
+          # Pin an exact version rather than a tag like "stable", which setup-solana resolves via the GitHub API (can fail with 429).
           solana-cli-version: 3.1.14
       - name: Install Quasar CLI
         # Pinned to quasar rev 3d6fb0d8 (the HEAD this migration was written

--- a/.github/workflows/solana-asm.yml
+++ b/.github/workflows/solana-asm.yml
@@ -207,7 +207,7 @@ jobs:
       - name: Setup Solana Stable
         uses: heyAyushh/setup-solana@v5.9
         with:
-          # setup-anchor resolves tags like stable by querying GitHub API for latest release which can fail with 429 errors
+          # Pin an exact version rather than a tag like "stable", which setup-solana resolves via the GitHub API (can fail with 429).
           solana-cli-version: 3.1.14
       - name: Build and Test with Stable
         run: |


### PR DESCRIPTION
The `native`, `quasar`, `pinocchio`, and `solana-asm` workflows set up the toolchain with `heyAyushh/setup-solana`, but each carried a copy-pasted comment blaming the pinned `solana-cli-version` on `setup-anchor` — an action none of them use. Reworded to explain why the version is pinned (avoiding GitHub-API tag resolution and its 429s) without naming the wrong action.

Comment-only change; no workflow behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4poAxV8XHWn5qcQXb9JPF)_