### PR TITLE
Fix: ASM test compilation when binaries are missing

### DIFF
--- a/basics/checking-accounts/asm/Cargo.toml
+++ b/basics/checking-accounts/asm/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+build = "build.rs"
 name = "checking-account-asm-program"
 version = "0.1.0"
 edition = "2021"

--- a/basics/checking-accounts/asm/build.rs
+++ b/basics/checking-accounts/asm/build.rs
@@ -1,0 +1,12 @@
+use std::path::Path;
+
+fn main() {
+    let so_path = Path::new("deploy/program.so");
+
+    if so_path.exists() {
+        println!("cargo:rustc-cfg=has_asm_binary");
+    } else {
+        println!("cargo:warning=ASM binary not found at deploy/program.so");
+        println!("cargo:warning=Run `sbpf build` in the asm directory to generate it");
+    }
+}

--- a/basics/checking-accounts/asm/build.rs
+++ b/basics/checking-accounts/asm/build.rs
@@ -1,12 +1,22 @@
+// The tests embed the assembled program with include_bytes!, which needs the
+// file to exist at compile time. `sbpf build` produces it, and it is gitignored,
+// so a fresh checkout has no binary and the test module cannot compile. Set a
+// cfg when the binary is present and let the tests key off it: present, they
+// compile and run; absent, they are left out and the crate still builds.
 use std::path::Path;
 
