### PR TITLE
test(hello-solana): assert the greeting log instead of only tx success

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1994,6 +1994,7 @@ dependencies = [
  "litesvm",
  "solana-kite",
  "solana-signer",
+ "solana-transaction",
 ]
 
 [[package]]

--- a/basics/hello-solana/anchor/programs/hello-solana/Cargo.toml
+++ b/basics/hello-solana/anchor/programs/hello-solana/Cargo.toml
@@ -26,6 +26,7 @@ anchor-lang = "1.1.2"
 litesvm = "0.13.1"
 solana-signer = "3.0.0"
 solana-kite = "0.4.0"
+solana-transaction = "3.0.1"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_os, values("solana"))'] }

--- a/basics/hello-solana/anchor/programs/hello-solana/tests/test_hello.rs
+++ b/basics/hello-solana/anchor/programs/hello-solana/tests/test_hello.rs
@@ -32,7 +32,10 @@ fn test_say_hello() {
     let metadata = svm.send_transaction(transaction).unwrap();
 
     assert!(
-        metadata.logs.iter().any(|log| log.contains("Hello, Solana!")),
+        metadata
+            .logs
+            .iter()
+            .any(|log| log.contains("Hello, Solana!")),
         "expected the program to log its greeting, got: {:?}",
         metadata.logs
     );

--- a/basics/hello-solana/anchor/programs/hello-solana/tests/test_hello.rs
+++ b/basics/hello-solana/anchor/programs/hello-solana/tests/test_hello.rs
@@ -1,8 +1,9 @@
 use {
     anchor_lang::{solana_program::instruction::Instruction, InstructionData, ToAccountMetas},
     litesvm::LiteSVM,
-    solana_kite::{create_wallet, send_transaction_from_instructions},
+    solana_kite::create_wallet,
     solana_signer::Signer,
+    solana_transaction::Transaction,
 };
 
 #[test]
@@ -19,6 +20,20 @@ fn test_say_hello() {
         hello_solana::accounts::HelloAccountConstraints {}.to_account_metas(None),
     );
 
-    send_transaction_from_instructions(&mut svm, vec![instruction], &[&payer], &payer.pubkey())
-        .unwrap();
+    // The program only logs; assert it emitted its greeting rather than merely
+    // that the transaction landed. kite's send helper discards the metadata, so
+    // send through LiteSVM directly to read the logs.
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&payer.pubkey()),
+        &[&payer],
+        svm.latest_blockhash(),
+    );
+    let metadata = svm.send_transaction(transaction).unwrap();
+
+    assert!(
+        metadata.logs.iter().any(|log| log.contains("Hello, Solana!")),
+        "expected the program to log its greeting, got: {:?}",
+        metadata.logs
+    );
 }

--- a/basics/hello-solana/native/program/tests/test.rs
+++ b/basics/hello-solana/native/program/tests/test.rs
@@ -34,5 +34,9 @@ fn test_hello_solana() {
         svm.latest_blockhash(),
     );
 
-    assert!(svm.send_transaction(tx).is_ok());
+    let result = svm.send_transaction(tx);
+    assert!(result.is_ok());
+
+    let logs = result.unwrap().logs;
+    assert!(logs.iter().any(|log| log.contains("Hello, Solana!")));
 }

--- a/basics/hello-solana/quasar/src/tests.rs
+++ b/basics/hello-solana/quasar/src/tests.rs
@@ -31,4 +31,12 @@ fn test_hello() {
     );
 
     result.assert_success();
+
+    // The program only logs; assert it emitted its greeting, not just that the
+    // transaction succeeded.
+    let logs = result.logs.join("\n");
+    assert!(
+        logs.contains("Hello, Solana!"),
+        "expected the program to log its greeting, got:\n{logs}"
+    );
 }


### PR DESCRIPTION
## Why

`hello-solana` logs a message and changes no state, so a test that only checks the transaction landed verifies nothing about the program's actual behavior — the skill calls these out as not-real tests. Each flavor now asserts the program emitted `Hello, Solana!`.

## Changes

- **anchor** — kite's `send_transaction_from_instructions` returns `Result<(), _>` and discards the metadata (and logs). Send through LiteSVM directly instead (adds a `solana-transaction` dev-dep) and assert the greeting appears in `metadata.logs`.
- **native** — was `assert!(...is_ok())`; now captures the result and asserts the log.
- **quasar** — asserts `result.logs` contains the greeting after `assert_success()`.
- **pinocchio** — already asserted the log; unchanged.

## Verification

The anchor rewrite was type-checked with `cargo check --tests` (against a placeholder `.so` so `include_bytes!` resolves — the sbf toolchain isn't available locally, so full execution is left to CI). The native and quasar changes mirror log-asserting patterns already used elsewhere in the repo (`pinocchio` hello-solana; `repository-layout/quasar`).

This covers the clearly-weak `hello-solana` family. If you want, I can sweep for other assert-only tests in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4poAxV8XHWn5qcQXb9JPF)_