### PR TITLE
docs: add a CHANGELOG.md to every example program

### DIFF
--- a/basics/account-data/anchor/CHANGELOG.md
+++ b/basics/account-data/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/account-data/native/CHANGELOG.md
+++ b/basics/account-data/native/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/account-data/pinocchio/CHANGELOG.md
+++ b/basics/account-data/pinocchio/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/account-data/quasar/CHANGELOG.md
+++ b/basics/account-data/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/checking-accounts/anchor/CHANGELOG.md
+++ b/basics/checking-accounts/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/checking-accounts/native/CHANGELOG.md
+++ b/basics/checking-accounts/native/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/checking-accounts/pinocchio/CHANGELOG.md
+++ b/basics/checking-accounts/pinocchio/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/checking-accounts/quasar/CHANGELOG.md
+++ b/basics/checking-accounts/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/close-account/anchor/CHANGELOG.md
+++ b/basics/close-account/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/close-account/native/CHANGELOG.md
+++ b/basics/close-account/native/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/close-account/pinocchio/CHANGELOG.md
+++ b/basics/close-account/pinocchio/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/close-account/quasar/CHANGELOG.md
+++ b/basics/close-account/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/counter/anchor/CHANGELOG.md
+++ b/basics/counter/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/counter/native/CHANGELOG.md
+++ b/basics/counter/native/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/counter/pinocchio/CHANGELOG.md
+++ b/basics/counter/pinocchio/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/counter/quasar/CHANGELOG.md
+++ b/basics/counter/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/create-account/anchor/CHANGELOG.md
+++ b/basics/create-account/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/create-account/native/CHANGELOG.md
+++ b/basics/create-account/native/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/create-account/pinocchio/CHANGELOG.md
+++ b/basics/create-account/pinocchio/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/create-account/quasar/CHANGELOG.md
+++ b/basics/create-account/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/cross-program-invocation/anchor/CHANGELOG.md
+++ b/basics/cross-program-invocation/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/cross-program-invocation/native/CHANGELOG.md
+++ b/basics/cross-program-invocation/native/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/cross-program-invocation/pinocchio/CHANGELOG.md
+++ b/basics/cross-program-invocation/pinocchio/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/cross-program-invocation/quasar/CHANGELOG.md
+++ b/basics/cross-program-invocation/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/favorites/anchor/CHANGELOG.md
+++ b/basics/favorites/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/favorites/native/CHANGELOG.md
+++ b/basics/favorites/native/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/favorites/pinocchio/CHANGELOG.md
+++ b/basics/favorites/pinocchio/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/favorites/quasar/CHANGELOG.md
+++ b/basics/favorites/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/hello-solana/anchor/CHANGELOG.md
+++ b/basics/hello-solana/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/hello-solana/native/CHANGELOG.md
+++ b/basics/hello-solana/native/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/hello-solana/pinocchio/CHANGELOG.md
+++ b/basics/hello-solana/pinocchio/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/hello-solana/quasar/CHANGELOG.md
+++ b/basics/hello-solana/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/pda-rent-payer/anchor/CHANGELOG.md
+++ b/basics/pda-rent-payer/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/pda-rent-payer/native/CHANGELOG.md
+++ b/basics/pda-rent-payer/native/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/pda-rent-payer/pinocchio/CHANGELOG.md
+++ b/basics/pda-rent-payer/pinocchio/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/pda-rent-payer/quasar/CHANGELOG.md
+++ b/basics/pda-rent-payer/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/processing-instructions/anchor/CHANGELOG.md
+++ b/basics/processing-instructions/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/processing-instructions/native/CHANGELOG.md
+++ b/basics/processing-instructions/native/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/processing-instructions/pinocchio/CHANGELOG.md
+++ b/basics/processing-instructions/pinocchio/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/processing-instructions/quasar/CHANGELOG.md
+++ b/basics/processing-instructions/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/program-derived-addresses/anchor/CHANGELOG.md
+++ b/basics/program-derived-addresses/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/program-derived-addresses/native/CHANGELOG.md
+++ b/basics/program-derived-addresses/native/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/program-derived-addresses/pinocchio/CHANGELOG.md
+++ b/basics/program-derived-addresses/pinocchio/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/program-derived-addresses/quasar/CHANGELOG.md
+++ b/basics/program-derived-addresses/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/pyth/anchor/CHANGELOG.md
+++ b/basics/pyth/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/pyth/quasar/CHANGELOG.md
+++ b/basics/pyth/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/realloc/anchor/CHANGELOG.md
+++ b/basics/realloc/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/realloc/native/CHANGELOG.md
+++ b/basics/realloc/native/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/realloc/pinocchio/CHANGELOG.md
+++ b/basics/realloc/pinocchio/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/realloc/quasar/CHANGELOG.md
+++ b/basics/realloc/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/rent/anchor/CHANGELOG.md
+++ b/basics/rent/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/rent/native/CHANGELOG.md
+++ b/basics/rent/native/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/rent/pinocchio/CHANGELOG.md
+++ b/basics/rent/pinocchio/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/rent/quasar/CHANGELOG.md
+++ b/basics/rent/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/repository-layout/anchor/CHANGELOG.md
+++ b/basics/repository-layout/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/repository-layout/native/CHANGELOG.md
+++ b/basics/repository-layout/native/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/repository-layout/pinocchio/CHANGELOG.md
+++ b/basics/repository-layout/pinocchio/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/repository-layout/quasar/CHANGELOG.md
+++ b/basics/repository-layout/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/transfer-sol/anchor/CHANGELOG.md
+++ b/basics/transfer-sol/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/transfer-sol/native/CHANGELOG.md
+++ b/basics/transfer-sol/native/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/transfer-sol/pinocchio/CHANGELOG.md
+++ b/basics/transfer-sol/pinocchio/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/basics/transfer-sol/quasar/CHANGELOG.md
+++ b/basics/transfer-sol/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/compression/cnft-burn/anchor/CHANGELOG.md
+++ b/compression/cnft-burn/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/compression/cnft-burn/quasar/CHANGELOG.md
+++ b/compression/cnft-burn/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/compression/cnft-vault/anchor/CHANGELOG.md
+++ b/compression/cnft-vault/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/compression/cnft-vault/quasar/CHANGELOG.md
+++ b/compression/cnft-vault/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/compression/cutils/anchor/CHANGELOG.md
+++ b/compression/cutils/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/compression/cutils/quasar/CHANGELOG.md
+++ b/compression/cutils/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/finance/betting-market/anchor/CHANGELOG.md
+++ b/finance/betting-market/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/finance/betting-market/quasar/CHANGELOG.md
+++ b/finance/betting-market/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/finance/escrow/anchor/CHANGELOG.md
+++ b/finance/escrow/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/finance/escrow/native/CHANGELOG.md
+++ b/finance/escrow/native/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/finance/escrow/quasar/CHANGELOG.md
+++ b/finance/escrow/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/finance/order-book/anchor/CHANGELOG.md
+++ b/finance/order-book/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/finance/order-book/quasar/CHANGELOG.md
+++ b/finance/order-book/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/finance/perpetual-futures/anchor/CHANGELOG.md
+++ b/finance/perpetual-futures/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/finance/perpetual-futures/quasar/CHANGELOG.md
+++ b/finance/perpetual-futures/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/finance/token-fundraiser/anchor/CHANGELOG.md
+++ b/finance/token-fundraiser/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/finance/token-fundraiser/quasar/CHANGELOG.md
+++ b/finance/token-fundraiser/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/finance/token-swap/anchor/CHANGELOG.md
+++ b/finance/token-swap/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/finance/token-swap/quasar/CHANGELOG.md
+++ b/finance/token-swap/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/finance/vault-strategy/quasar/CHANGELOG.md
+++ b/finance/vault-strategy/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/tokens/create-token/anchor/CHANGELOG.md
+++ b/tokens/create-token/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/tokens/create-token/native/CHANGELOG.md
+++ b/tokens/create-token/native/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/tokens/create-token/quasar/CHANGELOG.md
+++ b/tokens/create-token/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/tokens/external-delegate-token-master/anchor/CHANGELOG.md
+++ b/tokens/external-delegate-token-master/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/tokens/external-delegate-token-master/quasar/CHANGELOG.md
+++ b/tokens/external-delegate-token-master/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/tokens/nft-minter/anchor/CHANGELOG.md
+++ b/tokens/nft-minter/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/tokens/nft-minter/native/CHANGELOG.md
+++ b/tokens/nft-minter/native/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/tokens/nft-minter/quasar/CHANGELOG.md
+++ b/tokens/nft-minter/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/tokens/nft-operations/anchor/CHANGELOG.md
+++ b/tokens/nft-operations/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/tokens/nft-operations/quasar/CHANGELOG.md
+++ b/tokens/nft-operations/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/tokens/pda-mint-authority/anchor/CHANGELOG.md
+++ b/tokens/pda-mint-authority/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/tokens/pda-mint-authority/native/CHANGELOG.md
+++ b/tokens/pda-mint-authority/native/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/tokens/pda-mint-authority/quasar/CHANGELOG.md
+++ b/tokens/pda-mint-authority/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/tokens/token-minter/anchor/CHANGELOG.md
+++ b/tokens/token-minter/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/tokens/token-minter/native/CHANGELOG.md
+++ b/tokens/token-minter/native/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/tokens/token-minter/quasar/CHANGELOG.md
+++ b/tokens/token-minter/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/tokens/transfer-tokens/anchor/CHANGELOG.md
+++ b/tokens/transfer-tokens/anchor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/tokens/transfer-tokens/native/CHANGELOG.md
+++ b/tokens/transfer-tokens/native/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/tokens/transfer-tokens/quasar/CHANGELOG.md
+++ b/tokens/transfer-tokens/quasar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.

--- a/tools/shank-and-codama/native/CHANGELOG.md
+++ b/tools/shank-and-codama/native/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-07
+
+Added this changelog. Changes prior to this date were tracked in git history only.


### PR DESCRIPTION
## Why

Only a handful of programs (lending, vault-strategy, and the finance twins) had a `CHANGELOG.md`. Give every example program one, so each has a place to record user-visible changes going forward — the same way every program has a README.

## What

Adds a `CHANGELOG.md` to **every program flavor dir** (anchor, quasar, native, pinocchio) across `basics`, `tokens`, `compression`, and `finance` that lacked one — 102 files.

Each entry just marks when changelog tracking began — the programs predate the file, so it doesn't claim an "initial release"; earlier history lives in git:

```
# Changelog

## 2026-07-07

Added this changelog. Changes prior to this date were tracked in git history only.
```

The README documents what each program does, so the CHANGELOG doesn't repeat it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)