### PR TITLE
chore(anchor): set package_manager = pnpm in all Anchor.toml

### DIFF
--- a/basics/account-data/anchor/Anchor.toml
+++ b/basics/account-data/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/basics/checking-accounts/anchor/Anchor.toml
+++ b/basics/checking-accounts/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/basics/close-account/anchor/Anchor.toml
+++ b/basics/close-account/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/basics/counter/anchor/Anchor.toml
+++ b/basics/counter/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/basics/create-account/anchor/Anchor.toml
+++ b/basics/create-account/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/basics/cross-program-invocation/anchor/Anchor.toml
+++ b/basics/cross-program-invocation/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/basics/favorites/anchor/Anchor.toml
+++ b/basics/favorites/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/basics/hello-solana/anchor/Anchor.toml
+++ b/basics/hello-solana/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/basics/pda-rent-payer/anchor/Anchor.toml
+++ b/basics/pda-rent-payer/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/basics/processing-instructions/anchor/Anchor.toml
+++ b/basics/processing-instructions/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/basics/program-derived-addresses/anchor/Anchor.toml
+++ b/basics/program-derived-addresses/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/basics/pyth/anchor/Anchor.toml
+++ b/basics/pyth/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/basics/realloc/anchor/Anchor.toml
+++ b/basics/realloc/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/basics/rent/anchor/Anchor.toml
+++ b/basics/rent/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/basics/repository-layout/anchor/Anchor.toml
+++ b/basics/repository-layout/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/basics/transfer-sol/anchor/Anchor.toml
+++ b/basics/transfer-sol/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/compression/cnft-burn/anchor/Anchor.toml
+++ b/compression/cnft-burn/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/compression/cnft-vault/anchor/Anchor.toml
+++ b/compression/cnft-vault/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/compression/cutils/anchor/Anchor.toml
+++ b/compression/cutils/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/finance/betting-market/anchor/Anchor.toml
+++ b/finance/betting-market/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/finance/escrow/anchor/Anchor.toml
+++ b/finance/escrow/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/finance/lending/anchor/Anchor.toml
+++ b/finance/lending/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 # Pinned to match the rest of solana-program-examples (see tokens/token-swap).
 # Unpin when the repo-wide Solana version is bumped.
 solana_version = "3.1.8"

--- a/finance/order-book/anchor/Anchor.toml
+++ b/finance/order-book/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 # Pin Solana to the version used across the repo's Anchor 1.0 examples so the
 # bundled test validator and BPF toolchain stay in lock-step.
 solana_version = "3.1.8"

--- a/finance/perpetual-futures/anchor/Anchor.toml
+++ b/finance/perpetual-futures/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/finance/token-fundraiser/anchor/Anchor.toml
+++ b/finance/token-fundraiser/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/finance/token-swap/anchor/Anchor.toml
+++ b/finance/token-swap/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/finance/vault-strategy/anchor/Anchor.toml
+++ b/finance/vault-strategy/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/tokens/create-token/anchor/Anchor.toml
+++ b/tokens/create-token/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/tokens/external-delegate-token-master/anchor/Anchor.toml
+++ b/tokens/external-delegate-token-master/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/tokens/nft-minter/anchor/Anchor.toml
+++ b/tokens/nft-minter/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/tokens/nft-operations/anchor/Anchor.toml
+++ b/tokens/nft-operations/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/tokens/pda-mint-authority/anchor/Anchor.toml
+++ b/tokens/pda-mint-authority/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/tokens/token-extensions/basics/anchor/Anchor.toml
+++ b/tokens/token-extensions/basics/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/tokens/token-extensions/cpi-guard/anchor/Anchor.toml
+++ b/tokens/token-extensions/cpi-guard/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/tokens/token-extensions/default-account-state/anchor/Anchor.toml
+++ b/tokens/token-extensions/default-account-state/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/tokens/token-extensions/group/anchor/Anchor.toml
+++ b/tokens/token-extensions/group/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/tokens/token-extensions/immutable-owner/anchor/Anchor.toml
+++ b/tokens/token-extensions/immutable-owner/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/tokens/token-extensions/interest-bearing/anchor/Anchor.toml
+++ b/tokens/token-extensions/interest-bearing/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/tokens/token-extensions/memo-transfer/anchor/Anchor.toml
+++ b/tokens/token-extensions/memo-transfer/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/tokens/token-extensions/metadata/anchor/Anchor.toml
+++ b/tokens/token-extensions/metadata/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/tokens/token-extensions/mint-close-authority/anchor/Anchor.toml
+++ b/tokens/token-extensions/mint-close-authority/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/tokens/token-extensions/nft-meta-data-pointer/anchor-example/anchor/Anchor.toml
+++ b/tokens/token-extensions/nft-meta-data-pointer/anchor-example/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/tokens/token-extensions/non-transferable/anchor/Anchor.toml
+++ b/tokens/token-extensions/non-transferable/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/tokens/token-extensions/permanent-delegate/anchor/Anchor.toml
+++ b/tokens/token-extensions/permanent-delegate/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/tokens/token-extensions/transfer-fee/anchor/Anchor.toml
+++ b/tokens/token-extensions/transfer-fee/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/tokens/token-extensions/transfer-hook/account-data-as-seed/anchor/Anchor.toml
+++ b/tokens/token-extensions/transfer-hook/account-data-as-seed/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/tokens/token-extensions/transfer-hook/allow-block-list-token/anchor/Anchor.toml
+++ b/tokens/token-extensions/transfer-hook/allow-block-list-token/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/tokens/token-extensions/transfer-hook/counter/anchor/Anchor.toml
+++ b/tokens/token-extensions/transfer-hook/counter/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/tokens/token-extensions/transfer-hook/hello-world/anchor/Anchor.toml
+++ b/tokens/token-extensions/transfer-hook/hello-world/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/tokens/token-extensions/transfer-hook/transfer-cost/anchor/Anchor.toml
+++ b/tokens/token-extensions/transfer-hook/transfer-cost/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/tokens/token-extensions/transfer-hook/transfer-switch/anchor/Anchor.toml
+++ b/tokens/token-extensions/transfer-hook/transfer-switch/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/tokens/token-extensions/transfer-hook/whitelist/anchor/Anchor.toml
+++ b/tokens/token-extensions/transfer-hook/whitelist/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/tokens/token-minter/anchor/Anchor.toml
+++ b/tokens/token-minter/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]

--- a/tokens/transfer-tokens/anchor/Anchor.toml
+++ b/tokens/transfer-tokens/anchor/Anchor.toml
@@ -1,4 +1,6 @@
 [toolchain]
+# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
+package_manager = "pnpm"
 solana_version = "3.1.8"
 
 [features]


### PR DESCRIPTION
## Why

Anchor's `[toolchain].package_manager` was unset in all 54 `Anchor.toml` files. When unset, Anchor defaults to **yarn**, which this project's skill bans. The repo already standardises on **pnpm** (`pnpm-lock.yaml` at root, mandated in `CONTRIBUTING.md`), so `pnpm` — not `npm` — is the correct value here (the skill's rule is to keep pnpm where a project already uses it).

## What

Added to each `[toolchain]` section:

```toml
[toolchain]
# Match the repo package manager (pnpm-lock.yaml at root); avoids Anchor's yarn default.
package_manager = "pnpm"
```

The programs test via `cargo` / LiteSVM, so this is mostly latent — but it stops any `anchor` command that shells out to a JS package manager from picking yarn, and makes the intent explicit. All 54 files validated as parseable TOML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4poAxV8XHWn5qcQXb9JPF)_