### PR TITLE
finance: reject oracle prices from before a cluster restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this repository are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2026-08-04] - Oracle readers reject prices from before a cluster restart
+
+### Added
+
+- The three oracle-priced finance examples (`finance/lending`, `finance/prop-amm`, `finance/perpetual-futures`, Anchor and Quasar variants) now reject an oracle price stamped at or before the `LastRestartSlot` sysvar's slot, with a dedicated error (`PricePredatesRestart` / `PRICE_PREDATES_RESTART`) and a test per variant. A cluster halt stops the slot count but not the wall clock, so after a restart a feed can pass a slot-measured staleness bound while its price is hours old; the market pauses valuation until the publisher posts again. quasar-lang ships no LastRestartSlot sysvar, so each Quasar variant declares the 8-byte layout in `src/last_restart.rs` and reads it via `sol_get_sysvar`.
+
+### Fixed
+
+- The three Quasar variants pin `zeropod = "=0.3.3"`: zeropod 0.3.4 moved to wincode 0.5 while quasar-lang's pinned rev stays on wincode 0.4, so any fresh resolve (these projects commit no lockfile) split the graph across two wincode versions and failed every `Pod*` trait bound.
+
 ## [2026-07-23] - Metadata examples on Quasar 0.1.0 (vendored quasar-metadata)
 
 ### Added

--- a/finance/lending/anchor/CHANGELOG.md
+++ b/finance/lending/anchor/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-08-04
+
+Reject oracle prices from before a cluster restart. A halt stops the slot
+count but not the wall clock, so after a restart a feed can look fresh in
+slots while its price is hours old. `price_scaled` now also requires the
+feed's slot to be after the `LastRestartSlot` sysvar's slot
+(`PricePredatesRestart`), pausing valuation until the publisher posts again.
+Tested by `borrow_with_price_from_before_a_restart_is_rejected`.
+
 ## 0.1.0
 
 Initial lending program: a Kamino/Solend-style borrow/lend market.

--- a/finance/lending/anchor/README.md
+++ b/finance/lending/anchor/README.md
@@ -108,7 +108,10 @@ round-trips.
 `PriceFeed` mirrors a Switchboard On-Demand pull feed: a signed mantissa, an
 exponent (`price = mantissa * 10^exponent`), and the slot the price was written.
 Freshness is checked in **slots** (`MAX_PRICE_STALENESS_SLOTS`), not wall-clock