-fn main() {
-    let so_path = Path::new("deploy/program.so");
+const BINARY: &str = "deploy/checking-account-asm-program.so";
 
-    if so_path.exists() {
-        println!("cargo:rustc-cfg=has_asm_binary");
+fn main() {
+    // Declare the cfg so `-D warnings` builds do not fail on unexpected_cfgs.
+    println!("cargo::rustc-check-cfg=cfg(has_asm_binary)");
+    // Re-run when the binary appears or changes, so the cfg never goes stale.
+    println!("cargo::rerun-if-changed={BINARY}");
+
+    if Path::new(BINARY).exists() {
+        println!("cargo::rustc-cfg=has_asm_binary");
     } else {
-        println!("cargo:warning=ASM binary not found at deploy/program.so");
-        println!("cargo:warning=Run `sbpf build` in the asm directory to generate it");
+        println!("cargo::warning=ASM binary not found at {BINARY}: tests skipped");
+        println!("cargo::warning=Run `sbpf build` in this directory to generate it");
     }
 }

--- a/basics/checking-accounts/asm/src/lib.rs
+++ b/basics/checking-accounts/asm/src/lib.rs
@@ -1,4 +1,4 @@
-#[cfg(test)]
+#[cfg(all(test, has_asm_binary))]
 mod tests {
 
     use litesvm::LiteSVM;

--- a/basics/create-account/asm/Cargo.toml
+++ b/basics/create-account/asm/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+build = "build.rs"
 name = "create-account-asm-program"
 version = "0.1.0"
 edition = "2021"

--- a/basics/create-account/asm/build.rs
+++ b/basics/create-account/asm/build.rs
@@ -1,12 +1,22 @@
+// The tests embed the assembled program with include_bytes!, which needs the
+// file to exist at compile time. `sbpf build` produces it, and it is gitignored,
+// so a fresh checkout has no binary and the test module cannot compile. Set a
+// cfg when the binary is present and let the tests key off it: present, they
+// compile and run; absent, they are left out and the crate still builds.
 use std::path::Path;
 
-fn main() {
-    let so_path = Path::new("deploy/program.so");
+const BINARY: &str = "deploy/create-account-asm-program.so";
 
-    if so_path.exists() {
-        println!("cargo:rustc-cfg=has_asm_binary");
+fn main() {
+    // Declare the cfg so `-D warnings` builds do not fail on unexpected_cfgs.
+    println!("cargo::rustc-check-cfg=cfg(has_asm_binary)");
+    // Re-run when the binary appears or changes, so the cfg never goes stale.
+    println!("cargo::rerun-if-changed={BINARY}");
+
+    if Path::new(BINARY).exists() {
+        println!("cargo::rustc-cfg=has_asm_binary");
     } else {
-        println!("cargo:warning=ASM binary not found at deploy/program.so");
-        println!("cargo:warning=Run `sbpf build` in the asm directory to generate it");
+        println!("cargo::warning=ASM binary not found at {BINARY}: tests skipped");
+        println!("cargo::warning=Run `sbpf build` in this directory to generate it");
     }
 }

--- a/basics/create-account/asm/build.rs
+++ b/basics/create-account/asm/build.rs
@@ -1,0 +1,12 @@
+use std::path::Path;
+
+fn main() {
+    let so_path = Path::new("deploy/program.so");
+
+    if so_path.exists() {
+        println!("cargo:rustc-cfg=has_asm_binary");
+    } else {
+        println!("cargo:warning=ASM binary not found at deploy/program.so");
+        println!("cargo:warning=Run `sbpf build` in the asm directory to generate it");
+    }
+}

--- a/basics/create-account/asm/src/lib.rs
+++ b/basics/create-account/asm/src/lib.rs
@@ -1,4 +1,4 @@
-#[cfg(test)]
+#[cfg(all(test, has_asm_binary))]
 mod tests {
 
     use litesvm::LiteSVM;

--- a/basics/hello-solana/asm/Cargo.toml
+++ b/basics/hello-solana/asm/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+build = "build.rs"
 name = "hello-solana-asm-program"
 version = "0.1.0"
 edition = "2021"

--- a/basics/hello-solana/asm/build.rs
+++ b/basics/hello-solana/asm/build.rs
@@ -1,12 +1,22 @@
+// The tests embed the assembled program with include_bytes!, which needs the
+// file to exist at compile time. `sbpf build` produces it, and it is gitignored,
+// so a fresh checkout has no binary and the test module cannot compile. Set a
+// cfg when the binary is present and let the tests key off it: present, they
+// compile and run; absent, they are left out and the crate still builds.
 use std::path::Path;
 
-fn main() {
-    let so_path = Path::new("deploy/program.so");
+const BINARY: &str = "deploy/hello-solana-asm-program.so";
 
-    if so_path.exists() {
-        println!("cargo:rustc-cfg=has_asm_binary");
+fn main() {
+    // Declare the cfg so `-D warnings` builds do not fail on unexpected_cfgs.
+    println!("cargo::rustc-check-cfg=cfg(has_asm_binary)");
+    // Re-run when the binary appears or changes, so the cfg never goes stale.
+    println!("cargo::rerun-if-changed={BINARY}");
+
+    if Path::new(BINARY).exists() {
+        println!("cargo::rustc-cfg=has_asm_binary");
     } else {
-        println!("cargo:warning=ASM binary not found at deploy/program.so");
-        println!("cargo:warning=Run `sbpf build` in the asm directory to generate it");
+        println!("cargo::warning=ASM binary not found at {BINARY}: tests skipped");
+        println!("cargo::warning=Run `sbpf build` in this directory to generate it");
     }
 }

--- a/basics/hello-solana/asm/build.rs
+++ b/basics/hello-solana/asm/build.rs
@@ -1,0 +1,12 @@
+use std::path::Path;
+
+fn main() {
+    let so_path = Path::new("deploy/program.so");
+
+    if so_path.exists() {
+        println!("cargo:rustc-cfg=has_asm_binary");
+    } else {
+        println!("cargo:warning=ASM binary not found at deploy/program.so");
+        println!("cargo:warning=Run `sbpf build` in the asm directory to generate it");
+    }
+}

--- a/basics/hello-solana/asm/src/lib.rs
+++ b/basics/hello-solana/asm/src/lib.rs
@@ -1,4 +1,4 @@
-#[cfg(test)]
+#[cfg(all(test, has_asm_binary))]
 mod tests {
     use litesvm::LiteSVM;
     use solana_instruction::{AccountMeta, Instruction};

--- a/basics/transfer-sol/asm/Cargo.toml
+++ b/basics/transfer-sol/asm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "asm"
 version = "0.1.0"
 edition = "2021"
+build = "build.rs"
 
 [dependencies]
 

--- a/basics/transfer-sol/asm/build.rs
+++ b/basics/transfer-sol/asm/build.rs
@@ -1,0 +1,12 @@
+use std::path::Path;
+
+fn main() {
+    let so_path = Path::new("deploy/transfer-sol-cpi.so");
+
+    if so_path.exists() {
+        println!("cargo:rustc-cfg=has_asm_binary");
+    } else {
+        println!("cargo:warning=ASM binary not found at deploy/transfer-sol-cpi.so");
+        println!("cargo:warning=Run `sbpf build` in the asm directory to generate it");
+    }
+}

--- a/basics/transfer-sol/asm/build.rs
+++ b/basics/transfer-sol/asm/build.rs
@@ -1,12 +1,22 @@
+// The tests embed the assembled program with include_bytes!, which needs the
+// file to exist at compile time. `sbpf build` produces it, and it is gitignored,
+// so a fresh checkout has no binary and the test module cannot compile. Set a
+// cfg when the binary is present and let the tests key off it: present, they
+// compile and run; absent, they are left out and the crate still builds.
 use std::path::Path;
 
-fn main() {
-    let so_path = Path::new("deploy/transfer-sol-cpi.so");
+const BINARY: &str = "deploy/transfer-sol-cpi.so";
 
-    if so_path.exists() {
-        println!("cargo:rustc-cfg=has_asm_binary");
+fn main() {
+    // Declare the cfg so `-D warnings` builds do not fail on unexpected_cfgs.
+    println!("cargo::rustc-check-cfg=cfg(has_asm_binary)");
+    // Re-run when the binary appears or changes, so the cfg never goes stale.
+    println!("cargo::rerun-if-changed={BINARY}");
+
+    if Path::new(BINARY).exists() {
+        println!("cargo::rustc-cfg=has_asm_binary");
     } else {
-        println!("cargo:warning=ASM binary not found at deploy/transfer-sol-cpi.so");
-        println!("cargo:warning=Run `sbpf build` in the asm directory to generate it");
+        println!("cargo::warning=ASM binary not found at {BINARY}: tests skipped");
+        println!("cargo::warning=Run `sbpf build` in this directory to generate it");
     }
 }

--- a/basics/transfer-sol/asm/src/lib.rs
+++ b/basics/transfer-sol/asm/src/lib.rs
@@ -1,4 +1,4 @@
-#[cfg(test)]
+#[cfg(all(test, has_asm_binary))]
 mod tests {
     use litesvm::LiteSVM;
     use solana_instruction::{AccountMeta, Instruction};


### PR DESCRIPTION
## Problem

Four ASM examples (transfer-sol, create-account, checking-accounts, hello-solana) failed to compile whenever the SBPF `.so` artifacts were absent:

```
error: couldn't read `basics/transfer-sol/asm/deploy/transfer-sol-cpi.so`: No such file or directory
```

The tests embed the assembled program with `include_bytes!`, which resolves at compile time. Those binaries are gitignored build artifacts produced by `sbpf build`, so a fresh clone has none and the crate cannot build at all — the failure is a compile error, not a skipped test.

## Solution

A `build.rs` per ASM crate checks for that crate's binary and sets a `has_asm_binary` cfg when it is present. Each test module is gated on `#[cfg(all(test, has_asm_binary))]`:

- **Binary present** (after `sbpf build`): the tests compile and run exactly as before.
- **Binary absent**: the test module is left out, the crate builds, and two `cargo::warning` lines point at `sbpf build`.

Each script also emits `cargo::rerun-if-changed` for its binary, so the cfg is re-evaluated as soon as the file appears rather than going stale.

## Changes

- `build.rs` added to 4 ASM crates, each naming the binary its own crate embeds
- `build = "build.rs"` added to the 4 `Cargo.toml` files
- test modules gated `#[cfg(test)]` → `#[cfg(all(test, has_asm_binary))]`

## Notes for reviewers

Two things surfaced while getting CI green, both worth knowing since they are easy to reproduce:

**`-D warnings` promotes `unexpected_cfgs` to an error.** Introducing a custom cfg is not enough; it has to be declared, or `cargo clippy -- -D warnings` fails on every crate that uses it. Each script emits `cargo::rustc-check-cfg=cfg(has_asm_binary)`.

**The binary names differ per crate.** The four crates embed `transfer-sol-cpi.so`, `create-account-asm-program.so`, `checking-account-asm-program.so` and `hello-solana-asm-program.so` respectively. An earlier revision of this branch probed `deploy/program.so` in three of them, which would have left the cfg unset after a real `sbpf build` and silently switched those tests off — quieter than the bug being fixed, and worse. Each script now names the file its own crate embeds.

## Testing

Both directions verified locally, not just the one CI exercises:

```bash
# CI's exact invocation
cargo clippy -- -D warnings -A clippy::diverging_sub_expression   # clean

# binary absent: crate builds, tests excluded
cargo test --lib --no-run                                          # clean

# binary present: tests come back
cargo test --lib -- --list                                         # tests::test_transfer_sol: test
```