-time. The feed PDA is seeded by `[b"price_feed", market, mint]` (scoped to a
+time, plus one check slots alone cannot make: a cluster restart passes hours of
+wall-clock time in zero slots, so `price_scaled` also rejects any price stamped
+at or before the `LastRestartSlot` sysvar's slot, pausing valuation until the
+publisher posts again. The feed PDA is seeded by `[b"price_feed", market, mint]` (scoped to a
 market, not to any individual) and only that market's `owner` may write it
 (`set_price` checks `has_one = owner`). So prices can't be squatted, a reserve
 trusts exactly its own market's feed for the mint, and isolated markets can

--- a/finance/lending/anchor/programs/lending/Cargo.toml
+++ b/finance/lending/anchor/programs/lending/Cargo.toml
@@ -23,6 +23,10 @@ custom-panic = []
 # init-if-needed: the obligation share vault and the test price feed are created lazily.
 anchor-lang = { version = "1.1.2", features = ["init-if-needed"] }
 anchor-spl = "1.1.2"
+# For the LastRestartSlot sysvar (not re-exported by anchor-lang): the price
+# feed rejects prices from before a cluster restart. Same major as the
+# solana-sysvar anchor-lang itself uses, so only one copy is compiled in.
+solana-sysvar = "3"
 
 [dev-dependencies]
 litesvm = "0.13.1"

--- a/finance/lending/anchor/programs/lending/src/errors.rs
+++ b/finance/lending/anchor/programs/lending/src/errors.rs
@@ -18,7 +18,7 @@ pub enum LendingError {
     ObligationStale,
     #[msg("Price feed has not been updated recently enough")]
     StalePriceFeed,
-    #[msg("Price feed was last updated before the most recent cluster restart")]
+    #[msg("Price feed is stale: it predates the last cluster restart")]
     PricePredatesRestart,
     #[msg("Price feed reported a non-positive price")]
     InvalidOraclePrice,

--- a/finance/lending/anchor/programs/lending/src/errors.rs
+++ b/finance/lending/anchor/programs/lending/src/errors.rs
@@ -18,6 +18,8 @@ pub enum LendingError {
     ObligationStale,
     #[msg("Price feed has not been updated recently enough")]
     StalePriceFeed,
+    #[msg("Price feed was last updated before the most recent cluster restart")]
+    PricePredatesRestart,
     #[msg("Price feed reported a non-positive price")]
     InvalidOraclePrice,
     #[msg("Borrow would exceed the obligation's allowed borrow value")]

--- a/finance/lending/anchor/programs/lending/src/state/price_feed.rs
+++ b/finance/lending/anchor/programs/lending/src/state/price_feed.rs
@@ -1,4 +1,5 @@
 use anchor_lang::prelude::*;
+use solana_sysvar::last_restart_slot::LastRestartSlot;
 
 use crate::constants::MAX_PRICE_STALENESS_SLOTS;
 use crate::errors::LendingError;
@@ -44,6 +45,19 @@ impl PriceFeed {
             .checked_sub(self.last_updated_slot)
             .ok_or(LendingError::MathOverflow)?;
         require!(age <= MAX_PRICE_STALENESS_SLOTS, LendingError::StalePriceFeed);
+
+        // Restart handling. A cluster halt stops the slot count but not the
+        // wall clock, so after a restart a feed can look fresh in slots while
+        // its price is hours old. Reject any price stamped at or before the
+        // restart slot; the market then pauses valuation until the publisher
+        // posts again, rather than lending against a pre-halt price. Zero
+        // means the cluster has never restarted.
+        let last_restart_slot = LastRestartSlot::get()?.last_restart_slot;
+        require!(
+            last_restart_slot == 0 || self.last_updated_slot > last_restart_slot,
+            LendingError::PricePredatesRestart
+        );
+
         require!(self.price_mantissa > 0, LendingError::InvalidOraclePrice);
 
         price_mantissa_to_scaled(self.price_mantissa as u128, self.exponent)

--- a/finance/lending/anchor/programs/lending/tests/common/mod.rs
+++ b/finance/lending/anchor/programs/lending/tests/common/mod.rs
@@ -200,6 +200,14 @@ impl Env {
         self.svm.expire_blockhash();
     }
 
+    /// Simulate a cluster restart at `slot`: prices stamped at or before it
+    /// must be rejected until the publisher posts again.
+    pub fn set_last_restart_slot(&mut self, slot: u64) {
+        self.svm.set_sysvar(&solana_sysvar::last_restart_slot::LastRestartSlot {
+            last_restart_slot: slot,
+        });
+    }
+
     /// The feed PDA the market owner writes for `mint`: seeded by the owner's
     /// key, so it is the feed `add_reserve` registers reserves against.
     /// The feed PDA for a given market and mint (seeds `["price_feed", market, mint]`).

--- a/finance/lending/anchor/programs/lending/tests/test_borrow_repay.rs
+++ b/finance/lending/anchor/programs/lending/tests/test_borrow_repay.rs
@@ -89,10 +89,14 @@ fn borrow_with_price_from_before_a_restart_is_rejected() {
         "a pre-restart price must be rejected even inside the staleness window"
     );
 
-    // Publishing after the restart reopens the market.
+    // Publishing after the restart reopens the market. Warp first: the retry is
+    // otherwise byte-identical to the rejected borrow, so it would carry the
+    // same signature and be dropped as already processed. The failed borrow
+    // recorded nothing, so the obligation still has no borrows to refresh.
+    env.warp_slots(1);
     env.set_price(collateral.mint, dollars(1));
     env.set_price(borrow.mint, dollars(1));
-    env.try_borrow(&borrower, obligation, &[&collateral], &[&borrow], &borrow, 100_000_000)
+    env.try_borrow(&borrower, obligation, &[&collateral], &[], &borrow, 100_000_000)
         .expect("a freshly published price must be accepted after a restart");
 }
 

--- a/finance/lending/anchor/programs/lending/tests/test_borrow_repay.rs
+++ b/finance/lending/anchor/programs/lending/tests/test_borrow_repay.rs
@@ -69,6 +69,33 @@ fn borrow_with_stale_price_feed_is_rejected() {
     assert!(result.unwrap_err().contains("StalePriceFeed"));
 }
 
+/// A cluster restart passes hours of wall-clock time in zero slots, so a price
+/// published before the halt can still look fresh by slot count. The feed must
+/// reject it until the publisher posts again.
+#[test]
+fn borrow_with_price_from_before_a_restart_is_rejected() {
+    let (mut env, collateral, borrow, borrower, obligation) = setup();
+
+    // The prices were published at the current slot. Simulate a halt: the
+    // cluster restarts a few slots later, well inside the staleness window,
+    // so only the restart check can catch the pre-halt price.
+    let restart_slot = env.current_slot() + 3;
+    env.warp_slots(5);
+    env.set_last_restart_slot(restart_slot);
+
+    let result = env.try_borrow(&borrower, obligation, &[&collateral], &[], &borrow, 100_000_000);
+    assert!(
+        result.unwrap_err().contains("PricePredatesRestart"),
+        "a pre-restart price must be rejected even inside the staleness window"
+    );
+
+    // Publishing after the restart reopens the market.
+    env.set_price(collateral.mint, dollars(1));
+    env.set_price(borrow.mint, dollars(1));
+    env.try_borrow(&borrower, obligation, &[&collateral], &[&borrow], &borrow, 100_000_000)
+        .expect("a freshly published price must be accepted after a restart");
+}
+
 #[test]
 fn repay_reduces_debt_and_over_repay_clamps() {
     let (mut env, collateral, borrow, borrower, obligation) = setup();

--- a/finance/lending/quasar/CHANGELOG.md
+++ b/finance/lending/quasar/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [2026-08-04]
+
+### Changed
+
+- Reject oracle prices from before a cluster restart: `price_scaled` requires
+  the feed's slot to be after the `LastRestartSlot` sysvar's slot
+  (`PricePredatesRestart`). quasar-lang has no LastRestartSlot sysvar, so
+  `src/last_restart.rs` declares the layout and reads it via
+  `sol_get_sysvar`. Tested by
+  `borrow_with_price_from_before_a_restart_is_rejected`.
+- Pinned `zeropod = "=0.3.3"`: zeropod 0.3.4 moved to wincode 0.5 while
+  quasar-lang's pinned rev stays on wincode 0.4, so a fresh resolve failed
+  every Pod* trait bound.
+
 ## [2026-07-22]
 
 ### Changed

--- a/finance/lending/quasar/Cargo.toml
+++ b/finance/lending/quasar/Cargo.toml
@@ -32,6 +32,17 @@ idl-build = ["quasar-lang/idl-build"]
 quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "be60fca" }
 quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "be60fca" }
 solana-instruction = { version = "3.2.0" }
+# The LastRestartSlot sysvar declaration (src/last_restart.rs) names these
+# three crates directly. Versions match quasar-lang's own constraints so each
+# is compiled once.
+solana-address = { version = ">=2.2, <2.6" }
+solana-program-error = "3.0.0"
+solana-define-syscall = "5.0.0"
+# Pinned: quasar-lang asks for zeropod "0.3.3" and wincode 0.4, but zeropod
+# 0.3.4 moved to wincode 0.5, so a fresh resolve (no lockfile is committed)
+# splits the graph across two wincode versions and every Pod* trait bound
+# fails. Unpin when quasar-lang's pinned rev accepts zeropod 0.3.4+.
+zeropod = "=0.3.3"
 
 [dev-dependencies]
 quasar-test = { git = "https://github.com/blueshift-gg/quasar", rev = "be60fca" }

--- a/finance/lending/quasar/README.md
+++ b/finance/lending/quasar/README.md
@@ -24,6 +24,13 @@ fixed-size accounts, so this port follows that idiom:
   touches at the top of the instruction. Health is then computed inline from the
   freshly accrued reserves and the oracle prices passed in.
 
+- **A hand-declared `LastRestartSlot` sysvar.** quasar-lang ships only the
+  Clock and Rent sysvars, so `src/last_restart.rs` declares the 8-byte layout
+  itself and reads it with the same `sol_get_sysvar` syscall. `price_scaled`
+  uses it to reject prices published before a cluster restart, which slot-based
+  staleness alone cannot catch (a halt passes hours of wall-clock time in zero
+  slots).
+
 Everything else mirrors the Anchor version.
 
 ## Major concepts

--- a/finance/lending/quasar/src/error.rs
+++ b/finance/lending/quasar/src/error.rs
@@ -17,4 +17,5 @@ pub enum LendingError {
     WrongReserve,
     LiquidationTooLarge,
     NothingToCollect,
+    PricePredatesRestart,
 }

--- a/finance/lending/quasar/src/last_restart.rs
+++ b/finance/lending/quasar/src/last_restart.rs
@@ -1,0 +1,77 @@
+//! The LastRestartSlot sysvar: the slot of the most recent cluster restart,
+//! or 0 if the cluster has never restarted (SIMD-0047). quasar-lang ships
+//! only the Clock and Rent sysvars, so this program declares the 8-byte
+//! layout itself and reads it through the same `sol_get_sysvar` syscall
+//! quasar's own sysvars use.
+//!
+//! Why the program reads it: a halt stops the slot count but not the wall
+//! clock, so after a restart an oracle price can look fresh in slots while
+//! its value is hours old. `logic::price_scaled` rejects any price stamped
+//! at or before the restart slot, pausing valuation until the publisher
+//! posts again.
+
+use quasar_lang::{pod::PodU64, prelude::Address, sysvars::Sysvar};
+use solana_program_error::ProgramError;
+
+/// `SysvarLastRestartS1ot1111111111111111111111`, decoded at compile time.
+const LAST_RESTART_SLOT_ID: Address =
+    quasar_lang::prelude::address!("SysvarLastRestartS1ot1111111111111111111111");
+
+/// The sysvar's whole data: one little-endian u64.
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct LastRestartSlot {
+    pub last_restart_slot: PodU64,
+}
+
+const _: () = assert!(core::mem::size_of::<LastRestartSlot>() == 8);
+const _: () = assert!(core::mem::align_of::<LastRestartSlot>() == 1);
+
+// Written out by hand rather than with quasar-lang's `impl_sysvar_get!`: the
+// macro's expansion names private quasar-lang constants, so it only works
+// inside that crate. The sysvar is 8 bytes with no padding, so the syscall
+// fills the whole struct.
+impl Sysvar for LastRestartSlot {
+    const ID: Address = LAST_RESTART_SLOT_ID;
+
+    #[inline(always)]
+    unsafe fn from_bytes_unchecked(bytes: &[u8]) -> &Self {
+        // SAFETY: the caller guarantees `bytes` holds at least 8 bytes of
+        // valid sysvar data; the struct is `#[repr(C)]` with alignment 1,
+        // so the pointer cast is always valid.
+        unsafe { &*(bytes.as_ptr() as *const Self) }
+    }
+
+    fn get() -> Result<Self, ProgramError> {
+        let mut var = core::mem::MaybeUninit::<Self>::uninit();
+        let var_addr = var.as_mut_ptr() as *mut u8;
+
+        #[cfg(any(target_os = "solana", target_arch = "bpf"))]
+        // SAFETY: `var_addr` points at 8 writable bytes and the syscall
+        // writes exactly 8.
+        let result = unsafe {
+            solana_define_syscall::definitions::sol_get_sysvar(
+                &LAST_RESTART_SLOT_ID as *const _ as *const u8,
+                var_addr,
+                0,
+                core::mem::size_of::<Self>() as u64,
+            )
+        };
+
+        // Off-chain (IDL builds, client compilation) the sysvar reads as
+        // zero: the cluster has never restarted.
+        #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
+        let result: u64 = {
+            // SAFETY: `var_addr` points at 8 writable bytes.
+            unsafe { var_addr.write_bytes(0, core::mem::size_of::<Self>()) };
+            0
+        };
+
+        match result {
+            // SAFETY: on success the syscall (or the zeroing above) has
+            // initialized all 8 bytes.
+            0 => Ok(unsafe { var.assume_init() }),
+            _ => Err(ProgramError::UnsupportedSysvar),
+        }
+    }
+}

--- a/finance/lending/quasar/src/lib.rs
+++ b/finance/lending/quasar/src/lib.rs
@@ -18,6 +18,7 @@ use quasar_lang::prelude::*;
 mod constants;
 mod error;
 mod instructions;
+mod last_restart;
 mod logic;
 mod math;
 mod state;

--- a/finance/lending/quasar/src/logic.rs
+++ b/finance/lending/quasar/src/logic.rs
@@ -8,6 +8,7 @@ use quasar_lang::{prelude::*, sysvars::Sysvar};
 use crate::{
     constants::{FIXED_POINT_SCALE, MAX_PRICE_STALENESS_SLOTS},
     error::LendingError,
+    last_restart::LastRestartSlot,
     math::{accrue_index, current_debt, mul_div_floor, price_mantissa_to_scaled},
     state::{Obligation, ObligationInner, PriceFeed, Reserve, ReserveInner},
 };
@@ -105,6 +106,19 @@ pub fn price_scaled(feed: &Account<PriceFeed>, slot: u64) -> Result<u128, Progra
         .checked_sub(last_updated)
         .ok_or(LendingError::MathOverflow)?;
     require!(age <= MAX_PRICE_STALENESS_SLOTS, LendingError::StalePrice);
+
+    // Restart handling. A cluster halt stops the slot count but not the wall
+    // clock, so after a restart a feed can look fresh in slots while its
+    // price is hours old. Reject any price stamped at or before the restart
+    // slot; the market then pauses valuation until the publisher posts again,
+    // rather than lending against a pre-halt price. Zero means the cluster
+    // has never restarted.
+    let last_restart = u64::from(LastRestartSlot::get()?.last_restart_slot);
+    require!(
+        last_restart == 0 || last_updated > last_restart,
+        LendingError::PricePredatesRestart
+    );
+
     let mantissa = i128::from(feed.price_mantissa);
     require!(mantissa > 0, LendingError::InvalidOraclePrice);
     price_mantissa_to_scaled(mantissa as u128, i32::from(feed.exponent))

--- a/finance/lending/quasar/src/tests.rs
+++ b/finance/lending/quasar/src/tests.rs
@@ -754,6 +754,31 @@ mod slot_warp {
         );
     }
 
+    /// A cluster restart passes hours of wall-clock time in zero slots, so a
+    /// price published before the halt can still look fresh by slot count.
+    /// `price_scaled` must reject it until the publisher posts again.
+    #[test]
+    fn borrow_with_price_from_before_a_restart_is_rejected() {
+        let mut world = World::new();
+        world.bootstrap_position();
+
+        // Prices were published at the current slot. Simulate a halt: the
+        // cluster restarts a few slots later, well inside the staleness
+        // window, so only the restart check can catch the pre-halt price.
+        let restart_slot = world.svm.sysvars.clock.slot + 3;
+        world.svm.sysvars.warp_to_slot(restart_slot + 2);
+        world.svm.sysvars.last_restart_slot.last_restart_slot = restart_slot;
+
+        world.borrow(100 * UNIT).assert_error(quasar_svm::ProgramError::Custom(
+            crate::error::LendingError::PricePredatesRestart as u32,
+        ));
+
+        // Publishing after the restart reopens the market.
+        world.set_price(COLLATERAL_MINT, world.collateral_price, dollars(1));
+        world.set_price(BORROW_MINT, world.borrow_price, dollars(1));
+        world.borrow(100 * UNIT).assert_success();
+    }
+
     #[test]
     fn protocol_fees_accrue_and_owner_can_collect() {
         let mut world = World::new();

--- a/finance/perpetual-futures/anchor/CHANGELOG.md
+++ b/finance/perpetual-futures/anchor/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-08-04
+
+Reject oracle prices from before a cluster restart. A halt stops the slot
+count but not the wall clock, so after a restart a feed can look fresh in
+slots while its price is hours old; with leverage that error is amplified
+market-wide. `read_oracle_price` now also requires the feed's slot to be
+after the `LastRestartSlot` sysvar's slot (`PricePredatesRestart`). Tested
+by `test_open_rejects_price_from_before_a_restart`.
+
 ## 2026-07-07
 
 Added this changelog. Changes prior to this date were tracked in git history only.

--- a/finance/perpetual-futures/anchor/README.md
+++ b/finance/perpetual-futures/anchor/README.md
@@ -48,7 +48,7 @@ A position's *equity* is its net collateral plus profit/loss minus funding. Once
 
 ### Oracle
 
-The mark price comes from an oracle feed. This example validates the price for staleness (by slot), positivity, scale, and a [confidence band](https://docs.pyth.network/price-feeds/best-practices#confidence-intervals) that must stay within `max_confidence_bps` of the price: rejecting an uncertain price is one of the most common oracle-safety checks.
+The mark price comes from an oracle feed. This example validates the price for staleness (by slot), publication after the most recent cluster restart (the `LastRestartSlot` sysvar, because a halt passes hours of wall-clock time in zero slots), positivity, scale, and a [confidence band](https://docs.pyth.network/price-feeds/best-practices#confidence-intervals) that must stay within `max_confidence_bps` of the price: rejecting an uncertain price is one of the most common oracle-safety checks.
 
 ### Fees and slippage
 
@@ -205,7 +205,7 @@ This is a teaching example, not an audited exchange. Notably:
 
 ## Testing
 
-The tests run in-process with [LiteSVM](https://www.anchor-lang.com/docs/testing/litesvm) and [solana-kite](https://solanakite.org); no local validator is needed. They deploy both programs, drive the mock oracle, and cover liquidity round-trips, opening and closing longs and shorts in profit and loss, leverage and slippage rejection, stale-price and wide-confidence rejection, funding accrual, liquidation (and the refusal to liquidate a healthy position), reserved-liquidity behaviour (profit capped at the reserve, opens rejected when the pool can't back them, withdrawals blocked by reserved liquidity), and fee collection.
+The tests run in-process with [LiteSVM](https://www.anchor-lang.com/docs/testing/litesvm) and [solana-kite](https://solanakite.org); no local validator is needed. They deploy both programs, drive the mock oracle, and cover liquidity round-trips, opening and closing longs and shorts in profit and loss, leverage and slippage rejection, stale-price, pre-restart-price, and wide-confidence rejection, funding accrual, liquidation (and the refusal to liquidate a healthy position), reserved-liquidity behaviour (profit capped at the reserve, opens rejected when the pool can't back them, withdrawals blocked by reserved liquidity), and fee collection.
 
 ```bash
 anchor build

--- a/finance/perpetual-futures/anchor/programs/perpetual-futures/Cargo.toml
+++ b/finance/perpetual-futures/anchor/programs/perpetual-futures/Cargo.toml
@@ -31,6 +31,10 @@ anchor-spl = "1.1.2"
 # spl-token's) and fails.
 spl-token = { version = "9.0.0", features = ["no-entrypoint"] }
 spl-associated-token-account = { version = "8.0.0", features = ["no-entrypoint"] }
+# For the LastRestartSlot sysvar (not re-exported by anchor-lang): the oracle
+# reader rejects prices from before a cluster restart. Same major as the
+# solana-sysvar anchor-lang itself uses, so only one copy is compiled in.
+solana-sysvar = "3"
 
 [dev-dependencies]
 litesvm = "0.13.1"

--- a/finance/perpetual-futures/anchor/programs/perpetual-futures/src/errors.rs
+++ b/finance/perpetual-futures/anchor/programs/perpetual-futures/src/errors.rs
@@ -55,4 +55,7 @@ pub enum PerpError {
 
     #[msg("No protocol fees are available to collect")]
     NothingToClaim,
+
+    #[msg("Oracle price was last updated before the most recent cluster restart")]
+    PricePredatesRestart,
 }

--- a/finance/perpetual-futures/anchor/programs/perpetual-futures/src/errors.rs
+++ b/finance/perpetual-futures/anchor/programs/perpetual-futures/src/errors.rs
@@ -56,6 +56,6 @@ pub enum PerpError {
     #[msg("No protocol fees are available to collect")]
     NothingToClaim,
 
-    #[msg("Oracle price was last updated before the most recent cluster restart")]
+    #[msg("Oracle price is stale: it predates the last cluster restart")]
     PricePredatesRestart,
 }

--- a/finance/perpetual-futures/anchor/programs/perpetual-futures/src/state/oracle.rs
+++ b/finance/perpetual-futures/anchor/programs/perpetual-futures/src/state/oracle.rs
@@ -1,4 +1,5 @@
 use anchor_lang::prelude::*;
+use solana_sysvar::last_restart_slot::LastRestartSlot;
 
 use crate::constants::{BASIS_POINTS_DENOMINATOR, MAX_PRICE_STALENESS_SLOTS};
 use crate::errors::PerpError;
@@ -79,6 +80,18 @@ pub fn read_oracle_price(
     require!(
         current_slot.saturating_sub(last_update_slot) <= MAX_PRICE_STALENESS_SLOTS,
         PerpError::StalePrice
+    );
+
+    // Restart handling. A cluster halt stops the slot count but not the wall
+    // clock, so after a restart a feed can look fresh in slots while its
+    // price is hours old. With leverage a stale price is amplified into a
+    // market-wide equity error, so reject any price stamped at or before the
+    // restart slot; the pool pauses valuation until the publisher posts
+    // again. Zero means the cluster has never restarted.
+    let last_restart_slot = LastRestartSlot::get()?.last_restart_slot;
+    require!(
+        last_restart_slot == 0 || last_update_slot > last_restart_slot,
+        PerpError::PricePredatesRestart
     );
 
     // Reject an untrustworthy price: confidence band as a fraction of price,

--- a/finance/perpetual-futures/anchor/programs/perpetual-futures/tests/test_perpetual_futures.rs
+++ b/finance/perpetual-futures/anchor/programs/perpetual-futures/tests/test_perpetual_futures.rs
@@ -812,7 +812,10 @@ fn test_open_rejects_price_from_before_a_restart() {
         )
         .is_err());
 
-    // Publishing after the restart reopens the pool.
+    // Publishing after the restart reopens the pool. Warp first: the retry is
+    // otherwise byte-identical to the rejected open, so it would carry the same
+    // signature and be dropped as already processed.
+    market.warp(published_at + 6);
     market.set_price(dollars(100));
     market
         .open_position(

--- a/finance/perpetual-futures/anchor/programs/perpetual-futures/tests/test_perpetual_futures.rs
+++ b/finance/perpetual-futures/anchor/programs/perpetual-futures/tests/test_perpetual_futures.rs
@@ -219,6 +219,18 @@ impl Market {
         self.svm.expire_blockhash();
     }
 
+    fn current_slot(&self) -> u64 {
+        self.svm.get_sysvar::<anchor_lang::prelude::Clock>().slot
+    }
+
+    /// Simulate a cluster restart at `slot`: prices stamped at or before it
+    /// must be rejected until the publisher posts again.
+    fn set_last_restart_slot(&mut self, slot: u64) {
+        self.svm.set_sysvar(&solana_sysvar::last_restart_slot::LastRestartSlot {
+            last_restart_slot: slot,
+        });
+    }
+
     /// Create a wallet holding `amount` collateral tokens in its associated
     /// token account.
     fn funded_trader(&mut self, amount: u64) -> (Keypair, Pubkey) {
@@ -768,6 +780,50 @@ fn test_stale_price_rejected() {
             0
         )
         .is_err());
+}
+
+/// A cluster restart passes hours of wall-clock time in zero slots, so a
+/// price published before the halt can still look fresh by slot count. With
+/// leverage a stale price is amplified into a market-wide equity error, so
+/// the pool must refuse it until the publisher posts again.
+#[test]
+fn test_open_rejects_price_from_before_a_restart() {
+    let mut market = Market::default_market();
+    market.seed_liquidity(100_000 * ONE_USDC);
+    let collateral = 1_000 * ONE_USDC;
+    let (trader, trader_collateral) = market.funded_trader(collateral);
+
+    // Simulate a halt: the cluster restarts a few slots after the price was
+    // published, well inside the staleness window, so only the restart check
+    // can catch the pre-halt price.
+    market.set_price(dollars(100));
+    let published_at = market.current_slot();
+    market.warp(published_at + 5);
+    market.set_last_restart_slot(published_at + 3);
+
+    assert!(market
+        .open_position(
+            &trader,
+            trader_collateral,
+            Side::Long,
+            collateral,
+            5_000 * ONE_USDC,
+            u64::MAX
+        )
+        .is_err());
+
+    // Publishing after the restart reopens the pool.
+    market.set_price(dollars(100));
+    market
+        .open_position(
+            &trader,
+            trader_collateral,
+            Side::Long,
+            collateral,
+            5_000 * ONE_USDC,
+            u64::MAX
+        )
+        .expect("a freshly published price must be accepted after a restart");
 }
 
 #[test]

--- a/finance/perpetual-futures/quasar/CHANGELOG.md
+++ b/finance/perpetual-futures/quasar/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-08-04
+
+Reject oracle prices from before a cluster restart: `read_oracle_price`
+requires the feed's slot to be after the `LastRestartSlot` sysvar's slot
+(`PRICE_PREDATES_RESTART`). quasar-lang has no LastRestartSlot sysvar, so
+`src/last_restart.rs` declares the layout and reads it via
+`sol_get_sysvar`. Also pinned `zeropod = "=0.3.3"` (zeropod 0.3.4 moved to
+wincode 0.5 while quasar-lang's pinned rev stays on wincode 0.4, so a fresh
+resolve failed every Pod* trait bound). Tested by
+`open_rejects_price_from_before_a_restart`.
+
 ## [2026-07-22]
 
 ### Changed

--- a/finance/perpetual-futures/quasar/Cargo.toml
+++ b/finance/perpetual-futures/quasar/Cargo.toml
@@ -32,6 +32,17 @@ idl-build = ["quasar-lang/idl-build"]
 quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "be60fca" }
 quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "be60fca" }
 solana-instruction = { version = "3.2.0" }
+# The LastRestartSlot sysvar declaration (src/last_restart.rs) names these
+# three crates directly. Versions match quasar-lang's own constraints so each
+# is compiled once.
+solana-address = { version = ">=2.2, <2.6" }
+solana-program-error = "3.0.0"
+solana-define-syscall = "5.0.0"
+# Pinned: quasar-lang asks for zeropod "0.3.3" and wincode 0.4, but zeropod
+# 0.3.4 moved to wincode 0.5, so a fresh resolve (no lockfile is committed)
+# splits the graph across two wincode versions and every Pod* trait bound
+# fails. Unpin when quasar-lang's pinned rev accepts zeropod 0.3.4+.
+zeropod = "=0.3.3"
 
 [dev-dependencies]
 quasar-test = { git = "https://github.com/blueshift-gg/quasar", rev = "be60fca" }

--- a/finance/perpetual-futures/quasar/README.md
+++ b/finance/perpetual-futures/quasar/README.md
@@ -14,6 +14,12 @@ math. This page only covers what differs in the Quasar version.
   inputs, not instruction arguments, so the side cannot be a seed; the position
   PDA is `[b"position", pool, owner]` and the side is stored in the account. A
   trader therefore holds a single open position per pool here.
+- **A hand-declared `LastRestartSlot` sysvar.** quasar-lang ships only the
+  Clock and Rent sysvars, so `src/last_restart.rs` declares the 8-byte layout
+  itself and reads it with the same `sol_get_sysvar` syscall.
+  `read_oracle_price` uses it to reject prices published before a cluster
+  restart, which slot-based staleness alone cannot catch (a halt passes hours
+  of wall-clock time in zero slots).
 - **Oracle feed in tests.** Rather than a separate mock-oracle program, the
   tests write the feed account's bytes directly (price, scale, last-update slot)
   and the program reads them the same way it would read a real Switchboard feed.

--- a/finance/perpetual-futures/quasar/src/instructions/shared.rs
+++ b/finance/perpetual-futures/quasar/src/instructions/shared.rs
@@ -2,7 +2,9 @@
 //! All integer, all `checked_*`, multiply-before-divide, rounding toward the
 //! protocol. Errors are `ProgramError::Custom(code)`; the codes are listed here.
 
-use quasar_lang::prelude::*;
+use quasar_lang::{prelude::*, sysvars::Sysvar};
+
+use crate::last_restart::LastRestartSlot;
 
 use crate::constants::{
     BASIS_POINTS_DENOMINATOR, FUNDING_PRECISION, MAX_PRICE_STALENESS_SLOTS, SIDE_LONG,
@@ -28,6 +30,7 @@ pub mod error {
     pub const AMOUNT_ROUNDS_TO_ZERO: u32 = 15;
     pub const ORACLE_CONFIDENCE_TOO_WIDE: u32 = 16;
     pub const INSUFFICIENT_COLLATERAL: u32 = 17;
+    pub const PRICE_PREDATES_RESTART: u32 = 18;
 }
 
 #[inline(always)]
@@ -99,6 +102,17 @@ pub fn read_oracle_price(
     }
     if current_slot.saturating_sub(last_update_slot) > MAX_PRICE_STALENESS_SLOTS {
         return Err(err(error::STALE_PRICE));
+    }
+
+    // Restart handling. A cluster halt stops the slot count but not the wall
+    // clock, so after a restart a feed can look fresh in slots while its
+    // price is hours old. With leverage a stale price is amplified into a
+    // market-wide equity error, so reject any price stamped at or before the
+    // restart slot; the pool pauses valuation until the publisher posts
+    // again. Zero means the cluster has never restarted.
+    let last_restart = u64::from(LastRestartSlot::get()?.last_restart_slot);
+    if last_restart != 0 && last_update_slot <= last_restart {
+        return Err(err(error::PRICE_PREDATES_RESTART));
     }
 
     // Confidence band as a fraction of price, in basis points, must stay within

--- a/finance/perpetual-futures/quasar/src/last_restart.rs
+++ b/finance/perpetual-futures/quasar/src/last_restart.rs
@@ -1,0 +1,77 @@
+//! The LastRestartSlot sysvar: the slot of the most recent cluster restart,
+//! or 0 if the cluster has never restarted (SIMD-0047). quasar-lang ships
+//! only the Clock and Rent sysvars, so this program declares the 8-byte
+//! layout itself and reads it through the same `sol_get_sysvar` syscall
+//! quasar's own sysvars use.
+//!
+//! Why the program reads it: a halt stops the slot count but not the wall
+//! clock, so after a restart an oracle price can look fresh in slots while
+//! its value is hours old. `shared::read_oracle_price` rejects any price
+//! stamped at or before the restart slot, so the pool pauses valuation
+//! until the publisher posts again.
+
+use quasar_lang::{pod::PodU64, prelude::Address, sysvars::Sysvar};
+use solana_program_error::ProgramError;
+
+/// `SysvarLastRestartS1ot1111111111111111111111`, decoded at compile time.
+const LAST_RESTART_SLOT_ID: Address =
+    quasar_lang::prelude::address!("SysvarLastRestartS1ot1111111111111111111111");
+
+/// The sysvar's whole data: one little-endian u64.
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct LastRestartSlot {
+    pub last_restart_slot: PodU64,
+}
+
+const _: () = assert!(core::mem::size_of::<LastRestartSlot>() == 8);
+const _: () = assert!(core::mem::align_of::<LastRestartSlot>() == 1);
+
+// Written out by hand rather than with quasar-lang's `impl_sysvar_get!`: the
+// macro's expansion names private quasar-lang constants, so it only works
+// inside that crate. The sysvar is 8 bytes with no padding, so the syscall
+// fills the whole struct.
+impl Sysvar for LastRestartSlot {
+    const ID: Address = LAST_RESTART_SLOT_ID;
+
+    #[inline(always)]
+    unsafe fn from_bytes_unchecked(bytes: &[u8]) -> &Self {
+        // SAFETY: the caller guarantees `bytes` holds at least 8 bytes of
+        // valid sysvar data; the struct is `#[repr(C)]` with alignment 1,
+        // so the pointer cast is always valid.
+        unsafe { &*(bytes.as_ptr() as *const Self) }
+    }
+
+    fn get() -> Result<Self, ProgramError> {
+        let mut var = core::mem::MaybeUninit::<Self>::uninit();
+        let var_addr = var.as_mut_ptr() as *mut u8;
+
+        #[cfg(any(target_os = "solana", target_arch = "bpf"))]
+        // SAFETY: `var_addr` points at 8 writable bytes and the syscall
+        // writes exactly 8.
+        let result = unsafe {
+            solana_define_syscall::definitions::sol_get_sysvar(
+                &LAST_RESTART_SLOT_ID as *const _ as *const u8,
+                var_addr,
+                0,
+                core::mem::size_of::<Self>() as u64,
+            )
+        };
+
+        // Off-chain (IDL builds, client compilation) the sysvar reads as
+        // zero: the cluster has never restarted.
+        #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
+        let result: u64 = {
+            // SAFETY: `var_addr` points at 8 writable bytes.
+            unsafe { var_addr.write_bytes(0, core::mem::size_of::<Self>()) };
+            0
+        };
+
+        match result {
+            // SAFETY: on success the syscall (or the zeroing above) has
+            // initialized all 8 bytes.
+            0 => Ok(unsafe { var.assume_init() }),
+            _ => Err(ProgramError::UnsupportedSysvar),
+        }
+    }
+}

--- a/finance/perpetual-futures/quasar/src/lib.rs
+++ b/finance/perpetual-futures/quasar/src/lib.rs
@@ -9,6 +9,7 @@ use quasar_lang::prelude::*;
 
 mod constants;
 mod instructions;
+mod last_restart;
 pub mod state;
 #[cfg(test)]
 mod tests;

--- a/finance/perpetual-futures/quasar/src/tests.rs
+++ b/finance/perpetual-futures/quasar/src/tests.rs
@@ -42,12 +42,53 @@ fn dollars(whole: i128) -> i128 {
 /// last_update_slot (u64), confidence (u64). The tests own this; production
 /// reads a real feed.
 fn set_feed(test: &mut Test, price: i128, confidence: u64) {
+    set_feed_at_slot(test, price, SLOT, confidence);
+}
+
+fn set_feed_at_slot(test: &mut Test, price: i128, slot: u64, confidence: u64) {
     let mut data = Vec::with_capacity(36);
     data.extend_from_slice(&price.to_le_bytes());
     data.extend_from_slice(&ORACLE_SCALE.to_le_bytes());
-    data.extend_from_slice(&SLOT.to_le_bytes());
+    data.extend_from_slice(&slot.to_le_bytes());
     data.extend_from_slice(&confidence.to_le_bytes());
     test.set_account(Account::new(FEED, system_program::ID, 1_000_000, data));
+}
+
+/// Pin the Clock sysvar account at `slot`. Clock's bincode layout is the raw
+/// little-endian fields: slot, epoch_start_timestamp, epoch,
+/// leader_schedule_epoch, unix_timestamp.
+fn set_clock_at(test: &mut Test, slot: u64) {
+    let mut data = Vec::with_capacity(40);
+    data.extend_from_slice(&slot.to_le_bytes());
+    data.extend_from_slice(&0i64.to_le_bytes());
+    data.extend_from_slice(&0u64.to_le_bytes());
+    data.extend_from_slice(&0u64.to_le_bytes());
+    data.extend_from_slice(&0i64.to_le_bytes());
+    let clock_id: Pubkey = "SysvarC1ock11111111111111111111111111111111"
+        .parse()
+        .unwrap();
+    let sysvar_owner: Pubkey = "Sysvar1111111111111111111111111111111111111"
+        .parse()
+        .unwrap();
+    test.set_account(Account::new(clock_id, sysvar_owner, 1_169_280, data));
+}
+
+/// Pin the LastRestartSlot sysvar account, simulating a cluster restart at
+/// `slot`: prices stamped at or before it must be rejected until the
+/// publisher posts again. The sysvar's whole data is one little-endian u64.
+fn set_last_restart_slot(test: &mut Test, slot: u64) {
+    let sysvar_id: Pubkey = "SysvarLastRestartS1ot1111111111111111111111"
+        .parse()
+        .unwrap();
+    let sysvar_owner: Pubkey = "Sysvar1111111111111111111111111111111111111"
+        .parse()
+        .unwrap();
+    test.set_account(Account::new(
+        sysvar_id,
+        sysvar_owner,
+        1_169_280,
+        slot.to_le_bytes().to_vec(),
+    ));
 }
 
 fn init_pool(test: &mut Test, maintenance_margin_bps: u16, close_fee_bps: u16) -> Outcome {
@@ -197,6 +238,33 @@ fn open_long_position_creates_the_position(test: &mut Test) {
 
     let position = test.derive_pda(Position::seeds(&env.pool, &TRADER));
     assert!(test.account(position).is_some());
+}
+
+/// A cluster restart passes hours of wall-clock time in zero slots, so a
+/// price published before the halt can still look fresh by slot count. With
+/// leverage a stale price is amplified into a market-wide equity error, so
+/// the pool must refuse it until the publisher posts again.
+#[quasar_test]
+fn open_rejects_price_from_before_a_restart(test: &mut Test) {
+    let env = setup(test);
+    fund(test, PROVIDER, PROVIDER_COLLATERAL, 100_000 * ONE_USDC);
+    add_liquidity(test, &env, 100_000 * ONE_USDC).succeeds();
+    fund(test, TRADER, TRADER_COLLATERAL, 1_000 * ONE_USDC);
+
+    // The feed sits at slot 5, fresh by the 150-slot staleness bound, but the
+    // cluster restarted at slot 7: only the restart check can catch the
+    // pre-halt price.
+    set_clock_at(test, 10);
+    set_feed_at_slot(test, dollars(100), 5, 0);
+    set_last_restart_slot(test, 7);
+    assert!(
+        open_position(test, &env, 0, 1_000 * ONE_USDC, 5_000 * ONE_USDC).is_err(),
+        "a pre-restart price must be rejected even inside the staleness bound"
+    );
+
+    // Publishing after the restart (slot 10) reopens the pool.
+    set_feed_at_slot(test, dollars(100), 10, 0);
+    open_position(test, &env, 0, 1_000 * ONE_USDC, 5_000 * ONE_USDC).succeeds();
 }
 
 #[quasar_test]

--- a/finance/prop-amm/anchor/CHANGELOG.md
+++ b/finance/prop-amm/anchor/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-08-04
+
+Reject oracle prices from before a cluster restart. A halt stops the slot
+count but not the wall clock, so after a restart a feed can look fresh in
+slots while its price is hours old; for a market maker that is a free option
+for whoever trades first. `read_oracle_price` now also requires the feed's
+slot to be after the `LastRestartSlot` sysvar's slot
+(`PricePredatesRestart`). Tested by
+`test_swap_rejects_price_from_before_a_restart`.
+
 ## 2026-07-11 (later)
 
 Retuned the walkthrough trade to 5 NVDAx (825.825 USDC at the ask,

--- a/finance/prop-amm/anchor/README.md
+++ b/finance/prop-amm/anchor/README.md
@@ -62,8 +62,10 @@ during fast markets their quotes vanish and return minutes later.
 ### Oracle staleness and confidence
 
 Every swap re-validates the feed: the price must be positive, at the pinned
-scale, no older than 150 slots (~1 minute), and its confidence band must be
-inside `max_confidence_bps`. For this design the staleness bound is not
+scale, no older than 150 slots (~1 minute), stamped after the most recent
+cluster restart (the `LastRestartSlot` sysvar; a halt passes hours of
+wall-clock time in zero slots), and its confidence band must be inside
+`max_confidence_bps`. For this design the staleness bound is not
 hygiene, it is the business: a quote priced off an old number is a free
 option for whoever notices first.
 
@@ -171,4 +173,4 @@ The spread is the fee: buyers pay the oracle price plus `spread_bps`, sellers re
 
 ### What stops the venue from quoting a stale price?
 
-Every `swap` re-validates the feed: the price must be fresh (no older than 150 slots), at the pinned scale, and inside the configured confidence band. A stale quote is a free option for whoever notices first, so the staleness checks are the business model, not hygiene.
+Every `swap` re-validates the feed: the price must be fresh (no older than 150 slots), stamped after the most recent cluster restart, at the pinned scale, and inside the configured confidence band. A stale quote is a free option for whoever notices first, so the staleness checks are the business model, not hygiene.

--- a/finance/prop-amm/anchor/programs/prop-amm/Cargo.toml
+++ b/finance/prop-amm/anchor/programs/prop-amm/Cargo.toml
@@ -24,6 +24,10 @@ custom-panic = []
 # doesn't exist yet, so a first-time buyer needs no separate setup transaction.
 anchor-lang = { version = "1.1.2", features = ["init-if-needed"] }
 anchor-spl = "1.1.2"
+# For the LastRestartSlot sysvar (not re-exported by anchor-lang): the oracle
+# reader rejects prices from before a cluster restart. Same major as the
+# solana-sysvar anchor-lang itself uses, so only one copy is compiled in.
+solana-sysvar = "3"
 # Declared only so Cargo feature-unification turns on `no-entrypoint`; without
 # these the test binary links two `entrypoint` symbols and fails to build.
 spl-token = { version = "9.0.0", features = ["no-entrypoint"] }

--- a/finance/prop-amm/anchor/programs/prop-amm/src/errors.rs
+++ b/finance/prop-amm/anchor/programs/prop-amm/src/errors.rs
@@ -41,6 +41,6 @@ pub enum PropAmmError {
     #[msg("Oracle price confidence band is too wide to trust")]
     OracleConfidenceTooWide,
 
-    #[msg("Oracle price was last updated before the most recent cluster restart")]
+    #[msg("Oracle price is stale: it predates the last cluster restart")]
     PricePredatesRestart,
 }

--- a/finance/prop-amm/anchor/programs/prop-amm/src/errors.rs
+++ b/finance/prop-amm/anchor/programs/prop-amm/src/errors.rs
@@ -40,4 +40,7 @@ pub enum PropAmmError {
 
     #[msg("Oracle price confidence band is too wide to trust")]
     OracleConfidenceTooWide,
+
+    #[msg("Oracle price was last updated before the most recent cluster restart")]
+    PricePredatesRestart,
 }

--- a/finance/prop-amm/anchor/programs/prop-amm/src/state/oracle.rs
+++ b/finance/prop-amm/anchor/programs/prop-amm/src/state/oracle.rs
@@ -1,4 +1,5 @@
 use anchor_lang::prelude::*;
+use solana_sysvar::last_restart_slot::LastRestartSlot;
 
 use crate::constants::{BASIS_POINTS_DENOMINATOR, MAX_PRICE_STALENESS_SLOTS};
 use crate::errors::PropAmmError;
@@ -81,6 +82,18 @@ pub fn read_oracle_price(
     require!(
         current_slot.saturating_sub(last_update_slot) <= MAX_PRICE_STALENESS_SLOTS,
         PropAmmError::StalePrice
+    );
+
+    // Restart handling. A cluster halt stops the slot count but not the wall
+    // clock, so after a restart a feed can look fresh in slots while its
+    // price is hours old. For a market maker that is a free option for
+    // whoever trades first, so reject any price stamped at or before the
+    // restart slot; the market refuses to quote until the publisher posts
+    // again. Zero means the cluster has never restarted.
+    let last_restart_slot = LastRestartSlot::get()?.last_restart_slot;
+    require!(
+        last_restart_slot == 0 || last_update_slot > last_restart_slot,
+        PropAmmError::PricePredatesRestart
     );
 
     // Reject an untrustworthy price: confidence band as a fraction of price,

--- a/finance/prop-amm/anchor/programs/prop-amm/tests/test_prop_amm.rs
+++ b/finance/prop-amm/anchor/programs/prop-amm/tests/test_prop_amm.rs
@@ -264,6 +264,18 @@ impl Market {
         self.svm.expire_blockhash();
     }
 
+    fn current_slot(&self) -> u64 {
+        self.svm.get_sysvar::<anchor_lang::prelude::Clock>().slot
+    }
+
+    /// Simulate a cluster restart at `slot`: prices stamped at or before it
+    /// must be rejected until the publisher posts again.
+    fn set_last_restart_slot(&mut self, slot: u64) {
+        self.svm.set_sysvar(&solana_sysvar::last_restart_slot::LastRestartSlot {
+            last_restart_slot: slot,
+        });
+    }
+
     /// Create a wallet holding `base` and `quote` minor units in associated
     /// token accounts.
     fn funded_trader(&mut self, base: u64, quote: u64) -> (Keypair, Pubkey, Pubkey) {
@@ -634,6 +646,33 @@ fn test_swap_rejects_stale_price() {
     assert!(market
         .swap(&alice, Direction::BuyBase, 825_825_000, 0)
         .is_err());
+}
+
+/// A cluster restart passes hours of wall-clock time in zero slots, so a price
+/// published before the halt can still look fresh by slot count. The market
+/// must refuse to quote against it until the publisher posts again.
+#[test]
+fn test_swap_rejects_price_from_before_a_restart() {
+    let mut market = Market::default_market();
+    market.set_price(dollars(165));
+    let (alice, _, _) = market.funded_trader(0, 825_825_000);
+
+    // Simulate a halt: the cluster restarts a few slots after the price was
+    // published, well inside the 150-slot staleness bound, so only the
+    // restart check can catch the pre-halt price.
+    let published_at = market.current_slot();
+    market.warp(published_at + 5);
+    market.set_last_restart_slot(published_at + 3);
+
+    assert!(market
+        .swap(&alice, Direction::BuyBase, 825_825_000, 0)
+        .is_err());
+
+    // Publishing after the restart reopens the market.
+    market.set_price(dollars(165));
+    market
+        .swap(&alice, Direction::BuyBase, 825_825_000, 0)
+        .expect("a freshly published price must be accepted after a restart");
 }
 
 /// A price the oracle itself is unsure about is rejected: the confidence band

--- a/finance/prop-amm/anchor/programs/prop-amm/tests/test_prop_amm.rs
+++ b/finance/prop-amm/anchor/programs/prop-amm/tests/test_prop_amm.rs
@@ -668,7 +668,10 @@ fn test_swap_rejects_price_from_before_a_restart() {
         .swap(&alice, Direction::BuyBase, 825_825_000, 0)
         .is_err());
 
-    // Publishing after the restart reopens the market.
+    // Publishing after the restart reopens the market. Warp first: the retry is
+    // otherwise byte-identical to the rejected swap, so it would carry the same
+    // signature and be dropped as already processed.
+    market.warp(published_at + 6);
     market.set_price(dollars(165));
     market
         .swap(&alice, Direction::BuyBase, 825_825_000, 0)

--- a/finance/prop-amm/quasar/CHANGELOG.md
+++ b/finance/prop-amm/quasar/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-08-04
+
+Reject oracle prices from before a cluster restart: `read_oracle_price`
+requires the feed's slot to be after the `LastRestartSlot` sysvar's slot
+(`PRICE_PREDATES_RESTART`). quasar-lang has no LastRestartSlot sysvar, so
+`src/last_restart.rs` declares the layout and reads it via
+`sol_get_sysvar`. Also pinned `zeropod = "=0.3.3"` (zeropod 0.3.4 moved to
+wincode 0.5 while quasar-lang's pinned rev stays on wincode 0.4, so a fresh
+resolve failed every Pod* trait bound). Tested by
+`swap_rejects_price_from_before_a_restart`.
+
 ## [2026-07-22]
 
 ### Changed

--- a/finance/prop-amm/quasar/Cargo.toml
+++ b/finance/prop-amm/quasar/Cargo.toml
@@ -32,6 +32,17 @@ idl-build = ["quasar-lang/idl-build"]
 quasar-lang = { git = "https://github.com/blueshift-gg/quasar", rev = "be60fca" }
 quasar-spl = { git = "https://github.com/blueshift-gg/quasar", rev = "be60fca" }
 solana-instruction = { version = "3.2.0" }
+# The LastRestartSlot sysvar declaration (src/last_restart.rs) names these
+# three crates directly. Versions match quasar-lang's own constraints so each
+# is compiled once.
+solana-address = { version = ">=2.2, <2.6" }
+solana-program-error = "3.0.0"
+solana-define-syscall = "5.0.0"
+# Pinned: quasar-lang asks for zeropod "0.3.3" and wincode 0.4, but zeropod
+# 0.3.4 moved to wincode 0.5, so a fresh resolve (no lockfile is committed)
+# splits the graph across two wincode versions and every Pod* trait bound
+# fails. Unpin when quasar-lang's pinned rev accepts zeropod 0.3.4+.
+zeropod = "=0.3.3"
 
 [dev-dependencies]
 quasar-test = { git = "https://github.com/blueshift-gg/quasar", rev = "be60fca" }

--- a/finance/prop-amm/quasar/README.md
+++ b/finance/prop-amm/quasar/README.md
@@ -16,6 +16,12 @@ Quasar version.
 - **Trader token accounts must already exist.** The Anchor version uses
   `init_if_needed` to create the trader's destination account inside the swap;
   here the tests create both token accounts up front.
+- **A hand-declared `LastRestartSlot` sysvar.** quasar-lang ships only the
+  Clock and Rent sysvars, so `src/last_restart.rs` declares the 8-byte layout
+  itself and reads it with the same `sol_get_sysvar` syscall.
+  `read_oracle_price` uses it to reject prices published before a cluster
+  restart, which slot-based staleness alone cannot catch (a halt passes hours
+  of wall-clock time in zero slots).
 - **Oracle feed in tests.** Rather than a separate mock-oracle program, the
   tests write the feed account's bytes directly (price, scale, last-update
   slot, confidence) and the program reads them the same way it would read a
@@ -30,7 +36,7 @@ They build the program, set up both mints, an oracle feed at $165, and an
 operator with funded inventory, then verify the quote math to the minor unit
 in both directions, the exact 1.65 USDC round-trip spread, oracle repricing
 and re-quoting, the operator's full exit, and that every gate shuts: slippage,
-staleness, confidence, pause, zero amounts, inventory bounds, and operator
+staleness, restart handling, confidence, pause, zero amounts, inventory bounds, and operator
 access control.
 
 ```bash

--- a/finance/prop-amm/quasar/src/instructions/shared.rs
+++ b/finance/prop-amm/quasar/src/instructions/shared.rs
@@ -4,9 +4,10 @@
 //! favoring the market. Errors are `ProgramError::Custom(code)`; the codes are
 //! listed here.
 
-use quasar_lang::prelude::*;
+use quasar_lang::{prelude::*, sysvars::Sysvar};
 
 use crate::constants::{BASIS_POINTS_DENOMINATOR, MAX_PRICE_STALENESS_SLOTS};
+use crate::last_restart::LastRestartSlot;
 
 pub mod error {
     pub const ZERO_AMOUNT: u32 = 0;
@@ -22,6 +23,7 @@ pub mod error {
     pub const AMOUNT_ROUNDS_TO_ZERO: u32 = 10;
     pub const INVARIANT_VIOLATED: u32 = 11;
     pub const INVALID_DIRECTION: u32 = 12;
+    pub const PRICE_PREDATES_RESTART: u32 = 13;
 }
 
 #[inline(always)]
@@ -88,6 +90,17 @@ pub fn read_oracle_price(
     }
     if current_slot.saturating_sub(last_update_slot) > MAX_PRICE_STALENESS_SLOTS {
         return Err(err(error::STALE_PRICE));
+    }
+
+    // Restart handling. A cluster halt stops the slot count but not the wall
+    // clock, so after a restart a feed can look fresh in slots while its
+    // price is hours old. For a market maker that is a free option for
+    // whoever trades first, so reject any price stamped at or before the
+    // restart slot; the market refuses to quote until the publisher posts
+    // again. Zero means the cluster has never restarted.
+    let last_restart = u64::from(LastRestartSlot::get()?.last_restart_slot);
+    if last_restart != 0 && last_update_slot <= last_restart {
+        return Err(err(error::PRICE_PREDATES_RESTART));
     }
 
     // Confidence band as a fraction of price, in basis points, must stay

--- a/finance/prop-amm/quasar/src/last_restart.rs
+++ b/finance/prop-amm/quasar/src/last_restart.rs
@@ -1,0 +1,77 @@
+//! The LastRestartSlot sysvar: the slot of the most recent cluster restart,
+//! or 0 if the cluster has never restarted (SIMD-0047). quasar-lang ships
+//! only the Clock and Rent sysvars, so this program declares the 8-byte
+//! layout itself and reads it through the same `sol_get_sysvar` syscall
+//! quasar's own sysvars use.
+//!
+//! Why the program reads it: a halt stops the slot count but not the wall
+//! clock, so after a restart an oracle price can look fresh in slots while
+//! its value is hours old. `shared::read_oracle_price` rejects any price
+//! stamped at or before the restart slot, so the market refuses to quote
+//! until the publisher posts again.
+
+use quasar_lang::{pod::PodU64, prelude::Address, sysvars::Sysvar};
+use solana_program_error::ProgramError;
+
+/// `SysvarLastRestartS1ot1111111111111111111111`, decoded at compile time.
+const LAST_RESTART_SLOT_ID: Address =
+    quasar_lang::prelude::address!("SysvarLastRestartS1ot1111111111111111111111");
+
+/// The sysvar's whole data: one little-endian u64.
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct LastRestartSlot {
+    pub last_restart_slot: PodU64,
+}
+
+const _: () = assert!(core::mem::size_of::<LastRestartSlot>() == 8);
+const _: () = assert!(core::mem::align_of::<LastRestartSlot>() == 1);
+
+// Written out by hand rather than with quasar-lang's `impl_sysvar_get!`: the
+// macro's expansion names private quasar-lang constants, so it only works
+// inside that crate. The sysvar is 8 bytes with no padding, so the syscall
+// fills the whole struct.
+impl Sysvar for LastRestartSlot {
+    const ID: Address = LAST_RESTART_SLOT_ID;
+
+    #[inline(always)]
+    unsafe fn from_bytes_unchecked(bytes: &[u8]) -> &Self {
+        // SAFETY: the caller guarantees `bytes` holds at least 8 bytes of
+        // valid sysvar data; the struct is `#[repr(C)]` with alignment 1,
+        // so the pointer cast is always valid.
+        unsafe { &*(bytes.as_ptr() as *const Self) }
+    }
+
+    fn get() -> Result<Self, ProgramError> {
+        let mut var = core::mem::MaybeUninit::<Self>::uninit();
+        let var_addr = var.as_mut_ptr() as *mut u8;
+
+        #[cfg(any(target_os = "solana", target_arch = "bpf"))]
+        // SAFETY: `var_addr` points at 8 writable bytes and the syscall
+        // writes exactly 8.
+        let result = unsafe {
+            solana_define_syscall::definitions::sol_get_sysvar(
+                &LAST_RESTART_SLOT_ID as *const _ as *const u8,
+                var_addr,
+                0,
+                core::mem::size_of::<Self>() as u64,
+            )
+        };
+
+        // Off-chain (IDL builds, client compilation) the sysvar reads as
+        // zero: the cluster has never restarted.
+        #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
+        let result: u64 = {
+            // SAFETY: `var_addr` points at 8 writable bytes.
+            unsafe { var_addr.write_bytes(0, core::mem::size_of::<Self>()) };
+            0
+        };
+
+        match result {
+            // SAFETY: on success the syscall (or the zeroing above) has
+            // initialized all 8 bytes.
+            0 => Ok(unsafe { var.assume_init() }),
+            _ => Err(ProgramError::UnsupportedSysvar),
+        }
+    }
+}

--- a/finance/prop-amm/quasar/src/lib.rs
+++ b/finance/prop-amm/quasar/src/lib.rs
@@ -9,6 +9,7 @@ use quasar_lang::prelude::*;
 
 mod constants;
 mod instructions;
+mod last_restart;
 pub mod state;
 #[cfg(test)]
 mod tests;

--- a/finance/prop-amm/quasar/src/tests.rs
+++ b/finance/prop-amm/quasar/src/tests.rs
@@ -91,6 +91,24 @@ fn make_price_stale(test: &mut Test) {
     set_feed_at_slot(test, dollars(165), SLOT - 151, 0);
 }
 
+/// Pin the LastRestartSlot sysvar account, simulating a cluster restart at
+/// `slot`: prices stamped at or before it must be rejected until the
+/// publisher posts again. The sysvar's whole data is one little-endian u64.
+fn set_last_restart_slot(test: &mut Test, slot: u64) {
+    let sysvar_id: Pubkey = "SysvarLastRestartS1ot1111111111111111111111"
+        .parse()
+        .unwrap();
+    let sysvar_owner: Pubkey = "Sysvar1111111111111111111111111111111111111"
+        .parse()
+        .unwrap();
+    test.set_account(Account::new(
+        sysvar_id,
+        sysvar_owner,
+        1_169_280,
+        slot.to_le_bytes().to_vec(),
+    ));
+}
+
 fn init_market(test: &mut Test, spread_bps: u16) -> Outcome {
     test.send(InitializeMarketInstruction {
         operator: OPERATOR,
@@ -373,6 +391,30 @@ fn swap_rejects_stale_price(test: &mut Test) {
         swap(test, &env, TRADER, TRADER_BASE, TRADER_QUOTE, DIRECTION_BUY_BASE, 825_825_000, 0).is_err(),
         "a stale oracle price must be rejected"
     );
+}
+
+/// A cluster restart passes hours of wall-clock time in zero slots, so a
+/// price published before the halt can still look fresh by slot count. The
+/// market must refuse to quote against it until the publisher posts again.
+#[quasar_test]
+fn swap_rejects_price_from_before_a_restart(test: &mut Test) {
+    let env = setup(test);
+    fund_trader(test, TRADER, TRADER_BASE, TRADER_QUOTE, 0, 825_825_000 * 2);
+
+    // The feed is stamped at `SLOT - 5`: fresh by the 150-slot staleness
+    // bound, but published before a restart at `SLOT - 3`, so only the
+    // restart check can catch it.
+    set_feed_at_slot(test, dollars(165), SLOT - 5, 0);
+    set_last_restart_slot(test, SLOT - 3);
+    assert!(
+        swap(test, &env, TRADER, TRADER_BASE, TRADER_QUOTE, DIRECTION_BUY_BASE, 825_825_000, 0).is_err(),
+        "a pre-restart price must be rejected even inside the staleness bound"
+    );
+
+    // Publishing after the restart (at `SLOT`) reopens the market.
+    set_feed(test, dollars(165), 0);
+    swap(test, &env, TRADER, TRADER_BASE, TRADER_QUOTE, DIRECTION_BUY_BASE, 825_825_000, 0)
+        .succeeds();
 }
 
 /// A price the oracle itself is unsure about is rejected: the confidence band


### PR DESCRIPTION
## What

A cluster halt stops the slot count but not the wall clock, so after a restart an oracle price can pass a slot-measured staleness bound while its value is hours old. The three oracle-priced examples — **lending**, **prop-amm**, and **perpetual-futures**, in both Anchor and Quasar variants — now also require the feed's slot to be after the `LastRestartSlot` sysvar's slot, failing with a dedicated error (`PricePredatesRestart` / `PRICE_PREDATES_RESTART`) until the publisher posts again. Zero means the cluster has never restarted, so the check is a no-op on a chain with no restart history.

Each check carries a comment stating the intention: the market pauses valuation after a restart rather than acting on a pre-halt price.

## Tests

One new test per variant, each simulating a restart *inside* the staleness window (so only the restart check can catch it) and proving that a fresh publication reopens the market:

- `borrow_with_price_from_before_a_restart_is_rejected` (lending, Anchor + Quasar)
- `test_swap_rejects_price_from_before_a_restart` (prop-amm, Anchor) / `swap_rejects_price_from_before_a_restart` (Quasar)
- `test_open_rejects_price_from_before_a_restart` (perps, Anchor) / `open_rejects_price_from_before_a_restart` (Quasar)

LiteSVM initializes the sysvar and `set_sysvar` overrides it; the Quasar tests pin the sysvar account directly, which quasar-svm's sysvar cache picks up.

## Quasar sysvar declaration

quasar-lang ships only the Clock and Rent sysvars, so each Quasar variant declares the sysvar's 8-byte layout in `src/last_restart.rs` and reads it through the same `sol_get_sysvar` syscall quasar's own sysvars use. The `Sysvar` impl is written out by hand because quasar-lang's `impl_sysvar_get!` macro names private constants and cannot expand outside that crate.

## Incidental fix: zeropod pin

The three touched Quasar variants pin `zeropod = "=0.3.3"`. zeropod 0.3.4 moved to wincode 0.5 while quasar-lang's pinned rev stays on wincode 0.4, so any fresh resolve (these projects commit no lockfile) splits the graph across two wincode versions and fails every `Pod*` trait bound. **The repository's other Quasar examples have the same latent break** and will need the same pin (or an upstream quasar-lang fix) the next time their CI resolves fresh — happy to do that as a follow-up.

## Verification

All six workspaces pass `cargo check --workspace --all-targets` locally. The LiteSVM/quasar-test suites need `cargo build-sbf`, whose platform-tools download is blocked in this environment, so CI is the test signal for the suites.

This change pairs with a book update in quicknode/solana-book#16, which teaches what a halt does to the two clocks and points at these oracle readers as the demonstration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABFpszmPxRorwWtWGR2jXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABFpszmPxRorwWtWGR2jXj)_