### PR TITLE
workspace: add the Anchor programs CI never linted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,6 +617,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "betting-market"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer",
+ "spl-associated-token-account",
+ "spl-token",
+ "wincode 0.5.5",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1561,6 +1578,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "escrow"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer",
+ "wincode 0.5.5",
+]
+
+[[package]]
 name = "favorites-native"
 version = "0.1.0"
 dependencies = [
@@ -1675,6 +1707,24 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fundraiser"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-clock 3.1.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer",
+ "spl-associated-token-account",
+ "spl-token",
+ "wincode 0.5.5",
+]
 
 [[package]]
 name = "funty"
@@ -2010,6 +2060,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lending"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "pinocchio 0.11.2",
+ "solana-address 2.6.1",
+ "solana-clock 3.1.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-pubkey 3.0.0",
+ "solana-signer",
+ "solana-sysvar 3.1.1",
+ "wincode 0.5.5",
+]
+
+[[package]]
 name = "lever"
 version = "0.1.0"
 dependencies = [
@@ -2221,6 +2290,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "mock_switchboard"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "solana-address 2.6.1",
+ "wincode 0.5.5",
+]
+
+[[package]]
+name = "mock_switchboard_prop_amm"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "solana-address 2.6.1",
+ "wincode 0.5.5",
+]
+
+[[package]]
 name = "mpl-token-metadata"
 version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2406,6 +2493,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "order_book"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "bytemuck",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer",
+ "static_assertions",
+ "wincode 0.5.5",
+]
+
+[[package]]
 name = "pairing"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2536,6 +2639,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd23b938276f14057220b707937bcb42fa76dda7560e57a2da30cb52d557937"
 dependencies = [
  "num",
+]
+
+[[package]]
+name = "perpetual_futures"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "mock_switchboard",
+ "pinocchio 0.11.2",
+ "solana-address 2.6.1",
+ "solana-clock 3.1.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer",
+ "solana-sysvar 3.1.1",
+ "spl-associated-token-account",
+ "spl-token",
+ "wincode 0.5.5",
 ]
 
 [[package]]
@@ -2810,6 +2934,27 @@ dependencies = [
  "solana-keypair",
  "solana-kite",
  "solana-signer",
+ "wincode 0.5.5",
+]
+
+[[package]]
+name = "prop_amm"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "mock_switchboard_prop_amm",
+ "pinocchio 0.11.2",
+ "solana-address 2.6.1",
+ "solana-clock 3.1.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer",
+ "solana-sysvar 3.1.1",
+ "spl-associated-token-account",
+ "spl-token",
  "wincode 0.5.5",
 ]
 
@@ -6069,6 +6214,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6079,6 +6230,21 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "swap_example"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer",
+ "wincode 0.5.5",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,24 @@
 version = 4
 
 [[package]]
+name = "abl-token"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer 3.0.0",
+ "spl-discriminator 0.5.2",
+ "spl-tlv-account-resolution 0.11.1",
+ "spl-transfer-hook-interface 2.1.0",
+ "wincode 0.5.5",
+]
+
+[[package]]
 name = "account-data-anchor-program"
 version = "0.1.0"
 dependencies = [
@@ -11,7 +29,7 @@ dependencies = [
  "litesvm",
  "solana-keypair",
  "solana-kite",
- "solana-signer",
+ "solana-signer 3.0.0",
  "wincode 0.5.5",
 ]
 
@@ -27,7 +45,7 @@ dependencies = [
  "solana-native-token 3.0.0",
  "solana-program 4.0.0",
  "solana-pubkey 3.0.0",
- "solana-signer",
+ "solana-signer 3.0.0",
  "solana-system-interface 2.0.0",
  "solana-transaction",
 ]
@@ -44,7 +62,7 @@ dependencies = [
  "solana-message 4.0.0",
  "solana-native-token 3.0.0",
  "solana-pubkey 3.0.0",
- "solana-signer",
+ "solana-signer 3.0.0",
  "solana-system-interface 2.0.0",
  "solana-transaction",
 ]
@@ -95,7 +113,7 @@ dependencies = [
  "blstrs",
  "bytemuck",
  "bytemuck_derive",
- "group",
+ "group 0.13.0",
  "pairing",
 ]
 
@@ -133,7 +151,7 @@ checksum = "84debd4abe0cbab5a6aac2ee50e3969ef0e0961f7dff7e8f96bda0be7998bca2"
 dependencies = [
  "agave-bls12-381",
  "bincode",
- "libsecp256k1",
+ "libsecp256k1 0.6.0",
  "num-traits",
  "solana-account 3.4.0",
  "solana-account-info 3.1.1",
@@ -271,7 +289,7 @@ dependencies = [
  "litesvm",
  "solana-keypair",
  "solana-kite",
- "solana-signer",
+ "solana-signer 3.0.0",
  "wincode 0.5.5",
 ]
 
@@ -284,6 +302,7 @@ dependencies = [
  "anchor-lang",
  "borsh 1.7.0",
  "bytemuck",
+ "mpl-token-metadata",
  "pinocchio 0.11.2",
  "pinocchio-token",
  "pinocchio-token-2022",
@@ -291,7 +310,7 @@ dependencies = [
  "solana-instruction 3.2.0",
  "solana-program-error 3.0.1",
  "solana-pubkey 3.0.0",
- "spl-pod",
+ "spl-pod 0.7.3",
  "spl-token-2022-interface",
  "spl-token-group-interface",
  "spl-token-interface",
@@ -627,7 +646,7 @@ dependencies = [
  "solana-address 2.6.1",
  "solana-keypair",
  "solana-kite",
- "solana-signer",
+ "solana-signer 3.0.0",
  "spl-associated-token-account",
  "spl-token",
  "wincode 0.5.5",
@@ -723,7 +742,7 @@ dependencies = [
  "blst",
  "byte-slice-cast",
  "ff",
- "group",
+ "group 0.13.0",
  "pairing",
  "rand_core 0.6.4",
  "serde",
@@ -905,7 +924,7 @@ dependencies = [
  "litesvm",
  "solana-keypair",
  "solana-kite",
- "solana-signer",
+ "solana-signer 3.0.0",
  "wincode 0.5.5",
 ]
 
@@ -965,7 +984,7 @@ dependencies = [
  "litesvm",
  "solana-keypair",
  "solana-kite",
- "solana-signer",
+ "solana-signer 3.0.0",
  "wincode 0.5.5",
 ]
 
@@ -1039,7 +1058,7 @@ dependencies = [
  "solana-message 4.0.0",
  "solana-native-token 3.0.0",
  "solana-pubkey 3.0.0",
- "solana-signer",
+ "solana-signer 3.0.0",
  "solana-system-interface 2.0.0",
  "solana-transaction",
 ]
@@ -1053,7 +1072,7 @@ dependencies = [
  "solana-address 2.6.1",
  "solana-keypair",
  "solana-kite",
- "solana-signer",
+ "solana-signer 3.0.0",
  "wincode 0.5.5",
 ]
 
@@ -1062,6 +1081,46 @@ name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "cnft-burn"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-account 3.4.0",
+ "solana-address 2.6.1",
+ "solana-instruction 3.2.0",
+ "solana-keccak-hasher 3.1.0",
+ "solana-keypair",
+ "solana-message 3.1.0",
+ "solana-native-token 3.0.0",
+ "solana-pubkey 3.0.0",
+ "solana-signer 3.0.0",
+ "solana-transaction",
+ "wincode 0.5.5",
+]
+
+[[package]]
+name = "cnft-vault"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-account 3.4.0",
+ "solana-address 2.6.1",
+ "solana-instruction 3.2.0",
+ "solana-keccak-hasher 3.1.0",
+ "solana-keypair",
+ "solana-message 3.1.0",
+ "solana-native-token 3.0.0",
+ "solana-pubkey 3.0.0",
+ "solana-signer 3.0.0",
+ "solana-transaction",
+ "wincode 0.5.5",
+]
 
 [[package]]
 name = "combine"
@@ -1151,7 +1210,22 @@ dependencies = [
  "litesvm",
  "solana-keypair",
  "solana-kite",
- "solana-signer",
+ "solana-signer 3.0.0",
+ "wincode 0.5.5",
+]
+
+[[package]]
+name = "cpi-guard"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer 3.0.0",
  "wincode 0.5.5",
 ]
 
@@ -1225,7 +1299,22 @@ dependencies = [
  "litesvm",
  "solana-keypair",
  "solana-kite",
- "solana-signer",
+ "solana-signer 3.0.0",
+ "wincode 0.5.5",
+]
+
+[[package]]
+name = "create-token"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer 3.0.0",
  "wincode 0.5.5",
 ]
 
@@ -1240,7 +1329,7 @@ dependencies = [
  "solana-instruction 3.2.0",
  "solana-keypair",
  "solana-native-token 3.0.0",
- "solana-program 2.3.0",
+ "solana-program 3.0.0",
  "solana-program 4.0.0",
  "solana-pubkey 3.0.0",
  "solana-system-interface 2.0.0",
@@ -1310,6 +1399,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1357,6 +1456,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "cutils"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "borsh 1.7.0",
+ "litesvm",
+ "sha3",
+ "solana-account 3.4.0",
+ "solana-address 2.6.1",
+ "solana-instruction 3.2.0",
+ "solana-keccak-hasher 3.1.0",
+ "solana-keypair",
+ "solana-message 3.1.0",
+ "solana-native-token 3.0.0",
+ "solana-pubkey 3.0.0",
+ "solana-signer 3.0.0",
+ "solana-transaction",
+ "wincode 0.5.5",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1388,6 +1508,21 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "default-account-state"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer 3.0.0",
+ "wincode 0.5.5",
 ]
 
 [[package]]
@@ -1523,7 +1658,7 @@ dependencies = [
  "digest 0.10.7",
  "ff",
  "generic-array",
- "group",
+ "group 0.13.0",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -1588,7 +1723,54 @@ dependencies = [
  "solana-address 2.6.1",
  "solana-keypair",
  "solana-kite",
- "solana-signer",
+ "solana-signer 3.0.0",
+ "wincode 0.5.5",
+]
+
+[[package]]
+name = "extension_nft"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-instruction 3.2.0",
+ "solana-keypair",
+ "solana-kite",
+ "solana-pubkey 3.0.0",
+ "solana-signer 3.0.0",
+ "wincode 0.5.5",
+]
+
+[[package]]
+name = "external-delegate-token-master"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "libsecp256k1 0.7.2",
+ "litesvm",
+ "sha3",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-secp256k1-recover 2.2.1",
+ "solana-signer 3.0.0",
+ "wincode 0.5.5",
+]
+
+[[package]]
+name = "favorites"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "litesvm",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer 3.0.0",
  "wincode 0.5.5",
 ]
 
@@ -1720,7 +1902,7 @@ dependencies = [
  "solana-clock 3.1.1",
  "solana-keypair",
  "solana-kite",
- "solana-signer",
+ "solana-signer 3.0.0",
  "spl-associated-token-account",
  "spl-token",
  "wincode 0.5.5",
@@ -1811,6 +1993,21 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "group"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer 3.0.0",
+ "wincode 0.5.5",
+]
+
+[[package]]
+name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
@@ -1830,7 +2027,7 @@ dependencies = [
  "litesvm",
  "solana-keypair",
  "solana-kite",
- "solana-signer",
+ "solana-signer 3.0.0",
  "wincode 0.5.5",
 ]
 
@@ -1883,7 +2080,7 @@ dependencies = [
  "anchor-lang",
  "litesvm",
  "solana-kite",
- "solana-signer",
+ "solana-signer 3.0.0",
  "solana-transaction",
  "wincode 0.5.5",
 ]
@@ -1936,11 +2133,32 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hmac"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac-drbg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
+dependencies = [
+ "digest 0.9.0",
+ "generic-array",
+ "hmac 0.8.1",
 ]
 
 [[package]]
@@ -1959,6 +2177,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "immutable-owner"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer 3.0.0",
+ "wincode 0.5.5",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1975,6 +2208,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "interest-bearing"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer 3.0.0",
+ "wincode 0.5.5",
 ]
 
 [[package]]
@@ -2045,6 +2293,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kaigan"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f25ded719a2354f6b1a51d0c0741c25bc7afe038617664eb37f6418439eb084"
+dependencies = [
+ "borsh 0.10.4",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2073,7 +2330,7 @@ dependencies = [
  "solana-keypair",
  "solana-kite",
  "solana-pubkey 3.0.0",
- "solana-signer",
+ "solana-signer 3.0.0",
  "solana-sysvar 3.1.1",
  "wincode 0.5.5",
 ]
@@ -2086,7 +2343,7 @@ dependencies = [
  "litesvm",
  "solana-keypair",
  "solana-kite",
- "solana-signer",
+ "solana-signer 3.0.0",
  "wincode 0.5.5",
 ]
 
@@ -2105,12 +2362,31 @@ dependencies = [
  "arrayref",
  "base64 0.12.3",
  "digest 0.9.0",
- "libsecp256k1-core",
- "libsecp256k1-gen-ecmult",
- "libsecp256k1-gen-genmult",
+ "libsecp256k1-core 0.2.2",
+ "libsecp256k1-gen-ecmult 0.2.1",
+ "libsecp256k1-gen-genmult 0.2.1",
  "rand 0.7.3",
  "serde",
  "sha2 0.9.9",
+]
+
+[[package]]
+name = "libsecp256k1"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79019718125edc905a079a70cfa5f3820bc76139fc91d6f9abc27ea2a887139"
+dependencies = [
+ "arrayref",
+ "base64 0.22.1",
+ "digest 0.9.0",
+ "hmac-drbg",
+ "libsecp256k1-core 0.3.0",
+ "libsecp256k1-gen-ecmult 0.3.0",
+ "libsecp256k1-gen-genmult 0.3.0",
+ "rand 0.8.6",
+ "serde",
+ "sha2 0.9.9",
+ "typenum",
 ]
 
 [[package]]
@@ -2125,12 +2401,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsecp256k1-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
+dependencies = [
+ "crunchy",
+ "digest 0.9.0",
+ "subtle",
+]
+
+[[package]]
 name = "libsecp256k1-gen-ecmult"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccab96b584d38fac86a83f07e659f0deafd0253dc096dab5a36d53efe653c5c3"
 dependencies = [
- "libsecp256k1-core",
+ "libsecp256k1-core 0.2.2",
+]
+
+[[package]]
+name = "libsecp256k1-gen-ecmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
+dependencies = [
+ "libsecp256k1-core 0.3.0",
 ]
 
 [[package]]
@@ -2139,7 +2435,16 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
 dependencies = [
- "libsecp256k1-core",
+ "libsecp256k1-core 0.2.2",
+]
+
+[[package]]
+name = "libsecp256k1-gen-genmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
+dependencies = [
+ "libsecp256k1-core 0.3.0",
 ]
 
 [[package]]
@@ -2213,8 +2518,8 @@ dependencies = [
  "solana-rent 3.1.0",
  "solana-sdk-ids 3.1.0",
  "solana-sha256-hasher 3.1.0",
- "solana-signature",
- "solana-signer",
+ "solana-signature 3.3.0",
+ "solana-signer 3.0.0",
  "solana-slot-hashes 3.0.1",
  "solana-slot-history 3.1.0",
  "solana-stake-interface 2.0.2",
@@ -2254,6 +2559,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
+name = "memo-transfer"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer 3.0.0",
+ "wincode 0.5.5",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2275,6 +2595,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "metadata"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer 3.0.0",
+ "spl-token-metadata-interface",
+ "spl-type-length-value 0.9.1",
+ "wincode 0.5.5",
+]
+
+[[package]]
+name = "mint-close-authority"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer 3.0.0",
+ "wincode 0.5.5",
+]
+
+[[package]]
+name = "mint-nft"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer 3.0.0",
+ "wincode 0.5.5",
+]
+
+[[package]]
 name = "mock-swap-router"
 version = "0.1.0"
 dependencies = [
@@ -2285,7 +2652,7 @@ dependencies = [
  "solana-address 2.6.1",
  "solana-keypair",
  "solana-kite",
- "solana-signer",
+ "solana-signer 3.0.0",
  "wincode 0.5.5",
 ]
 
@@ -2309,15 +2676,32 @@ dependencies = [
 
 [[package]]
 name = "mpl-token-metadata"
-version = "5.1.1"
+version = "5.1.2-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046f0779684ec348e2759661361c8798d79021707b1392cb49f3b5eb911340ff"
+checksum = "9824d84a8e23b634256591ce2f05b3180f7be5fcd193d939c43764c804aac5ef"
 dependencies = [
- "borsh 0.10.4",
+ "borsh 1.7.0",
+ "kaigan",
  "num-derive 0.3.3",
  "num-traits",
- "solana-program 2.3.0",
+ "solana-program 3.0.0",
+ "solana-program-error 3.0.1",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "nft-minter"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer 3.0.0",
+ "wincode 0.5.5",
 ]
 
 [[package]]
@@ -2331,13 +2715,28 @@ dependencies = [
  "solana-instruction 3.2.0",
  "solana-keypair",
  "solana-native-token 3.0.0",
- "solana-program 2.3.0",
+ "solana-program 3.0.0",
  "solana-program 4.0.0",
  "solana-pubkey 3.0.0",
  "solana-system-interface 2.0.0",
  "solana-transaction",
  "spl-associated-token-account-interface",
  "spl-token-interface",
+]
+
+[[package]]
+name = "non-transferable"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer 3.0.0",
+ "wincode 0.5.5",
 ]
 
 [[package]]
@@ -2503,7 +2902,7 @@ dependencies = [
  "solana-address 2.6.1",
  "solana-keypair",
  "solana-kite",
- "solana-signer",
+ "solana-signer 3.0.0",
  "static_assertions",
  "wincode 0.5.5",
 ]
@@ -2514,7 +2913,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
- "group",
+ "group 0.13.0",
 ]
 
 [[package]]
@@ -2562,6 +2961,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pda-mint-authority-anchor"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-program-pack 3.1.0",
+ "solana-signer 3.0.0",
+ "wincode 0.5.5",
+]
+
+[[package]]
 name = "pda-mint-authority-native-program"
 version = "0.1.0"
 dependencies = [
@@ -2572,7 +2987,7 @@ dependencies = [
  "solana-instruction 3.2.0",
  "solana-keypair",
  "solana-native-token 3.0.0",
- "solana-program 2.3.0",
+ "solana-program 3.0.0",
  "solana-program 4.0.0",
  "solana-pubkey 3.0.0",
  "solana-system-interface 2.0.0",
@@ -2589,7 +3004,7 @@ dependencies = [
  "litesvm",
  "solana-keypair",
  "solana-kite",
- "solana-signer",
+ "solana-signer 3.0.0",
  "wincode 0.5.5",
 ]
 
@@ -2642,6 +3057,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "permanent-delegate"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer 3.0.0",
+ "wincode 0.5.5",
+]
+
+[[package]]
 name = "perpetual_futures"
 version = "0.1.0"
 dependencies = [
@@ -2655,7 +3085,7 @@ dependencies = [
  "solana-clock 3.1.1",
  "solana-keypair",
  "solana-kite",
- "solana-signer",
+ "solana-signer 3.0.0",
  "solana-sysvar 3.1.1",
  "spl-associated-token-account",
  "spl-token",
@@ -2841,7 +3271,7 @@ dependencies = [
  "litesvm",
  "solana-keypair",
  "solana-kite",
- "solana-signer",
+ "solana-signer 3.0.0",
  "wincode 0.5.5",
 ]
 
@@ -2933,7 +3363,7 @@ dependencies = [
  "litesvm",
  "solana-keypair",
  "solana-kite",
- "solana-signer",
+ "solana-signer 3.0.0",
  "wincode 0.5.5",
 ]
 
@@ -2951,10 +3381,28 @@ dependencies = [
  "solana-clock 3.1.1",
  "solana-keypair",
  "solana-kite",
- "solana-signer",
+ "solana-signer 3.0.0",
  "solana-sysvar 3.1.1",
  "spl-associated-token-account",
  "spl-token",
+ "wincode 0.5.5",
+]
+
+[[package]]
+name = "pythexample"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "borsh 1.7.0",
+ "litesvm",
+ "pythexample",
+ "sha2 0.10.9",
+ "solana-account 3.4.0",
+ "solana-address 2.6.1",
+ "solana-clock 3.1.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer 3.0.0",
  "wincode 0.5.5",
 ]
 
@@ -3186,7 +3634,7 @@ dependencies = [
  "litesvm",
  "solana-keypair",
  "solana-kite",
- "solana-signer",
+ "solana-signer 3.0.0",
  "wincode 0.5.5",
 ]
 
@@ -3242,7 +3690,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -3685,7 +4133,7 @@ dependencies = [
  "blstrs",
  "cfg_eval",
  "ff",
- "group",
+ "group 0.13.0",
  "pairing",
  "rand 0.8.6",
  "serde",
@@ -3961,6 +4409,17 @@ name = "solana-define-syscall"
 version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21e14a4f604117f379840956a8fc8695e4c84f5b0ebed192f31f60d9b85d581d"
+
+[[package]]
+name = "solana-derivation-path"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "939756d798b25c5ec3cca10e06212bdca3b1443cb9bb740a38124f58b258737b"
+dependencies = [
+ "derivation-path",
+ "qstring",
+ "uriparse",
+]
 
 [[package]]
 name = "solana-derivation-path"
@@ -4367,9 +4826,9 @@ dependencies = [
  "five8_core 1.0.0",
  "rand 0.9.4",
  "solana-address 2.6.1",
- "solana-seed-phrase",
- "solana-signature",
- "solana-signer",
+ "solana-seed-phrase 3.0.0",
+ "solana-signature 3.3.0",
+ "solana-signer 3.0.0",
 ]
 
 [[package]]
@@ -4385,7 +4844,7 @@ dependencies = [
  "solana-message 3.1.0",
  "solana-program 3.0.0",
  "solana-pubkey 3.0.0",
- "solana-signer",
+ "solana-signer 3.0.0",
  "solana-transaction",
  "spl-associated-token-account",
  "spl-token",
@@ -5177,7 +5636,7 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baa3120b6cdaa270f39444f5093a90a7b03d296d362878f7a6991d6de3bbe496"
 dependencies = [
- "libsecp256k1",
+ "libsecp256k1 0.6.0",
  "solana-define-syscall 2.3.0",
  "thiserror 2.0.18",
 ]
@@ -5195,11 +5654,31 @@ dependencies = [
 
 [[package]]
 name = "solana-seed-derivable"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beb82b5adb266c6ea90e5cf3967235644848eac476c5a1f2f9283a143b7c97f"
+dependencies = [
+ "solana-derivation-path 2.2.1",
+]
+
+[[package]]
+name = "solana-seed-derivable"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff7bdb72758e3bec33ed0e2658a920f1f35dfb9ed576b951d20d63cb61ecd95c"
 dependencies = [
- "solana-derivation-path",
+ "solana-derivation-path 3.0.0",
+]
+
+[[package]]
+name = "solana-seed-phrase"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36187af2324f079f65a675ec22b31c24919cb4ac22c79472e85d819db9bbbc15"
+dependencies = [
+ "hmac 0.12.1",
+ "pbkdf2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -5208,7 +5687,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc905b200a95f2ea9146e43f2a7181e3aeb55de6bc12afb36462d00a3c7310de"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "pbkdf2",
  "sha2 0.10.9",
 ]
@@ -5295,6 +5774,16 @@ dependencies = [
 
 [[package]]
 name = "solana-signature"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c8ec8e657aecfc187522fc67495142c12f35e55ddeca8698edbb738b8dbd8c"
+dependencies = [
+ "five8 0.2.1",
+ "solana-sanitize 2.2.1",
+]
+
+[[package]]
+name = "solana-signature"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "132a93134f1262aa832f1849b83bec6c9945669b866da18661a427943b9e801e"
@@ -5310,12 +5799,23 @@ dependencies = [
 
 [[package]]
 name = "solana-signer"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c41991508a4b02f021c1342ba00bcfa098630b213726ceadc7cb032e051975b"
+dependencies = [
+ "solana-pubkey 2.4.0",
+ "solana-signature 2.3.0",
+ "solana-transaction-error 2.2.1",
+]
+
+[[package]]
+name = "solana-signer"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bfea97951fee8bae0d6038f39a5efcb6230ecdfe33425ac75196d1a1e3e3235"
 dependencies = [
  "solana-pubkey 3.0.0",
- "solana-signature",
+ "solana-signature 3.3.0",
  "solana-transaction-error 3.1.0",
 ]
 
@@ -5486,7 +5986,7 @@ dependencies = [
  "solana-message 3.1.0",
  "solana-pubkey 4.1.0",
  "solana-sdk-ids 3.1.0",
- "solana-signature",
+ "solana-signature 3.3.0",
  "solana-transaction",
 ]
 
@@ -5713,8 +6213,8 @@ dependencies = [
  "solana-sanitize 3.0.1",
  "solana-sdk-ids 3.1.0",
  "solana-short-vec 3.2.2",
- "solana-signature",
- "solana-signer",
+ "solana-signature 3.3.0",
+ "solana-signer 3.0.0",
  "solana-transaction-error 3.1.0",
 ]
 
@@ -5832,7 +6332,7 @@ dependencies = [
  "solana-pubkey 4.1.0",
  "solana-rent 3.1.0",
  "solana-sdk-ids 3.1.0",
- "solana-signer",
+ "solana-signer 3.0.0",
  "solana-slot-hashes 3.0.1",
  "solana-system-interface 3.1.0",
  "solana-transaction",
@@ -5871,6 +6371,42 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-sdk"
+version = "2.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97b9fc6ec37d16d0dccff708ed1dd6ea9ba61796700c3bb7c3b401973f10f63b"
+dependencies = [
+ "aes-gcm-siv",
+ "base64 0.22.1",
+ "bincode",
+ "bytemuck",
+ "bytemuck_derive",
+ "curve25519-dalek",
+ "itertools 0.12.1",
+ "js-sys",
+ "merlin",
+ "num-derive 0.4.2",
+ "num-traits",
+ "rand 0.8.6",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha3",
+ "solana-derivation-path 2.2.1",
+ "solana-instruction 2.3.3",
+ "solana-pubkey 2.4.0",
+ "solana-sdk-ids 2.2.1",
+ "solana-seed-derivable 2.2.1",
+ "solana-seed-phrase 2.2.1",
+ "solana-signature 2.3.0",
+ "solana-signer 2.2.1",
+ "subtle",
+ "thiserror 2.0.18",
+ "wasm-bindgen",
+ "zeroize",
+]
+
+[[package]]
+name = "solana-zk-sdk"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9602bcb1f7af15caef92b91132ec2347e1c51a72ecdbefdaefa3eac4b8711475"
@@ -5892,14 +6428,14 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha3",
- "solana-derivation-path",
+ "solana-derivation-path 3.0.0",
  "solana-instruction 3.2.0",
  "solana-pubkey 3.0.0",
  "solana-sdk-ids 3.1.0",
- "solana-seed-derivable",
- "solana-seed-phrase",
- "solana-signature",
- "solana-signer",
+ "solana-seed-derivable 3.0.0",
+ "solana-seed-phrase 3.0.0",
+ "solana-signature 3.3.0",
+ "solana-signer 3.0.0",
  "subtle",
  "thiserror 2.0.18",
  "wasm-bindgen",
@@ -5928,13 +6464,13 @@ dependencies = [
  "serde_json",
  "sha3",
  "solana-address 2.6.1",
- "solana-derivation-path",
+ "solana-derivation-path 3.0.0",
  "solana-instruction 3.2.0",
  "solana-sdk-ids 3.1.0",
- "solana-seed-derivable",
- "solana-seed-phrase",
- "solana-signature",
- "solana-signer",
+ "solana-seed-derivable 3.0.0",
+ "solana-seed-phrase 3.0.0",
+ "solana-signature 3.3.0",
+ "solana-signer 3.0.0",
  "subtle",
  "thiserror 2.0.18",
  "zeroize",
@@ -5998,6 +6534,18 @@ dependencies = [
 
 [[package]]
 name = "spl-discriminator"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7398da23554a31660f17718164e31d31900956054f54f52d5ec1be51cb4f4b3"
+dependencies = [
+ "bytemuck",
+ "solana-program-error 2.2.2",
+ "solana-sha256-hasher 2.3.0",
+ "spl-discriminator-derive",
+]
+
+[[package]]
+name = "spl-discriminator"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e597c5ff9ed7c74a54dbc47bae2f06e4db8c98f4356ad280200dc11878266db1"
@@ -6034,6 +6582,25 @@ dependencies = [
 
 [[package]]
 name = "spl-pod"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d994afaf86b779104b4a95ba9ca75b8ced3fdb17ee934e38cb69e72afbe17799"
+dependencies = [
+ "bytemuck",
+ "bytemuck_derive",
+ "num-derive 0.4.2",
+ "num-traits",
+ "solana-decode-error",
+ "solana-msg 2.2.1",
+ "solana-program-error 2.2.2",
+ "solana-program-option 2.2.1",
+ "solana-pubkey 2.4.0",
+ "solana-zk-sdk 2.3.13",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "spl-pod"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f9c6e142cdf1e7e77f480053ec9f0ce989890768ddf91f619b50f39d1b456f5"
@@ -6049,6 +6616,101 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-zero-copy",
  "solana-zk-sdk 4.0.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "spl-program-error"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d39b5186f42b2b50168029d81e58e800b690877ef0b30580d107659250da1d1"
+dependencies = [
+ "num-derive 0.4.2",
+ "num-traits",
+ "solana-program 2.3.0",
+ "spl-program-error-derive 0.4.1",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spl-program-error"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c4f6cf26cb6768110bf024bc7224326c720d711f7ad25d16f40f6cee40edb2d"
+dependencies = [
+ "num-derive 0.4.2",
+ "num-traits",
+ "num_enum",
+ "solana-msg 3.1.0",
+ "solana-program-error 3.0.1",
+ "spl-program-error-derive 0.6.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "spl-program-error-derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d375dd76c517836353e093c2dbb490938ff72821ab568b545fd30ab3256b3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sha2 0.10.9",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "spl-program-error-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ec8965aa4dc6c74701cbb48b9cad5af35b9a394514934949edbb357b78f840d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sha2 0.10.9",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "spl-tlv-account-resolution"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd99ff1e9ed2ab86e3fd582850d47a739fec1be9f4661cba1782d3a0f26805f3"
+dependencies = [
+ "bytemuck",
+ "num-derive 0.4.2",
+ "num-traits",
+ "solana-account-info 2.3.0",
+ "solana-decode-error",
+ "solana-instruction 2.3.3",
+ "solana-msg 2.2.1",
+ "solana-program-error 2.2.2",
+ "solana-pubkey 2.4.0",
+ "spl-discriminator 0.4.1",
+ "spl-pod 0.5.1",
+ "spl-program-error 0.6.0",
+ "spl-type-length-value 0.7.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spl-tlv-account-resolution"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6927f613c9d7ce20835d3cefb602137cab2518e383a047c0eaa58054a60644c8"
+dependencies = [
+ "bytemuck",
+ "num-derive 0.4.2",
+ "num-traits",
+ "num_enum",
+ "solana-account-info 3.1.1",
+ "solana-instruction 3.2.0",
+ "solana-program-error 3.0.1",
+ "solana-pubkey 3.0.0",
+ "spl-discriminator 0.5.2",
+ "spl-pod 0.7.3",
+ "spl-program-error 0.8.0",
+ "spl-type-length-value 0.9.1",
  "thiserror 2.0.18",
 ]
 
@@ -6099,12 +6761,12 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-sdk-ids 3.1.0",
  "solana-zk-sdk 4.0.0",
- "spl-pod",
+ "spl-pod 0.7.3",
  "spl-token-confidential-transfer-proof-extraction",
  "spl-token-confidential-transfer-proof-generation",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
- "spl-type-length-value",
+ "spl-type-length-value 0.9.1",
  "thiserror 2.0.18",
 ]
 
@@ -6124,7 +6786,7 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-sdk-ids 3.1.0",
  "solana-zk-sdk 4.0.0",
- "spl-pod",
+ "spl-pod 0.7.3",
  "thiserror 2.0.18",
 ]
 
@@ -6152,8 +6814,8 @@ dependencies = [
  "solana-instruction 3.2.0",
  "solana-program-error 3.0.1",
  "solana-pubkey 3.0.0",
- "spl-discriminator",
- "spl-pod",
+ "spl-discriminator 0.5.2",
+ "spl-pod 0.7.3",
  "thiserror 2.0.18",
 ]
 
@@ -6190,10 +6852,79 @@ dependencies = [
  "solana-instruction 3.2.0",
  "solana-program-error 3.0.1",
  "solana-pubkey 3.0.0",
- "spl-discriminator",
- "spl-pod",
- "spl-type-length-value",
+ "spl-discriminator 0.5.2",
+ "spl-pod 0.7.3",
+ "spl-type-length-value 0.9.1",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "spl-transfer-hook-interface"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa7503d52107c33c88e845e1351565050362c2314036ddf19a36cd25137c043"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive 0.4.2",
+ "num-traits",
+ "solana-account-info 2.3.0",
+ "solana-cpi 2.2.1",
+ "solana-decode-error",
+ "solana-instruction 2.3.3",
+ "solana-msg 2.2.1",
+ "solana-program-error 2.2.2",
+ "solana-pubkey 2.4.0",
+ "spl-discriminator 0.4.1",
+ "spl-pod 0.5.1",
+ "spl-program-error 0.6.0",
+ "spl-tlv-account-resolution 0.9.0",
+ "spl-type-length-value 0.7.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spl-transfer-hook-interface"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34b46b8f39bc64a9ab177a0ea8e9a58826db76f8d9d154a2400ee60baef7b1e"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive 0.4.2",
+ "num-traits",
+ "solana-account-info 3.1.1",
+ "solana-cpi 3.1.0",
+ "solana-instruction 3.2.0",
+ "solana-msg 3.1.0",
+ "solana-program-error 3.0.1",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids 3.1.0",
+ "solana-system-interface 2.0.0",
+ "spl-discriminator 0.5.2",
+ "spl-pod 0.7.3",
+ "spl-program-error 0.8.0",
+ "spl-tlv-account-resolution 0.11.1",
+ "spl-type-length-value 0.9.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "spl-type-length-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba70ef09b13af616a4c987797870122863cba03acc4284f226a4473b043923f9"
+dependencies = [
+ "bytemuck",
+ "num-derive 0.4.2",
+ "num-traits",
+ "solana-account-info 2.3.0",
+ "solana-decode-error",
+ "solana-msg 2.2.1",
+ "solana-program-error 2.2.2",
+ "spl-discriminator 0.4.1",
+ "spl-pod 0.5.1",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6209,7 +6940,7 @@ dependencies = [
  "solana-account-info 3.1.1",
  "solana-program-error 3.0.1",
  "solana-zero-copy",
- "spl-discriminator",
+ "spl-discriminator 0.5.2",
  "thiserror 2.0.18",
 ]
 
@@ -6242,7 +6973,7 @@ dependencies = [
  "solana-address 2.6.1",
  "solana-keypair",
  "solana-kite",
- "solana-signer",
+ "solana-signer 3.0.0",
  "wincode 0.5.5",
 ]
 
@@ -6339,6 +7070,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "token-2022-basic-anchor"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer 3.0.0",
+ "wincode 0.5.5",
+]
+
+[[package]]
 name = "token-2022-default-account-state-program"
 version = "0.1.0"
 dependencies = [
@@ -6426,6 +7172,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "token-minter"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer 3.0.0",
+ "wincode 0.5.5",
+]
+
+[[package]]
 name = "token-minter-native-program"
 version = "0.1.0"
 dependencies = [
@@ -6436,7 +7197,7 @@ dependencies = [
  "solana-instruction 3.2.0",
  "solana-keypair",
  "solana-native-token 3.0.0",
- "solana-program 2.3.0",
+ "solana-program 3.0.0",
  "solana-program 4.0.0",
  "solana-pubkey 3.0.0",
  "solana-system-interface 2.0.0",
@@ -6485,6 +7246,111 @@ dependencies = [
 ]
 
 [[package]]
+name = "transfer-fee"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer 3.0.0",
+ "wincode 0.5.5",
+]
+
+[[package]]
+name = "transfer-hook-account-data-as-seed"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer 3.0.0",
+ "spl-discriminator 0.4.1",
+ "spl-tlv-account-resolution 0.9.0",
+ "spl-transfer-hook-interface 0.9.0",
+ "wincode 0.5.5",
+]
+
+[[package]]
+name = "transfer-hook-counter"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer 3.0.0",
+ "spl-discriminator 0.4.1",
+ "spl-tlv-account-resolution 0.9.0",
+ "spl-transfer-hook-interface 0.9.0",
+ "wincode 0.5.5",
+]
+
+[[package]]
+name = "transfer-hook-hello-world"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer 3.0.0",
+ "spl-discriminator 0.4.1",
+ "spl-tlv-account-resolution 0.9.0",
+ "spl-transfer-hook-interface 0.9.0",
+ "wincode 0.5.5",
+]
+
+[[package]]
+name = "transfer-hook-transfer-cost"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer 3.0.0",
+ "spl-discriminator 0.5.2",
+ "spl-tlv-account-resolution 0.11.1",
+ "spl-transfer-hook-interface 2.1.0",
+ "wincode 0.5.5",
+]
+
+[[package]]
+name = "transfer-hook-whitelist"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer 3.0.0",
+ "spl-discriminator 0.4.1",
+ "spl-tlv-account-resolution 0.9.0",
+ "spl-transfer-hook-interface 0.9.0",
+ "wincode 0.5.5",
+]
+
+[[package]]
 name = "transfer-sol"
 version = "0.1.0"
 dependencies = [
@@ -6492,7 +7358,7 @@ dependencies = [
  "litesvm",
  "solana-keypair",
  "solana-kite",
- "solana-signer",
+ "solana-signer 3.0.0",
  "wincode 0.5.5",
 ]
 
@@ -6528,6 +7394,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "transfer-switch"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer 3.0.0",
+ "spl-discriminator 0.4.1",
+ "spl-tlv-account-resolution 0.9.0",
+ "spl-transfer-hook-interface 0.9.0",
+ "wincode 0.5.5",
+]
+
+[[package]]
+name = "transfer-tokens"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "borsh 1.7.0",
+ "litesvm",
+ "solana-address 2.6.1",
+ "solana-keypair",
+ "solana-kite",
+ "solana-signer 3.0.0",
+ "wincode 0.5.5",
+]
+
+[[package]]
 name = "transfer-tokens-program"
 version = "0.1.0"
 dependencies = [
@@ -6538,7 +7437,7 @@ dependencies = [
  "solana-instruction 3.2.0",
  "solana-keypair",
  "solana-native-token 3.0.0",
- "solana-program 2.3.0",
+ "solana-program 3.0.0",
  "solana-program 4.0.0",
  "solana-pubkey 3.0.0",
  "solana-system-interface 2.0.0",
@@ -6608,7 +7507,7 @@ dependencies = [
  "solana-clock 3.1.1",
  "solana-keypair",
  "solana-kite",
- "solana-signer",
+ "solana-signer 3.0.0",
  "wincode 0.5.5",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,23 @@ members = [
     "basics/transfer-sol/asm",
 
     # finance
+    #
+    # Each of these also sits under its project's own `anchor/Cargo.toml`
+    # workspace, which is what `anchor build` uses. Listing them here as well
+    # puts them in front of the repository-wide `cargo fmt` and `cargo clippy`
+    # jobs, which only ever see members of this workspace.
+    #
+    # The two `mock-switchboard` crates are excluded below: they share a package
+    # name, and one workspace cannot hold two packages called the same thing.
+    # They stay path dependencies of the programs that test against them.
+    "finance/betting-market/anchor/programs/betting-market",
+    "finance/escrow/anchor/programs/escrow",
+    "finance/lending/anchor/programs/lending",
+    "finance/order-book/anchor/programs/order-book",
+    "finance/perpetual-futures/anchor/programs/perpetual-futures",
+    "finance/prop-amm/anchor/programs/prop-amm",
+    "finance/token-fundraiser/anchor/programs/fundraiser",
+    "finance/token-swap/anchor/programs/token-swap",
     "finance/vault-strategy/anchor/programs/vault-strategy",
     "finance/vault-strategy/anchor/programs/mock-swap-router",
 
@@ -65,6 +82,13 @@ members = [
     "tokens/transfer-tokens/native/program",
     "tokens/nft-minter/native/program",
     "tokens/pda-mint-authority/native/program",
+]
+# A path dependency inside the workspace directory joins the workspace unless it
+# is excluded. Both of these are named `mock_switchboard`, so leaving them in
+# fails with "two packages named `mock_switchboard` in this workspace".
+exclude = [
+    "finance/perpetual-futures/anchor/programs/mock-switchboard",
+    "finance/prop-amm/anchor/programs/mock-switchboard",
 ]
 resolver = "2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,8 @@
 [workspace]
+# Every anchor program is listed twice: here, and in its own project's
+# `anchor/Cargo.toml` workspace. `anchor build` uses the project workspace; this
+# one is what the repository-wide `cargo fmt` and `cargo clippy` jobs see, and
+# they only ever look at members. A crate missing here is a crate CI never lints.
 members = [
     #basics
     "basics/account-data/native/program",
@@ -42,6 +46,8 @@ members = [
     "basics/rent/anchor/programs/*",
     "basics/favorites/native/program",
     "basics/favorites/pinocchio/program",
+    "basics/favorites/anchor/programs/favorites",
+    "basics/pyth/anchor/programs/pythexample",
     "basics/repository-layout/native/program",
     "basics/repository-layout/pinocchio/program",
     "basics/repository-layout/anchor/programs/*",
@@ -50,12 +56,12 @@ members = [
     "basics/transfer-sol/anchor/programs/*",
     "basics/transfer-sol/asm",
 
+    # compression
+    "compression/cnft-burn/anchor/programs/cnft-burn",
+    "compression/cnft-vault/anchor/programs/cnft-vault",
+    "compression/cutils/anchor/programs/cutils",
+
     # finance
-    #
-    # Each of these also sits under its project's own `anchor/Cargo.toml`
-    # workspace, which is what `anchor build` uses. Listing them here as well
-    # puts them in front of the repository-wide `cargo fmt` and `cargo clippy`
-    # jobs, which only ever see members of this workspace.
     #
     # The two `mock-switchboard` crates are excluded below: they share a package
     # name, and one workspace cannot hold two packages called the same thing.
@@ -82,6 +88,33 @@ members = [
     "tokens/transfer-tokens/native/program",
     "tokens/nft-minter/native/program",
     "tokens/pda-mint-authority/native/program",
+    "tokens/create-token/anchor/programs/create-token",
+    "tokens/external-delegate-token-master/anchor/programs/external-delegate-token-master",
+    "tokens/nft-minter/anchor/programs/nft-minter",
+    "tokens/nft-operations/anchor/programs/mint-nft",
+    "tokens/pda-mint-authority/anchor/programs/token-minter",
+    "tokens/token-minter/anchor/programs/token-minter",
+    "tokens/transfer-tokens/anchor/programs/transfer-tokens",
+    "tokens/token-extensions/basics/anchor/programs/basics",
+    "tokens/token-extensions/cpi-guard/anchor/programs/cpi-guard",
+    "tokens/token-extensions/default-account-state/anchor/programs/default-account-state",
+    "tokens/token-extensions/group/anchor/programs/group",
+    "tokens/token-extensions/immutable-owner/anchor/programs/immutable-owner",
+    "tokens/token-extensions/interest-bearing/anchor/programs/interest-bearing",
+    "tokens/token-extensions/memo-transfer/anchor/programs/memo-transfer",
+    "tokens/token-extensions/metadata/anchor/programs/metadata",
+    "tokens/token-extensions/mint-close-authority/anchor/programs/mint-close-authority",
+    "tokens/token-extensions/nft-meta-data-pointer/anchor-example/anchor/programs/extension_nft",
+    "tokens/token-extensions/non-transferable/anchor/programs/non-transferable",
+    "tokens/token-extensions/permanent-delegate/anchor/programs/permanent-delegate",
+    "tokens/token-extensions/transfer-fee/anchor/programs/transfer-fee",
+    "tokens/token-extensions/transfer-hook/account-data-as-seed/anchor/programs/transfer-hook",
+    "tokens/token-extensions/transfer-hook/allow-block-list-token/anchor/programs/abl-token",
+    "tokens/token-extensions/transfer-hook/counter/anchor/programs/transfer-hook",
+    "tokens/token-extensions/transfer-hook/hello-world/anchor/programs/transfer-hook",
+    "tokens/token-extensions/transfer-hook/transfer-cost/anchor/programs/transfer-hook",
+    "tokens/token-extensions/transfer-hook/transfer-switch/anchor/programs/transfer-switch",
+    "tokens/token-extensions/transfer-hook/whitelist/anchor/programs/transfer-hook",
 ]
 # A path dependency inside the workspace directory joins the workspace unless it
 # is excluded. Both of these are named `mock_switchboard`, so leaving them in
@@ -100,7 +133,7 @@ overflow-checks = true
 # misc
 borsh = "1.6.1"
 borsh-derive = "1.5.7"
-mpl-token-metadata = { version = "5.1.1", features = [ "no-entrypoint" ] }
+mpl-token-metadata = { version = "=5.1.2-alpha.2", features = [ "no-entrypoint" ] }
 
 
 # spl

--- a/compression/cutils/anchor/programs/cutils/src/instructions/mint.rs
+++ b/compression/cutils/anchor/programs/cutils/src/instructions/mint.rs
@@ -10,7 +10,7 @@ use anchor_lang::solana_program::{
 use borsh::BorshSerialize;
 
 #[derive(Accounts)]
-#[instruction(params: MintParams)]
+#[instruction(_params: MintParams)]
 pub struct MintAccountConstraints {
     pub payer: Signer,
 
@@ -192,7 +192,10 @@ pub fn handle_mint(
         context.accounts.payer.cpi_handle(),
         context.accounts.tree_delegate.cpi_handle(),
         context.accounts.collection_authority.cpi_handle(),
-        context.accounts.collection_authority_record_pda.cpi_handle(),
+        context
+            .accounts
+            .collection_authority_record_pda
+            .cpi_handle(),
         context.accounts.collection_mint.cpi_handle(),
         context.accounts.collection_metadata.cpi_handle_mut().into(),
         context.accounts.edition_account.cpi_handle(),
@@ -202,7 +205,6 @@ pub fn handle_mint(
         context.accounts.token_metadata_program.cpi_handle(),
         context.accounts.system_program.cpi_handle(),
     ];
-
 
     invoke(&instruction, &account_infos)?;
 

--- a/compression/cutils/anchor/programs/cutils/src/instructions/verify.rs
+++ b/compression/cutils/anchor/programs/cutils/src/instructions/verify.rs
@@ -3,7 +3,7 @@ use crate::*;
 use anchor_lang::solana_program::instruction::{AccountMeta, Instruction};
 
 #[derive(Accounts)]
-#[instruction(params: VerifyParams)]
+#[instruction(_params: VerifyParams)]
 pub struct VerifyAccountConstraints {
     pub leaf_owner: Signer,
 
@@ -40,11 +40,11 @@ pub fn handle_verify(
     // and the proof accounts stay alive for the CPI below.
     let proof_accounts = context.remaining_accounts()?;
 
-    let asset_id = get_asset_id(&context.accounts.merkle_tree.address(), params.nonce);
+    let asset_id = get_asset_id(context.accounts.merkle_tree.address(), params.nonce);
     let leaf_hash = leaf_schema_v1_hash(
         &asset_id,
-        &context.accounts.leaf_owner.address(),
-        &context.accounts.leaf_delegate.address(),
+        context.accounts.leaf_owner.address(),
+        context.accounts.leaf_delegate.address(),
         params.nonce,
         &params.data_hash,
         &params.creator_hash,

--- a/docs/anchor-v2-migration.md
+++ b/docs/anchor-v2-migration.md
@@ -207,6 +207,15 @@ Three ways this goes wrong:
    That includes the derive's own use of the account after the handler returns:
    `associated_token::authority = event`, `address = event.x` and friends all
    deref it. So the reacquire has to happen before the handler ends.
+
+   It also means the *seed material* has to be read before the release, since
+   reading `event.event_id` is a deref. Where a helper needs it, copy the fields
+   into a small struct while the borrow is live and pass that, so the ordering is
+   enforced by having to construct the struct first. `betting-market`'s
+   `EventSigner::new` is this; three handlers there sign a transfer for the event
+   PDA and all three would panic if they read `event_id` a line later. Clippy
+   pushes the other way here, because passing the fields individually is what
+   trips `too_many_arguments` on the helper: bundling them satisfies both.
 2. **Release and reacquire must be on the same branch.** Releasing inside
    `if fee > 0` and reacquiring unconditionally re-borrows an account you still
    hold.

--- a/finance/betting-market/anchor/programs/betting-market/src/instructions/claim_refund.rs
+++ b/finance/betting-market/anchor/programs/betting-market/src/instructions/claim_refund.rs
@@ -6,7 +6,7 @@ use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
 
 use crate::{error::BettingError, Bet, EventStatus, User};
 
-use super::transfer_tokens_from_vault;
+use super::{transfer_tokens_from_vault, EventSigner};
 
 #[derive(Accounts)]
 pub struct ClaimRefundAccountConstraints {
@@ -75,24 +75,21 @@ pub fn handle_claim_refund(context: &mut Context<ClaimRefundAccountConstraints>)
     // transfer (effects before interactions); the Bet account itself closes
     // when the instruction finishes.
     let bet_key = context.accounts.bet.address();
-    context.accounts.user.remove_bet(&bet_key)?;
+    context.accounts.user.remove_bet(bet_key)?;
 
-    let event_id = context.accounts.event.event_id;
-    let event_bump = context.accounts.event.bump;
+    // Gather the signing material before the borrow goes away.
+    let event_signer = EventSigner::new(&context.accounts.event);
     // `event` signs the transfer below. Release its borrow across
     // the CPI: the runtime rejects a CPI that borrows an account we hold.
     context.accounts.event.release_borrow()?;
-    let event_view = *context.accounts.event.account();
 
     transfer_tokens_from_vault(
         &mut context.accounts.vault,
         &mut context.accounts.bettor_token_account,
         stake,
         &context.accounts.token_mint,
-        event_view,
+        &event_signer,
         &context.accounts.token_program,
-        event_id,
-        event_bump,
     )?;
 
     // Take the borrow back before the derive's exit path touches `event` again.

--- a/finance/betting-market/anchor/programs/betting-market/src/instructions/claim_winnings.rs
+++ b/finance/betting-market/anchor/programs/betting-market/src/instructions/claim_winnings.rs
@@ -6,7 +6,7 @@ use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
 
 use crate::{error::BettingError, Bet, EventStatus, User};
 
-use super::transfer_tokens_from_vault;
+use super::{transfer_tokens_from_vault, EventSigner};
 
 #[derive(Accounts)]
 pub struct ClaimWinningsAccountConstraints {
@@ -100,24 +100,21 @@ pub fn handle_claim_winnings(context: &mut Context<ClaimWinningsAccountConstrain
     // transfer (effects before interactions); the Bet account itself closes
     // when the instruction finishes.
     let bet_key = context.accounts.bet.address();
-    context.accounts.user.remove_bet(&bet_key)?;
+    context.accounts.user.remove_bet(bet_key)?;
 
-    let event_id = context.accounts.event.event_id;
-    let event_bump = context.accounts.event.bump;
+    // Gather the signing material before the borrow goes away.
+    let event_signer = EventSigner::new(&context.accounts.event);
     // `event` signs the transfer below. Release its borrow across
     // the CPI: the runtime rejects a CPI that borrows an account we hold.
     context.accounts.event.release_borrow()?;
-    let event_view = *context.accounts.event.account();
 
     transfer_tokens_from_vault(
         &mut context.accounts.vault,
         &mut context.accounts.bettor_token_account,
         payout,
         &context.accounts.token_mint,
-        event_view,
+        &event_signer,
         &context.accounts.token_program,
-        event_id,
-        event_bump,
     )?;
 
     // Take the borrow back before the derive's exit path touches `event` again.

--- a/finance/betting-market/anchor/programs/betting-market/src/instructions/close_losing_bet.rs
+++ b/finance/betting-market/anchor/programs/betting-market/src/instructions/close_losing_bet.rs
@@ -49,6 +49,6 @@ pub fn handle_close_losing_bet(
     );
 
     let bet_key = context.accounts.bet.address();
-    context.accounts.user.remove_bet(&bet_key)?;
+    context.accounts.user.remove_bet(bet_key)?;
     Ok(())
 }

--- a/finance/betting-market/anchor/programs/betting-market/src/instructions/initialize_event.rs
+++ b/finance/betting-market/anchor/programs/betting-market/src/instructions/initialize_event.rs
@@ -12,7 +12,10 @@ use crate::{error::BettingError, Config, EventStatus};
 pub const MAX_DESCRIPTION_LEN: usize = 200;
 
 #[derive(Accounts)]
-#[instruction(event_id: u64)]
+// The leading underscore is for rustc: `#[derive(Accounts)]` expands
+// `_event_id` into a path that never reads it, so the plain name warns as
+// unused. The `seeds` expression below is the real use.
+#[instruction(_event_id: u64)]
 pub struct InitializeEventAccountConstraints {
     #[account(mut, address = config.admin @ BettingError::Unauthorized)]
     pub admin: Signer,
@@ -29,7 +32,7 @@ pub struct InitializeEventAccountConstraints {
         init,
         payer = admin,
         space = Event::DISCRIMINATOR.len() + Event::INIT_SPACE,
-        seeds = [b"event", event_id.to_le_bytes()],
+        seeds = [b"event", _event_id.to_le_bytes()],
         bump
     )]
     pub event: BorshAccount<Event>,

--- a/finance/betting-market/anchor/programs/betting-market/src/instructions/settle_event.rs
+++ b/finance/betting-market/anchor/programs/betting-market/src/instructions/settle_event.rs
@@ -9,12 +9,15 @@ use anchor_spl::{
 
 use crate::{error::BettingError, Config, EventStatus, Outcome};
 
-use super::transfer_tokens_from_vault;
+use super::{transfer_tokens_from_vault, EventSigner};
 
 const BPS_DENOMINATOR: u128 = 10_000;
 
 #[derive(Accounts)]
-#[instruction(winning_outcome_index: u8)]
+// The leading underscore is for rustc: `#[derive(Accounts)]` expands
+// `_winning_outcome_index` into a path that never reads it, so the plain name warns as
+// unused. The `seeds` expression below is the real use.
+#[instruction(_winning_outcome_index: u8)]
 pub struct SettleEventAccountConstraints {
     #[account(mut, address = config.admin @ BettingError::Unauthorized)]
     pub admin: Signer,
@@ -35,7 +38,7 @@ pub struct SettleEventAccountConstraints {
     pub event: BorshAccount<Event>,
 
     #[account(
-        seeds = [b"outcome", event.address().as_ref(), &[winning_outcome_index]],
+        seeds = [b"outcome", event.address().as_ref(), &[_winning_outcome_index]],
         bump = winning_outcome.bump,
     )]
     pub winning_outcome: BorshAccount<Outcome>,
@@ -90,22 +93,19 @@ pub fn handle_settle_event(
     let distributable_losing_pool = losing_pool - fee;
 
     if fee > 0 {
-        let event_id = context.accounts.event.event_id;
-        let event_bump = context.accounts.event.bump;
+        // Gather the signing material before the borrow goes away.
+        let event_signer = EventSigner::new(&context.accounts.event);
         // `event` signs the transfer below. Release its borrow across the CPI:
         // the runtime rejects a CPI that borrows an account we still hold.
         context.accounts.event.release_borrow()?;
-        let event_view = *context.accounts.event.account();
 
         transfer_tokens_from_vault(
             &mut context.accounts.vault,
             &mut context.accounts.fee_recipient_token_account,
             fee,
             &context.accounts.token_mint,
-            event_view,
+            &event_signer,
             &context.accounts.token_program,
-            event_id,
-            event_bump,
         )?;
 
         // Take the borrow back before writing the settled state through it.

--- a/finance/betting-market/anchor/programs/betting-market/src/instructions/shared.rs
+++ b/finance/betting-market/anchor/programs/betting-market/src/instructions/shared.rs
@@ -27,6 +27,33 @@ pub fn transfer_tokens_to_vault(
     transfer_checked(cpi_context, amount, decimals)
 }
 
+/// Everything needed to sign for the Event PDA, copied out of the account
+/// while its borrow is still live.
+///
+/// `transfer_tokens_from_vault` runs a CPI the event signs for, and the runtime
+/// rejects a CPI that borrows an account the program is holding, so the caller
+/// has to `release_borrow()` first. `BorshAccount` derefs into the loaded copy,
+/// and that deref panics once the borrow is released, so the two fields have to
+/// be read before that happens. Gathering them here makes the ordering a matter
+/// of calling `new` before `release_borrow`.
+pub struct EventSigner {
+    view: AccountView,
+    id: u64,
+    bump: u8,
+}
+
+impl EventSigner {
+    /// Read the event's signing material. Call this **before**
+    /// `event.release_borrow()`.
+    pub fn new(event: &BorshAccount<Event>) -> Self {
+        Self {
+            view: *event.account(),
+            id: event.event_id,
+            bump: event.bump,
+        }
+    }
+}
+
 // Move tokens out of the vault, signed by the Event PDA. The event vault's
 // authority is the Event account, so the program signs with the event's seeds.
 pub fn transfer_tokens_from_vault(
@@ -34,13 +61,11 @@ pub fn transfer_tokens_from_vault(
     to: &mut InterfaceAccount<TokenAccount>,
     amount: u64,
     mint: &InterfaceAccount<Mint>,
-    event: AccountView,
+    event: &EventSigner,
     token_program: &Interface<'static, TokenInterface>,
-    event_id: u64,
-    event_bump: u8,
 ) -> Result<()> {
-    let event_id_bytes = event_id.to_le_bytes();
-    let seeds = &[b"event".as_ref(), event_id_bytes.as_ref(), &[event_bump]];
+    let event_id_bytes = event.id.to_le_bytes();
+    let seeds = &[b"event".as_ref(), event_id_bytes.as_ref(), &[event.bump]];
     let signer_seeds = [&seeds[..]];
 
     let decimals = mint.decimals();
@@ -48,7 +73,7 @@ pub fn transfer_tokens_from_vault(
         from: vault.cpi_handle_mut(),
         mint: mint.cpi_handle(),
         to: to.cpi_handle_mut(),
-        authority: CpiHandle::readonly(&event),
+        authority: CpiHandle::readonly(&event.view),
     };
     let cpi_context =
         CpiContext::new_with_signer(token_program.address(), transfer_accounts, &signer_seeds);

--- a/finance/escrow/anchor/programs/escrow/src/instructions/make_offer.rs
+++ b/finance/escrow/anchor/programs/escrow/src/instructions/make_offer.rs
@@ -12,7 +12,10 @@ use super::transfer_tokens;
 
 // See https://www.anchor-lang.com/docs/references/account-constraints#instruction-attribute
 #[derive(Accounts)]
-#[instruction(id: u64)]
+// The leading underscore is for rustc: `#[derive(Accounts)]` expands
+// `_id` into a path that never reads it, so the plain name warns as
+// unused. The `seeds` expression below is the real use.
+#[instruction(_id: u64)]
 pub struct MakeOfferAccountConstraints {
     #[account(mut)]
     pub maker: Signer,
@@ -47,7 +50,7 @@ pub struct MakeOfferAccountConstraints {
         init,
         payer = maker,
         space = Offer::DISCRIMINATOR.len() + Offer::INIT_SPACE,
-        seeds = [b"offer", maker.address().as_ref(), id.to_le_bytes()],
+        seeds = [b"offer", maker.address().as_ref(), _id.to_le_bytes()],
         bump
     )]
     pub offer: BorshAccount<Offer>,

--- a/finance/lending/anchor/programs/lending/src/instructions/admin/initialize_lending_market.rs
+++ b/finance/lending/anchor/programs/lending/src/instructions/admin/initialize_lending_market.rs
@@ -17,7 +17,10 @@ pub fn handle_initialize_lending_market(
 }
 
 #[derive(Accounts)]
-#[instruction(market_id: u64)]
+// The leading underscore is for rustc: `#[derive(Accounts)]` expands
+// `_market_id` into a path that never reads it, so the plain name warns as
+// unused. The `seeds` expression below is the real use.
+#[instruction(_market_id: u64)]
 pub struct InitializeLendingMarket {
     // Seeded by `market_id` alone — the market is not identified by any
     // individual's address. `owner` is stored as a field and used only for
@@ -26,7 +29,7 @@ pub struct InitializeLendingMarket {
         init,
         payer = owner,
         space = LendingMarket::DISCRIMINATOR.len() + LendingMarket::INIT_SPACE,
-        seeds = [LENDING_MARKET_SEED, &market_id.to_le_bytes()],
+        seeds = [LENDING_MARKET_SEED, &_market_id.to_le_bytes()],
         bump,
     )]
     pub lending_market: BorshAccount<LendingMarket>,

--- a/finance/order-book/anchor/programs/order-book/src/instructions/cancel_order.rs
+++ b/finance/order-book/anchor/programs/order-book/src/instructions/cancel_order.rs
@@ -58,10 +58,12 @@ pub fn handle_cancel_order(context: &mut Context<CancelOrderAccountConstraints>)
     // Remove the leaf from the slab. The current cancel API doesn't tell us
     // which side the order is on without reading the Order PDA - which we
     // already have, so use it.
-    let mut order_book = (&mut *context.accounts.order_book);
-    let removed = order_book.remove_from(order.side, order.order_id).is_some();
+    let removed = context
+        .accounts
+        .order_book
+        .remove_from(order.side, order.order_id)
+        .is_some();
     require!(removed, ErrorCode::OrderNotFound);
-    drop(order_book);
 
     let market_user = &mut context.accounts.market_user;
     remove_open_order(market_user, order.order_id);

--- a/finance/order-book/anchor/programs/order-book/src/instructions/place_order.rs
+++ b/finance/order-book/anchor/programs/order-book/src/instructions/place_order.rs
@@ -45,7 +45,10 @@ pub fn handle_place_order(
 
     require!(market.is_active, ErrorCode::MarketPaused);
     require!(price > 0, ErrorCode::InvalidPrice);
-    require!(price % market.tick_size == 0, ErrorCode::InvalidTickSize);
+    require!(
+        price.is_multiple_of(market.tick_size),
+        ErrorCode::InvalidTickSize
+    );
     require!(
         quantity >= market.min_order_size,
         ErrorCode::BelowMinOrderSize
@@ -130,8 +133,8 @@ pub fn handle_place_order(
     // RefCell-based runtime borrow, so the loaded ref must not outlive the
     // plan we copy out of it.
     let (fills, taker_remaining) = {
-        let order_book = (&*order_book_loader);
-        plan_fills(&order_book, side, price, quantity)
+        let order_book = &*order_book_loader;
+        plan_fills(order_book, side, price, quantity)
     };
 
     require!(
@@ -345,7 +348,7 @@ pub fn handle_place_order(
     };
 
     {
-        let mut order_book = (&mut *order_book_loader);
+        let order_book = &mut *order_book_loader;
         for fill in &fills {
             order_book.apply_fill_to_maker(
                 maker_side,
@@ -414,7 +417,7 @@ pub fn handle_place_order(
     // ---------------------------------------------------------------
     let timestamp = Clock::get()?.unix_timestamp;
     let order_id = {
-        let mut order_book = (&mut *order_book_loader);
+        let order_book = &mut *order_book_loader;
         let id = order_book.allocate_order_id()?;
         if taker_remaining > 0 {
             require!(!order_book.is_side_full(side), ErrorCode::OrderBookFull);
@@ -462,7 +465,7 @@ pub fn handle_place_order(
 }
 
 #[derive(Accounts)]
-#[instruction(side: OrderSide, price: u64, quantity: u64)]
+#[instruction(_side: OrderSide, _price: u64, _quantity: u64)]
 pub struct PlaceOrderAccountConstraints {
     // `address` ties every market-owned account on this struct to the
     // addresses recorded on the Market PDA. Crucially, without
@@ -492,7 +495,7 @@ pub struct PlaceOrderAccountConstraints {
         seeds = [
             ORDER_SEED,
             market.address().as_ref(),
-            (&*order_book).next_order_id.to_le_bytes()
+            order_book.next_order_id.to_le_bytes()
         ],
         bump
     )]

--- a/finance/order-book/anchor/programs/order-book/src/state/order_book.rs
+++ b/finance/order-book/anchor/programs/order-book/src/state/order_book.rs
@@ -102,7 +102,7 @@ impl OrderBook {
         self.next_order_id = self
             .next_order_id
             .checked_add(1)
-            .ok_or_else(|| ErrorCode::NumericalOverflow)?;
+            .ok_or(ErrorCode::NumericalOverflow)?;
         Ok(id)
     }
 
@@ -221,11 +221,11 @@ impl OrderBook {
         let (handle, remaining_after) = {
             let (handle, leaf) = nodes
                 .find_by_key(root, key)
-                .ok_or_else(|| ErrorCode::OrderNotFound)?;
+                .ok_or(ErrorCode::OrderNotFound)?;
             let remaining = leaf
                 .quantity
                 .checked_sub(fill_quantity)
-                .ok_or_else(|| ErrorCode::NumericalOverflow)?;
+                .ok_or(ErrorCode::NumericalOverflow)?;
             (handle, remaining)
         };
         if remaining_after == 0 {
@@ -237,7 +237,7 @@ impl OrderBook {
             let leaf = nodes
                 .node_mut(handle)
                 .and_then(AnyNode::as_leaf_mut)
-                .ok_or_else(|| ErrorCode::OrderNotFound)?;
+                .ok_or(ErrorCode::OrderNotFound)?;
             leaf.quantity = remaining_after;
         }
         Ok(())
@@ -247,15 +247,6 @@ impl OrderBook {
         match side {
             OrderSide::Bid => self.bids.is_full(),
             OrderSide::Ask => self.asks.is_full(),
-        }
-    }
-}
-
-impl Default for OrderTreeRoot {
-    fn default() -> Self {
-        Self {
-            maybe_node: 0,
-            leaf_count: 0,
         }
     }
 }

--- a/finance/order-book/anchor/programs/order-book/src/state/slab/nodes.rs
+++ b/finance/order-book/anchor/programs/order-book/src/state/slab/nodes.rs
@@ -258,7 +258,7 @@ pub enum NodeRefMut<'a> {
 }
 
 impl AnyNode {
-    pub fn case(&self) -> Option<NodeRef> {
+    pub fn case(&self) -> Option<NodeRef<'_>> {
         match NodeTag::from_u8(self.tag)? {
             NodeTag::InnerNode => Some(NodeRef::Inner(cast_ref(self))),
             NodeTag::LeafNode => Some(NodeRef::Leaf(cast_ref(self))),
@@ -266,7 +266,7 @@ impl AnyNode {
         }
     }
 
-    pub fn case_mut(&mut self) -> Option<NodeRefMut> {
+    pub fn case_mut(&mut self) -> Option<NodeRefMut<'_>> {
         match NodeTag::from_u8(self.tag)? {
             NodeTag::InnerNode => Some(NodeRefMut::Inner(cast_mut(self))),
             NodeTag::LeafNode => Some(NodeRefMut::Leaf(cast_mut(self))),

--- a/finance/order-book/anchor/programs/order-book/src/state/slab/ordertree.rs
+++ b/finance/order-book/anchor/programs/order-book/src/state/slab/ordertree.rs
@@ -22,7 +22,7 @@ pub const MAX_TREE_NODES: usize = 1024;
 ///
 /// `maybe_node` is only meaningful when `leaf_count > 0` - a freshly-zeroed
 /// root represents an empty tree.
-#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+#[derive(Copy, Clone, Default, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 pub struct OrderTreeRoot {
     pub maybe_node: NodeHandle,
@@ -279,9 +279,7 @@ impl OrderTreeNodes {
         let mut stack: Vec<(NodeHandle, bool)> = vec![];
 
         loop {
-            let parent_contents = *self
-                .node(parent_handle)
-                .ok_or_else(|| ErrorCode::OrderBookFull)?;
+            let parent_contents = *self.node(parent_handle).ok_or(ErrorCode::OrderBookFull)?;
             let parent_key = parent_contents.key().unwrap();
 
             // Exact-key collision: only possible if the existing slot is a

--- a/finance/order-book/anchor/programs/order-book/tests/test_order_book.rs
+++ b/finance/order-book/anchor/programs/order-book/tests/test_order_book.rs
@@ -17,7 +17,11 @@ use {
         },
         // `system_program` moved to the crate root in v2, and `Pubkey` is
         // compat-only: `Address` is the same 32-byte type.
-        system_program, Address, Discriminator, InstructionData, ToAccountMetas,
+        system_program,
+        Address,
+        Discriminator,
+        InstructionData,
+        ToAccountMetas,
     },
     litesvm::LiteSVM,
     solana_keypair::Keypair,

--- a/finance/perpetual-futures/anchor/programs/perpetual-futures/src/instructions/open_position.rs
+++ b/finance/perpetual-futures/anchor/programs/perpetual-futures/src/instructions/open_position.rs
@@ -126,7 +126,10 @@ pub fn handle_open_position(
 }
 
 #[derive(Accounts)]
-#[instruction(side: Side)]
+// The leading underscore is for rustc: `#[derive(Accounts)]` expands
+// `_side` into a path that never reads it, so the plain name warns as
+// unused. The `seeds` expression below is the real use.
+#[instruction(_side: Side)]
 pub struct OpenPositionAccountConstraints {
     #[account(mut)]
     pub owner: Signer,
@@ -142,7 +145,7 @@ pub struct OpenPositionAccountConstraints {
         init,
         payer = owner,
         space = Position::DISCRIMINATOR.len() + Position::INIT_SPACE,
-        seeds = [POSITION_SEED, pool.address().as_ref(), owner.address().as_ref(), side.as_seed()],
+        seeds = [POSITION_SEED, pool.address().as_ref(), owner.address().as_ref(), _side.as_seed()],
         bump,
     )]
     pub position: Box<BorshAccount<Position>>,

--- a/finance/prop-amm/anchor/programs/mock-switchboard/Cargo.toml
+++ b/finance/prop-amm/anchor/programs/mock-switchboard/Cargo.toml
@@ -1,5 +1,10 @@
 [package]
-name = "mock_switchboard"
+# The perpetual-futures project has a mock of the same feed. Two path packages
+# with one name cannot both appear in a lockfile, and the repository-root
+# workspace pulls both in, so the package names differ. `[lib] name` stays
+# `mock_switchboard`, which is what Anchor.toml, the IDL and the .so are keyed
+# on, and the dependent renames it back with `package = `.
+name = "mock_switchboard_prop_amm"
 version = "0.1.0"
 description = "Mock Switchboard On-Demand feed for testing the prop-amm program"
 edition = "2021"

--- a/finance/prop-amm/anchor/programs/prop-amm/Cargo.toml
+++ b/finance/prop-amm/anchor/programs/prop-amm/Cargo.toml
@@ -54,7 +54,7 @@ solana-kite = "0.4.0"
 borsh = "1.6.1"
 # The LiteSVM tests load the compiled mock oracle program; depending on the
 # crate here lets the tests reuse its instruction-argument types and program ID.
-mock_switchboard = { path = "../mock-switchboard", features = ["no-entrypoint"] }
+mock_switchboard = { package = "mock_switchboard_prop_amm", path = "../mock-switchboard", features = ["no-entrypoint"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_os, values("solana"))'] }

--- a/finance/token-fundraiser/anchor/programs/fundraiser/src/lib.rs
+++ b/finance/token-fundraiser/anchor/programs/fundraiser/src/lib.rs
@@ -16,7 +16,7 @@ pub mod fundraiser {
     use super::*;
 
     pub fn initialize_fundraiser(
-        mut context: &mut Context<InitializeFundraiserAccountConstraints>,
+        context: &mut Context<InitializeFundraiserAccountConstraints>,
         amount: u64,
         duration: u16,
     ) -> Result<()> {
@@ -26,7 +26,7 @@ pub mod fundraiser {
     }
 
     pub fn contribute(
-        mut context: &mut Context<ContributeAccountConstraints>,
+        context: &mut Context<ContributeAccountConstraints>,
         amount: u64,
     ) -> Result<()> {
         handle_contribute(&mut context.accounts, amount, &context.bumps)?;
@@ -35,21 +35,21 @@ pub mod fundraiser {
     }
 
     pub fn check_contributions(
-        mut context: &mut Context<CheckContributionsAccountConstraints>,
+        context: &mut Context<CheckContributionsAccountConstraints>,
     ) -> Result<()> {
         handle_check_contributions(&mut context.accounts)?;
 
         Ok(())
     }
 
-    pub fn refund(mut context: &mut Context<RefundAccountConstraints>) -> Result<()> {
+    pub fn refund(context: &mut Context<RefundAccountConstraints>) -> Result<()> {
         handle_refund(&mut context.accounts)?;
 
         Ok(())
     }
 
     pub fn close_fundraiser(
-        mut context: &mut Context<CloseFundraiserAccountConstraints>,
+        context: &mut Context<CloseFundraiserAccountConstraints>,
     ) -> Result<()> {
         handle_close_fundraiser(&mut context.accounts)?;
 

--- a/finance/token-swap/anchor/programs/token-swap/Cargo.toml
+++ b/finance/token-swap/anchor/programs/token-swap/Cargo.toml
@@ -29,7 +29,7 @@ wincode = { version = "0.5", features = ["derive"] }
 # belong to the version the account derives are not using and every
 # `SchemaRead`/`SchemaWrite` bound fails. 2.6.1 is the last 0.5-line release.
 solana-address = ">=2.6, <2.7"
-anchor-spl = { version = "2.0.0-rc.1", features = ["metadata"] }
+anchor-spl = "2.0.0-rc.1"
 # `fixed` removed: all financial math is now u128 + checked_*, matching how
 # production Solana AMMs (Orca, Raydium, Meteora, Saber) do it. Floats /
 # fixed-point types are not used for money in this program.

--- a/finance/token-swap/anchor/programs/token-swap/src/instructions/deposit_liquidity.rs
+++ b/finance/token-swap/anchor/programs/token-swap/src/instructions/deposit_liquidity.rs
@@ -19,7 +19,7 @@ fn integer_sqrt(n: u128) -> u128 {
         return n;
     }
     let mut x = n;
-    let mut y = (x + 1) / 2;
+    let mut y = x.div_ceil(2);
     while y < x {
         x = y;
         y = (x + n / x) / 2;
@@ -236,7 +236,10 @@ pub fn handle_deposit_liquidity(
             context.accounts.token_program.address(),
             MintTo {
                 mint: context.accounts.liquidity_provider_mint.to_cpi_handle_mut(),
-                to: context.accounts.liquidity_provider_token.to_cpi_handle_mut(),
+                to: context
+                    .accounts
+                    .liquidity_provider_token
+                    .to_cpi_handle_mut(),
                 authority: context.accounts.pool_authority.cpi_handle(),
             },
             signer_seeds,

--- a/finance/token-swap/anchor/programs/token-swap/src/instructions/initialize_config.rs
+++ b/finance/token-swap/anchor/programs/token-swap/src/instructions/initialize_config.rs
@@ -21,8 +21,11 @@ pub fn handle_initialize_config(
     Ok(())
 }
 
+// The leading underscores are for rustc: `#[derive(Accounts)]` expands these
+// into a path that never reads them, so the plain names warn as unused. The
+// `constraint` expressions below are the real use.
 #[derive(Accounts)]
-#[instruction(fee: u16, admin_share_bps: u16)]
+#[instruction(_fee: u16, _admin_share_bps: u16)]
 pub struct InitializeConfigAccountConstraints {
     #[account(
         init,
@@ -30,8 +33,8 @@ pub struct InitializeConfigAccountConstraints {
         space = Config::DISCRIMINATOR.len() + Config::INIT_SPACE,
         seeds = [CONFIG_SEED],
         bump,
-        constraint = (fee as u64) < BASIS_POINTS_DIVISOR @ AmmError::InvalidFee,
-        constraint = (admin_share_bps as u64) < BASIS_POINTS_DIVISOR @ AmmError::AdminShareTooHigh,
+        constraint = (_fee as u64) < BASIS_POINTS_DIVISOR @ AmmError::InvalidFee,
+        constraint = (_admin_share_bps as u64) < BASIS_POINTS_DIVISOR @ AmmError::AdminShareTooHigh,
     )]
     pub config: BorshAccount<Config>,
 

--- a/finance/token-swap/anchor/programs/token-swap/src/instructions/withdraw_liquidity.rs
+++ b/finance/token-swap/anchor/programs/token-swap/src/instructions/withdraw_liquidity.rs
@@ -129,7 +129,10 @@ pub fn handle_withdraw_liquidity(
             context.accounts.token_program.address(),
             Burn {
                 mint: context.accounts.liquidity_provider_mint.to_cpi_handle_mut(),
-                from: context.accounts.liquidity_provider_token.to_cpi_handle_mut(),
+                from: context
+                    .accounts
+                    .liquidity_provider_token
+                    .to_cpi_handle_mut(),
                 authority: context.accounts.withdrawer.cpi_handle(),
             },
         ),

--- a/finance/token-swap/anchor/programs/token-swap/tests/test_swap.rs
+++ b/finance/token-swap/anchor/programs/token-swap/tests/test_swap.rs
@@ -1385,7 +1385,11 @@ fn test_withdraw_reverts_when_below_min() {
         &ts.payer.pubkey(),
     );
     let err = format!("{:?}", result.expect_err("must revert (A side)"));
-    assert_program_error(&err, AmmError::WithdrawalBelowMinimum, "WithdrawalBelowMinimum");
+    assert_program_error(
+        &err,
+        AmmError::WithdrawalBelowMinimum,
+        "WithdrawalBelowMinimum",
+    );
 
     // Same on the B side.
     let strict_ix_b = withdraw_ix_with_min(&ts, lp / 2, 0, 4_000_000);
@@ -1396,7 +1400,11 @@ fn test_withdraw_reverts_when_below_min() {
         &ts.payer.pubkey(),
     );
     let err_b = format!("{:?}", result_b.expect_err("must revert (B side)"));
-    assert_program_error(&err_b, AmmError::WithdrawalBelowMinimum, "WithdrawalBelowMinimum");
+    assert_program_error(
+        &err_b,
+        AmmError::WithdrawalBelowMinimum,
+        "WithdrawalBelowMinimum",
+    );
 }
 
 /// Slippage test: passing `min_output_amount = 0` is the explicit

--- a/tokens/create-token/native/program/Cargo.toml
+++ b/tokens/create-token/native/program/Cargo.toml
@@ -9,10 +9,14 @@ borsh-derive.workspace = true
 solana-program.workspace = true
 solana-system-interface = { version = "2.0.0", features = ["bincode"] }
 spl-token-interface = "2.0.0"
-mpl-token-metadata = "5.1.1"
+# anchor-spl 2.0.0-rc.1 depends on `=5.1.2-alpha.2`, and a caret range excludes
+# pre-releases, so `^5.1.1` here and that exact pin cannot both be satisfied in
+# one lockfile. Matching the pin is what lets the anchor and native token
+# examples share a workspace.
+mpl-token-metadata = "=5.1.2-alpha.2"
 # Alias for the (older) solana-program version mpl-token-metadata's instruction
 # builders return, so we can name that Instruction/Pubkey type when bridging.
-mpl-solana-program = { package = "solana-program", version = "2.3" }
+mpl-solana-program = { package = "solana-program", version = "3.0" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/tokens/external-delegate-token-master/anchor/programs/external-delegate-token-master/Cargo.toml
+++ b/tokens/external-delegate-token-master/anchor/programs/external-delegate-token-master/Cargo.toml
@@ -29,7 +29,7 @@ wincode = { version = "0.5", features = ["derive"] }
 # belong to the version the account derives are not using and every
 # `SchemaRead`/`SchemaWrite` bound fails. 2.6.1 is the last 0.5-line release.
 solana-address = ">=2.6, <2.7"
-anchor-spl = { version = "2.0.0-rc.1", features = ["metadata"] }
+anchor-spl = "2.0.0-rc.1"
 sha3 = "0.10.8"
 solana-secp256k1-recover = "2.0.0"
 

--- a/tokens/external-delegate-token-master/anchor/programs/external-delegate-token-master/src/instructions/transfer_tokens.rs
+++ b/tokens/external-delegate-token-master/anchor/programs/external-delegate-token-master/src/instructions/transfer_tokens.rs
@@ -47,7 +47,7 @@ pub fn handler(
     let message = build_transfer_authorization_message(
         &user_account_key,
         amount,
-        &context.accounts.recipient_token_account.address(),
+        context.accounts.recipient_token_account.address(),
         user_account.nonce,
     );
 

--- a/tokens/nft-minter/anchor/programs/nft-minter/src/lib.rs
+++ b/tokens/nft-minter/anchor/programs/nft-minter/src/lib.rs
@@ -26,7 +26,7 @@ pub mod nft_minter {
     ) -> Result<()> {
         // `AccountView` is Copy, and a copy still points at the same
         // account. v2's typed handles make the aliasing a compile error.
-        let mint_account_view = *context.accounts.mint_account.account();
+        let _mint_account_view = *context.accounts.mint_account.account();
         let payer_view = *context.accounts.payer.account();
         msg!("Minting Token");
         // Cross Program Invocation (CPI)

--- a/tokens/nft-minter/native/program/Cargo.toml
+++ b/tokens/nft-minter/native/program/Cargo.toml
@@ -10,10 +10,14 @@ solana-program.workspace = true
 solana-system-interface = { version = "2.0.0", features = ["bincode"] }
 spl-token-interface = "2.0.0"
 spl-associated-token-account-interface = "2.0.0"
-mpl-token-metadata = "5.1.1"
+# anchor-spl 2.0.0-rc.1 depends on `=5.1.2-alpha.2`, and a caret range excludes
+# pre-releases, so `^5.1.1` here and that exact pin cannot both be satisfied in
+# one lockfile. Matching the pin is what lets the anchor and native token
+# examples share a workspace.
+mpl-token-metadata = "=5.1.2-alpha.2"
 # Alias for the (older) solana-program version mpl-token-metadata's instruction
 # builders return, so we can name that Instruction/Pubkey type when bridging.
-mpl-solana-program = { package = "solana-program", version = "2.3" }
+mpl-solana-program = { package = "solana-program", version = "3.0" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/tokens/nft-operations/anchor/programs/mint-nft/src/instructions/create_collection.rs
+++ b/tokens/nft-operations/anchor/programs/mint-nft/src/instructions/create_collection.rs
@@ -20,7 +20,7 @@ use super::validate_metadata_strings;
 #[derive(Accounts)]
 pub struct CreateCollectionAccountConstraints {
     #[account(mut)]
-    user: Signer,
+    pub user: Signer,
 
     #[account(
         init,
@@ -29,7 +29,7 @@ pub struct CreateCollectionAccountConstraints {
         mint::authority = mint_authority,
         mint::freeze_authority = mint_authority,
     )]
-    mint: Account<Mint>,
+    pub mint: Account<Mint>,
 
     #[account(
         seeds = [b"authority"],
@@ -40,11 +40,11 @@ pub struct CreateCollectionAccountConstraints {
 
     #[account(mut)]
     /// CHECK: This account will be initialized by the metaplex program
-    metadata: UncheckedAccount,
+    pub metadata: UncheckedAccount,
 
     #[account(mut)]
     /// CHECK: This account will be initialized by the metaplex program
-    master_edition: UncheckedAccount,
+    pub master_edition: UncheckedAccount,
 
     #[account(
         init,
@@ -52,12 +52,12 @@ pub struct CreateCollectionAccountConstraints {
         associated_token::mint = mint,
         associated_token::authority = user
     )]
-    destination: Account<TokenAccount>,
+    pub destination: Account<TokenAccount>,
 
-    system_program: Program<System>,
-    token_program: Program<Token>,
-    associated_token_program: Program<AssociatedToken>,
-    token_metadata_program: Program<Metadata>,
+    pub system_program: Program<System>,
+    pub token_program: Program<Token>,
+    pub associated_token_program: Program<AssociatedToken>,
+    pub token_metadata_program: Program<Metadata>,
 }
 
 /// Creates a collection NFT with caller-supplied metadata.

--- a/tokens/nft-operations/anchor/programs/mint-nft/src/instructions/verify_collection.rs
+++ b/tokens/nft-operations/anchor/programs/mint-nft/src/instructions/verify_collection.rs
@@ -5,8 +5,7 @@ use anchor_lang::prelude::*;
 // usable here. The collection is created sized (`CollectionDetails::V1`), so
 // the sized-item variant is the matching instruction.
 use anchor_spl::metadata::{
-    verify_sized_collection_item, MasterEditionAccount, MetadataAccount,
-    VerifySizedCollectionItem,
+    verify_sized_collection_item, MasterEditionAccount, MetadataAccount, VerifySizedCollectionItem,
 };
 use anchor_spl::{metadata::Metadata, token::Mint};
 // pinocchio does not re-export the instructions sysvar id; decode it here.

--- a/tokens/nft-operations/anchor/programs/mint-nft/src/lib.rs
+++ b/tokens/nft-operations/anchor/programs/mint-nft/src/lib.rs
@@ -14,7 +14,7 @@ pub mod mint_nft {
 
     /// Create a collection NFT with the given metadata.
     pub fn create_collection(
-        mut context: &mut Context<CreateCollectionAccountConstraints>,
+        context: &mut Context<CreateCollectionAccountConstraints>,
         name: String,
         symbol: String,
         uri: String,
@@ -30,7 +30,7 @@ pub mod mint_nft {
 
     /// Mint an NFT into the collection with the given metadata.
     pub fn mint_nft(
-        mut context: &mut Context<MintNftAccountConstraints>,
+        context: &mut Context<MintNftAccountConstraints>,
         name: String,
         symbol: String,
         uri: String,
@@ -46,7 +46,7 @@ pub mod mint_nft {
 
     /// Verify an NFT as a member of the collection.
     pub fn verify_collection(
-        mut context: &mut Context<VerifyCollectionMintAccountConstraints>,
+        context: &mut Context<VerifyCollectionMintAccountConstraints>,
     ) -> Result<()> {
         instructions::verify_collection::handle_verify_collection(
             &mut context.accounts,

--- a/tokens/pda-mint-authority/anchor/programs/token-minter/src/instructions/create.rs
+++ b/tokens/pda-mint-authority/anchor/programs/token-minter/src/instructions/create.rs
@@ -2,8 +2,6 @@
 // This is to demonstrate that the same PDA can be used for both the address of an account and CPI signing
 use {
     anchor_lang::prelude::*,
-    // `Mint::LEN` comes from `Pack`, which anchor-spl does not re-export.
-    solana_program_pack::Pack,
     anchor_lang::system_program::{create_account, CreateAccount},
     anchor_spl::{
         metadata::{
@@ -12,6 +10,8 @@ use {
         },
         token::{initialize_mint2, spl_token::state::Mint as MintState, InitializeMint2, Token},
     },
+    // `Mint::LEN` comes from `Pack`, which anchor-spl does not re-export.
+    solana_program_pack::Pack,
 };
 
 #[derive(Accounts)]

--- a/tokens/pda-mint-authority/native/program/Cargo.toml
+++ b/tokens/pda-mint-authority/native/program/Cargo.toml
@@ -10,10 +10,14 @@ solana-program.workspace = true
 solana-system-interface = { version = "2.0.0", features = ["bincode"] }
 spl-token-interface = "2.0.0"
 spl-associated-token-account-interface = "2.0.0"
-mpl-token-metadata = "5.1.1"
+# anchor-spl 2.0.0-rc.1 depends on `=5.1.2-alpha.2`, and a caret range excludes
+# pre-releases, so `^5.1.1` here and that exact pin cannot both be satisfied in
+# one lockfile. Matching the pin is what lets the anchor and native token
+# examples share a workspace.
+mpl-token-metadata = "=5.1.2-alpha.2"
 # Alias for the (older) solana-program version mpl-token-metadata's instruction
 # builders return, so we can name that Instruction/Pubkey type when bridging.
-mpl-solana-program = { package = "solana-program", version = "2.3" }
+mpl-solana-program = { package = "solana-program", version = "3.0" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/tokens/token-extensions/basics/anchor/programs/basics/src/instructions/create_token.rs
+++ b/tokens/token-extensions/basics/anchor/programs/basics/src/instructions/create_token.rs
@@ -3,7 +3,10 @@ use anchor_spl::mint;
 use anchor_spl::token_interface::{Mint, TokenInterface};
 
 #[derive(Accounts)]
-#[instruction(token_name: String)]
+// The leading underscore is for rustc: `#[derive(Accounts)]` expands `_token_name`
+// into a path that never reads it, so the plain name warns as unused. The
+// `seeds` expression below is the real use.
+#[instruction(_token_name: String)]
 pub struct CreateTokenAccountConstraints {
     #[account(mut)]
     pub signer: Signer,
@@ -15,7 +18,7 @@ pub struct CreateTokenAccountConstraints {
         // Required when the token program is an `Interface`: without it
         // the init CPI is rejected with InvalidArgument.
         mint::token_program = token_program,
-        seeds = [b"token-2022-token", signer.address().as_ref(), token_name.as_bytes()],
+        seeds = [b"token-2022-token", signer.address().as_ref(), _token_name.as_bytes()],
         bump,
     )]
     pub mint: InterfaceAccount<Mint>,

--- a/tokens/token-extensions/basics/anchor/programs/basics/src/instructions/mint_token.rs
+++ b/tokens/token-extensions/basics/anchor/programs/basics/src/instructions/mint_token.rs
@@ -14,8 +14,8 @@ pub struct MintTokenAccountConstraints {
 
 pub fn handler(context: &mut Context<MintTokenAccountConstraints>, amount: u64) -> Result<()> {
     let cpi_accounts = MintTo {
-        mint: context.accounts.mint.cpi_handle_mut().clone(),
-        to: context.accounts.receiver.cpi_handle_mut().clone(),
+        mint: context.accounts.mint.cpi_handle_mut(),
+        to: context.accounts.receiver.cpi_handle_mut(),
         authority: context.accounts.signer.cpi_handle(),
     };
     let cpi_program = context.accounts.token_program.address();

--- a/tokens/token-extensions/basics/anchor/programs/basics/src/instructions/transfer_token.rs
+++ b/tokens/token-extensions/basics/anchor/programs/basics/src/instructions/transfer_token.rs
@@ -28,9 +28,9 @@ pub struct TransferTokenAccountConstraints {
 
 pub fn handler(context: &mut Context<TransferTokenAccountConstraints>, amount: u64) -> Result<()> {
     let cpi_accounts = TransferChecked {
-        from: context.accounts.from.cpi_handle_mut().clone(),
-        mint: context.accounts.mint.cpi_handle().clone(),
-        to: context.accounts.to_ata.cpi_handle_mut().clone(),
+        from: context.accounts.from.cpi_handle_mut(),
+        mint: context.accounts.mint.cpi_handle(),
+        to: context.accounts.to_ata.cpi_handle_mut(),
         authority: context.accounts.signer.cpi_handle(),
     };
     let cpi_program = context.accounts.token_program.address();

--- a/tokens/token-extensions/cpi-guard/anchor/programs/cpi-guard/src/lib.rs
+++ b/tokens/token-extensions/cpi-guard/anchor/programs/cpi-guard/src/lib.rs
@@ -24,11 +24,16 @@ pub mod cpi_guard {
         // (`token::authority` has to name a sibling field), so the account is
         // created here instead: the `init_if_needed` semantics become an
         // explicit "create when empty".
-        if context.accounts.recipient_token_account.account().data_len() == 0 {
+        if context
+            .accounts
+            .recipient_token_account
+            .account()
+            .data_len()
+            == 0
+        {
             let space = ExtensionType::try_calculate_account_len::<PodAccount>(&[])?;
             let lamports = Rent::get()?.try_minimum_balance(space)?;
-            let signer_seeds: &[&[&[u8]]] =
-                &[&[b"pda", &[context.bumps.recipient_token_account]]];
+            let signer_seeds: &[&[&[u8]]] = &[&[b"pda", &[context.bumps.recipient_token_account]]];
 
             create_account(
                 CpiContext::new(
@@ -45,17 +50,15 @@ pub mod cpi_guard {
             )?;
 
             let recipient_handle = context.accounts.recipient_token_account.cpi_handle_mut();
-            initialize_account3(
-                CpiContext::new(
-                    context.accounts.token_program.address(),
-                    InitializeAccount3 {
-                        account: recipient_handle,
-                        mint: context.accounts.mint_account.cpi_handle(),
-                        // The account is its own authority.
-                        authority: recipient_handle.into_readonly(),
-                    },
-                ),
-            )?;
+            initialize_account3(CpiContext::new(
+                context.accounts.token_program.address(),
+                InitializeAccount3 {
+                    account: recipient_handle,
+                    mint: context.accounts.mint_account.cpi_handle(),
+                    // The account is its own authority.
+                    authority: recipient_handle.into_readonly(),
+                },
+            ))?;
         }
 
         transfer_checked(

--- a/tokens/token-extensions/default-account-state/anchor/programs/default-account-state/src/instructions/initialize.rs
+++ b/tokens/token-extensions/default-account-state/anchor/programs/default-account-state/src/instructions/initialize.rs
@@ -39,9 +39,9 @@ pub fn handler(context: &mut Context<InitializeAccountConstraints>) -> Result<()
                 to: context.accounts.mint_account.cpi_handle_mut(),
             },
         ),
-        lamports,                                  // Lamports
-        mint_size as u64,                          // Space
-        &context.accounts.token_program.address(), // Owner Program
+        lamports,                                 // Lamports
+        mint_size as u64,                         // Space
+        context.accounts.token_program.address(), // Owner Program
     )?;
 
     // Initialize the NonTransferable extension
@@ -64,9 +64,9 @@ pub fn handler(context: &mut Context<InitializeAccountConstraints>) -> Result<()
                 mint: context.accounts.mint_account.cpi_handle_mut(),
             },
         ),
-        2,                                       // decimals
-        &context.accounts.payer.address(),       // mint authority
-        Some(&context.accounts.payer.address()), // freeze authority
+        2,                                      // decimals
+        context.accounts.payer.address(),       // mint authority
+        Some(context.accounts.payer.address()), // freeze authority
     )?;
     Ok(())
 }

--- a/tokens/token-extensions/immutable-owner/anchor/programs/immutable-owner/src/lib.rs
+++ b/tokens/token-extensions/immutable-owner/anchor/programs/immutable-owner/src/lib.rs
@@ -38,9 +38,9 @@ pub mod immutable_owner {
                     to: context.accounts.token_account.cpi_handle_mut(),
                 },
             ),
-            lamports,                                  // Lamports
-            token_account_size as u64,                 // Space
-            &context.accounts.token_program.address(), // Owner Program
+            lamports,                                 // Lamports
+            token_account_size as u64,                // Space
+            context.accounts.token_program.address(), // Owner Program
         )?;
 
         // Initialize the token account with the immutable owner extension

--- a/tokens/token-extensions/interest-bearing/anchor/programs/interest-bearing/src/instructions/initialize.rs
+++ b/tokens/token-extensions/interest-bearing/anchor/programs/interest-bearing/src/instructions/initialize.rs
@@ -49,7 +49,7 @@ pub fn handler(context: &mut Context<InitializeAccountConstraints>, rate: i16) -
         ),
         lamports,                                  // Lamports
         mint_size as u64,                          // Space
-        &context.accounts.token_program.address(), // Owner Program
+        context.accounts.token_program.address(), // Owner Program
     )?;
 
     // Initialize the InterestBearingConfig extension
@@ -74,8 +74,8 @@ pub fn handler(context: &mut Context<InitializeAccountConstraints>, rate: i16) -
             },
         ),
         2,                                       // decimals
-        &context.accounts.payer.address(),       // mint authority
-        Some(&context.accounts.payer.address()), // freeze authority
+        context.accounts.payer.address(),       // mint authority
+        Some(context.accounts.payer.address()), // freeze authority
     )?;
 
     // The mint is a `Signer` here, which holds no borrow on the account's data,

--- a/tokens/token-extensions/interest-bearing/anchor/programs/interest-bearing/src/instructions/initialize.rs
+++ b/tokens/token-extensions/interest-bearing/anchor/programs/interest-bearing/src/instructions/initialize.rs
@@ -47,8 +47,8 @@ pub fn handler(context: &mut Context<InitializeAccountConstraints>, rate: i16) -
                 to: context.accounts.mint_account.cpi_handle_mut(),
             },
         ),
-        lamports,                                  // Lamports
-        mint_size as u64,                          // Space
+        lamports,                                 // Lamports
+        mint_size as u64,                         // Space
         context.accounts.token_program.address(), // Owner Program
     )?;
 
@@ -73,7 +73,7 @@ pub fn handler(context: &mut Context<InitializeAccountConstraints>, rate: i16) -
                 mint: context.accounts.mint_account.cpi_handle_mut(),
             },
         ),
-        2,                                       // decimals
+        2,                                      // decimals
         context.accounts.payer.address(),       // mint authority
         Some(context.accounts.payer.address()), // freeze authority
     )?;

--- a/tokens/token-extensions/memo-transfer/anchor/programs/memo-transfer/src/instructions/initialize.rs
+++ b/tokens/token-extensions/memo-transfer/anchor/programs/memo-transfer/src/instructions/initialize.rs
@@ -41,9 +41,9 @@ pub fn handler(context: &mut Context<InitializeAccountConstraints>) -> Result<()
                 to: context.accounts.token_account.cpi_handle_mut(),
             },
         ),
-        lamports,                                  // Lamports
-        token_account_size as u64,                 // Space
-        &context.accounts.token_program.address(), // Owner Program
+        lamports,                                 // Lamports
+        token_account_size as u64,                // Space
+        context.accounts.token_program.address(), // Owner Program
     )?;
 
     // Initialize the standard token account data

--- a/tokens/token-extensions/metadata/anchor/programs/metadata/src/instructions/emit.rs
+++ b/tokens/token-extensions/metadata/anchor/programs/metadata/src/instructions/emit.rs
@@ -14,8 +14,8 @@ pub struct EmitAccountConstraints {
 pub fn process_emit(context: &mut Context<EmitAccountConstraints>) -> Result<()> {
     invoke(
         &emit(
-            &context.accounts.token_program.address(), // token program id
-            &context.accounts.mint_account.address(),  // "metadata" account
+            context.accounts.token_program.address(), // token program id
+            context.accounts.mint_account.address(),  // "metadata" account
             None,
             None,
         ),

--- a/tokens/token-extensions/metadata/anchor/programs/metadata/src/instructions/remove_key.rs
+++ b/tokens/token-extensions/metadata/anchor/programs/metadata/src/instructions/remove_key.rs
@@ -22,9 +22,9 @@ pub fn process_remove_key(
 ) -> Result<()> {
     invoke(
         &remove_key(
-            &context.accounts.token_program.address(), // token program id
-            &context.accounts.mint_account.address(),  // "metadata" account
-            &context.accounts.update_authority.address(), // update authority
+            context.accounts.token_program.address(), // token program id
+            context.accounts.mint_account.address(),  // "metadata" account
+            context.accounts.update_authority.address(), // update authority
             key,                                       // key to remove
             true, // idempotent flag, if true transaction will not fail if key does not exist
         ),

--- a/tokens/token-extensions/metadata/anchor/programs/metadata/src/instructions/remove_key.rs
+++ b/tokens/token-extensions/metadata/anchor/programs/metadata/src/instructions/remove_key.rs
@@ -25,7 +25,7 @@ pub fn process_remove_key(
             context.accounts.token_program.address(), // token program id
             context.accounts.mint_account.address(),  // "metadata" account
             context.accounts.update_authority.address(), // update authority
-            key,                                       // key to remove
+            key,                                      // key to remove
             true, // idempotent flag, if true transaction will not fail if key does not exist
         ),
         // Handles line up positionally with the instruction's metas, and a

--- a/tokens/token-extensions/mint-close-authority/anchor/programs/mint-close-authority/Cargo.toml
+++ b/tokens/token-extensions/mint-close-authority/anchor/programs/mint-close-authority/Cargo.toml
@@ -34,3 +34,6 @@ solana-kite = "0.4.0"
 solana-signer = "3.0.0"
 solana-keypair = "3.0.1"
 borsh = "1.6.1"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_os, values("solana"))'] }

--- a/tokens/token-extensions/nft-meta-data-pointer/anchor-example/anchor/programs/extension_nft/src/instructions/chop_tree.rs
+++ b/tokens/token-extensions/nft-meta-data-pointer/anchor-example/anchor/programs/extension_nft/src/instructions/chop_tree.rs
@@ -73,7 +73,10 @@ pub fn chop_tree(
 }
 
 #[derive(Accounts)]
-#[instruction(level_seed: String)]
+// The leading underscore is for rustc: `#[derive(Accounts)]` expands `_level_seed`
+// into a path that never reads it, so the plain name warns as unused. The
+// `seeds` expression below is the real use.
+#[instruction(_level_seed: String)]
 pub struct ChopTreeAccountConstraints {
     // Session tokens are passed as optional accounts. The token is validated in
     // `chop_tree` (see `session::is_valid_session`) rather than by a derive,
@@ -96,7 +99,7 @@ pub struct ChopTreeAccountConstraints {
         init_if_needed,
         payer = signer,
         space = GameData::DISCRIMINATOR.len() + GameData::INIT_SPACE,
-        seeds = [level_seed.as_bytes()],
+        seeds = [_level_seed.as_bytes()],
         bump,
     )]
     pub game_data: BorshAccount<GameData>,

--- a/tokens/token-extensions/nft-meta-data-pointer/anchor-example/anchor/programs/extension_nft/src/instructions/init_player.rs
+++ b/tokens/token-extensions/nft-meta-data-pointer/anchor-example/anchor/programs/extension_nft/src/instructions/init_player.rs
@@ -19,7 +19,10 @@ pub fn handle_init_player(context: &mut Context<InitPlayerAccountConstraints>) -
 }
 
 #[derive(Accounts)]
-#[instruction(level_seed: String)]
+// The leading underscore is for rustc: `#[derive(Accounts)]` expands `_level_seed`
+// into a path that never reads it, so the plain name warns as unused. The
+// `seeds` expression below is the real use.
+#[instruction(_level_seed: String)]
 pub struct InitPlayerAccountConstraints {
     #[account(
         init,
@@ -34,7 +37,7 @@ pub struct InitPlayerAccountConstraints {
         init_if_needed,
         payer = signer,
         space = GameData::DISCRIMINATOR.len() + GameData::INIT_SPACE,
-        seeds = [level_seed.as_bytes()],
+        seeds = [_level_seed.as_bytes()],
         bump,
     )]
     pub game_data: BorshAccount<GameData>,

--- a/tokens/token-extensions/nft-meta-data-pointer/anchor-example/anchor/programs/extension_nft/src/instructions/mint_nft.rs
+++ b/tokens/token-extensions/nft-meta-data-pointer/anchor-example/anchor/programs/extension_nft/src/instructions/mint_nft.rs
@@ -63,7 +63,7 @@ pub fn handle_mint_nft(context: &mut Context<MintNftAccountConstraints>) -> Resu
         ),
         lamports_required,
         space as u64,
-        &context.accounts.token_program.address(),
+        context.accounts.token_program.address(),
     )?;
 
     // Assign the mint to the token program
@@ -81,7 +81,7 @@ pub fn handle_mint_nft(context: &mut Context<MintNftAccountConstraints>) -> Resu
     let init_meta_data_pointer_ix =
         match spl_token_2022::extension::metadata_pointer::instruction::initialize(
             &Token2022::id(),
-            &context.accounts.mint.address(),
+            context.accounts.mint.address(),
             Some(*context.accounts.nft_authority.address()),
             Some(*context.accounts.mint.address()),
         ) {
@@ -106,8 +106,7 @@ pub fn handle_mint_nft(context: &mut Context<MintNftAccountConstraints>) -> Resu
         },
     );
 
-    token_2022::initialize_mint2(mint_cpi_ix, 0, &nft_authority_address, None)
-    .unwrap();
+    token_2022::initialize_mint2(mint_cpi_ix, 0, &nft_authority_address, None).unwrap();
 
     // We use a PDA as a mint authority for the metadata account because
     // we want to be able to update the NFT from the program.

--- a/tokens/token-extensions/nft-meta-data-pointer/anchor-example/anchor/programs/extension_nft/src/session.rs
+++ b/tokens/token-extensions/nft-meta-data-pointer/anchor-example/anchor/programs/extension_nft/src/session.rs
@@ -54,7 +54,8 @@ pub fn is_valid_session(
         return Ok(false);
     }
     let mut payload = &data[disc_len..];
-    let Ok(token) = <SessionToken as wincode::SchemaRead<anchor_lang::BorshConfig>>::get(&mut payload)
+    let Ok(token) =
+        <SessionToken as wincode::SchemaRead<anchor_lang::BorshConfig>>::get(&mut payload)
     else {
         return Ok(false);
     };

--- a/tokens/token-extensions/non-transferable/anchor/programs/non-transferable/Cargo.toml
+++ b/tokens/token-extensions/non-transferable/anchor/programs/non-transferable/Cargo.toml
@@ -34,3 +34,6 @@ solana-kite = "0.4.0"
 solana-signer = "3.0.0"
 solana-keypair = "3.0.1"
 borsh = "1.6.1"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_os, values("solana"))'] }

--- a/tokens/token-extensions/non-transferable/anchor/programs/non-transferable/src/lib.rs
+++ b/tokens/token-extensions/non-transferable/anchor/programs/non-transferable/src/lib.rs
@@ -34,9 +34,9 @@ pub mod non_transferable {
                     to: context.accounts.mint_account.cpi_handle_mut(),
                 },
             ),
-            lamports,                                  // Lamports
-            mint_size as u64,                          // Space
-            &context.accounts.token_program.address(), // Owner Program
+            lamports,                                 // Lamports
+            mint_size as u64,                         // Space
+            context.accounts.token_program.address(), // Owner Program
         )?;
 
         // Initialize the NonTransferable extension
@@ -56,9 +56,9 @@ pub mod non_transferable {
                     mint: context.accounts.mint_account.cpi_handle_mut(),
                 },
             ),
-            2,                                       // decimals
-            &context.accounts.payer.address(),       // mint authority
-            Some(&context.accounts.payer.address()), // freeze authority
+            2,                                      // decimals
+            context.accounts.payer.address(),       // mint authority
+            Some(context.accounts.payer.address()), // freeze authority
         )?;
         Ok(())
     }

--- a/tokens/token-extensions/transfer-fee/anchor/programs/transfer-fee/Cargo.toml
+++ b/tokens/token-extensions/transfer-fee/anchor/programs/transfer-fee/Cargo.toml
@@ -34,3 +34,6 @@ solana-kite = "0.4.0"
 solana-signer = "3.0.0"
 solana-keypair = "3.0.1"
 borsh = "1.6.1"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_os, values("solana"))'] }

--- a/tokens/token-extensions/transfer-fee/anchor/programs/transfer-fee/src/instructions/initialize.rs
+++ b/tokens/token-extensions/transfer-fee/anchor/programs/transfer-fee/src/instructions/initialize.rs
@@ -53,9 +53,9 @@ pub fn handle_process_initialize(
                 to: context.accounts.mint_account.cpi_handle_mut(),
             },
         ),
-        lamports,                                  // Lamports
-        mint_size as u64,                          // Space
-        &context.accounts.token_program.address(), // Owner Program
+        lamports,                                 // Lamports
+        mint_size as u64,                         // Space
+        context.accounts.token_program.address(), // Owner Program
     )?;
 
     // Initialize the transfer fee extension data
@@ -67,10 +67,10 @@ pub fn handle_process_initialize(
                 mint: context.accounts.mint_account.cpi_handle_mut(),
             },
         ),
-        Some(&context.accounts.payer.address()), // transfer fee config authority (update fee)
-        Some(&context.accounts.payer.address()), // withdraw authority (withdraw fees)
-        transfer_fee_basis_points,               // transfer fee basis points (% fee per transfer)
-        maximum_fee, // maximum fee (maximum units of token per transfer)
+        Some(context.accounts.payer.address()), // transfer fee config authority (update fee)
+        Some(context.accounts.payer.address()), // withdraw authority (withdraw fees)
+        transfer_fee_basis_points,              // transfer fee basis points (% fee per transfer)
+        maximum_fee,                            // maximum fee (maximum units of token per transfer)
     )?;
 
     // Initialize the standard mint account data
@@ -81,9 +81,9 @@ pub fn handle_process_initialize(
                 mint: context.accounts.mint_account.cpi_handle_mut(),
             },
         ),
-        2,                                       // decimals
-        &context.accounts.payer.address(),       // mint authority
-        Some(&context.accounts.payer.address()), // freeze authority
+        2,                                      // decimals
+        context.accounts.payer.address(),       // mint authority
+        Some(context.accounts.payer.address()), // freeze authority
     )?;
 
     handle_check_mint_data(&context.accounts)?;

--- a/tokens/token-extensions/transfer-hook/account-data-as-seed/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/account-data-as-seed/anchor/programs/transfer-hook/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
-name = "transfer-hook"
+# Five transfer-hook examples ship a crate in `programs/transfer-hook`, and a
+# workspace cannot hold two packages with one name. The package name carries the
+# variant; `[lib] name` stays `transfer_hook`, which is what Anchor.toml, the IDL
+# and the .so are keyed on.
+name = "transfer-hook-account-data-as-seed"
 version = "0.1.0"
 description = "Created with Anchor"
 edition = "2021"

--- a/tokens/token-extensions/transfer-hook/account-data-as-seed/anchor/programs/transfer-hook/src/entrypoint.rs
+++ b/tokens/token-extensions/transfer-hook/account-data-as-seed/anchor/programs/transfer-hook/src/entrypoint.rs
@@ -20,11 +20,19 @@ pinocchio::default_allocator!();
 pinocchio::default_panic_handler!();
 
 /// Interface discriminator paired with the handler's own, in declaration order.
+// Read only by `entrypoint` below, which the host build cfgs out.
+#[cfg(target_os = "solana")]
 const DISCRIMINATOR_MAP: [([u8; 8], [u8; 8]); 2] = [
     // initialize_extra_account_meta_list
-    ([43, 34, 13, 49, 167, 88, 235, 235], [92, 197, 174, 197, 41, 124, 19, 3]),
+    (
+        [43, 34, 13, 49, 167, 88, 235, 235],
+        [92, 197, 174, 197, 41, 124, 19, 3],
+    ),
     // transfer_hook
-    ([105, 37, 101, 197, 75, 251, 102, 26], [220, 57, 220, 152, 126, 125, 97, 168]),
+    (
+        [105, 37, 101, 197, 75, 251, 102, 26],
+        [220, 57, 220, 152, 126, 125, 97, 168],
+    ),
 ];
 
 /// # Safety

--- a/tokens/token-extensions/transfer-hook/account-data-as-seed/anchor/programs/transfer-hook/src/instructions/initialize_extra_account_meta_list.rs
+++ b/tokens/token-extensions/transfer-hook/account-data-as-seed/anchor/programs/transfer-hook/src/instructions/initialize_extra_account_meta_list.rs
@@ -31,7 +31,7 @@ pub struct InitializeExtraAccountMetaListAccountConstraints {
 }
 
 pub fn handler(
-    mut context: &mut Context<InitializeExtraAccountMetaListAccountConstraints>,
+    context: &mut Context<InitializeExtraAccountMetaListAccountConstraints>,
 ) -> Result<()> {
     let extra_account_metas = handle_extra_account_metas()?;
 

--- a/tokens/token-extensions/transfer-hook/account-data-as-seed/anchor/programs/transfer-hook/src/instructions/transfer_hook.rs
+++ b/tokens/token-extensions/transfer-hook/account-data-as-seed/anchor/programs/transfer-hook/src/instructions/transfer_hook.rs
@@ -26,7 +26,7 @@ pub struct TransferHookAccountConstraints {
 
 pub fn handler(context: &mut Context<TransferHookAccountConstraints>, amount: u64) -> Result<()> {
     // Fail this instruction if it is not called from within a transfer hook
-    check_is_transferring(&context)?;
+    check_is_transferring(context)?;
 
     // Check if the amount is too big
     if amount > 50 {

--- a/tokens/token-extensions/transfer-hook/account-data-as-seed/anchor/programs/transfer-hook/src/lib.rs
+++ b/tokens/token-extensions/transfer-hook/account-data-as-seed/anchor/programs/transfer-hook/src/lib.rs
@@ -1,5 +1,3 @@
-use std::cell::RefMut;
-
 use anchor_lang::prelude::*;
 use anchor_spl::token_2022::spl_token_2022::{
     extension::{
@@ -7,11 +5,7 @@ use anchor_spl::token_2022::spl_token_2022::{
     },
     pod::PodAccount,
 };
-use spl_discriminator::SplDiscriminate;
 use spl_tlv_account_resolution::{account::ExtraAccountMeta, seeds::Seed};
-use spl_transfer_hook_interface::instruction::{
-    ExecuteInstruction, InitializeExtraAccountMetaListInstruction,
-};
 
 mod instructions;
 use instructions::*;

--- a/tokens/token-extensions/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/entrypoint.rs
+++ b/tokens/token-extensions/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/entrypoint.rs
@@ -21,9 +21,13 @@ pinocchio::default_panic_handler!();
 
 /// `sha256("spl-transfer-hook-interface:execute")[..8]`, the discriminator
 /// Token-2022 uses when it calls a mint's transfer hook.
+// Read only by `entrypoint` below, which the host build cfgs out.
+#[cfg(target_os = "solana")]
 const EXECUTE_DISCRIMINATOR: [u8; 8] = [105, 37, 101, 197, 75, 251, 102, 26];
 
 /// `sha256("global:tx_hook")[..8]`, what anchor's dispatch matches on.
+// Read only by `entrypoint` below, which the host build cfgs out.
+#[cfg(target_os = "solana")]
 const TX_HOOK_DISCRIMINATOR: [u8; 8] = [55, 222, 121, 59, 26, 10, 108, 168];
 
 /// # Safety
@@ -37,10 +41,8 @@ const TX_HOOK_DISCRIMINATOR: [u8; 8] = [55, 222, 121, 59, 26, 10, 108, 168];
 pub unsafe extern "C" fn entrypoint(input: *mut u8, ix_data_ptr: *const u8) -> u64 {
     let len = *(ix_data_ptr.sub(8) as *const u64) as usize;
     if len >= EXECUTE_DISCRIMINATOR.len() {
-        let discriminator = core::slice::from_raw_parts_mut(
-            ix_data_ptr as *mut u8,
-            EXECUTE_DISCRIMINATOR.len(),
-        );
+        let discriminator =
+            core::slice::from_raw_parts_mut(ix_data_ptr as *mut u8, EXECUTE_DISCRIMINATOR.len());
         if discriminator == EXECUTE_DISCRIMINATOR {
             discriminator.copy_from_slice(&TX_HOOK_DISCRIMINATOR);
         }

--- a/tokens/token-extensions/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/instructions/init_mint.rs
+++ b/tokens/token-extensions/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/instructions/init_mint.rs
@@ -23,7 +23,9 @@ use spl_transfer_hook_interface::instruction::ExecuteInstruction;
 use crate::{get_extra_account_metas, get_meta_list_size, Mode, META_LIST_ACCOUNT_SEED};
 
 #[derive(Accounts)]
-#[instruction(args: InitMintArgs)]
+// The leading underscore is for rustc: `#[derive(Accounts)]` expands `_args`
+// into a path that never reads it, so the plain name warns as unused.
+#[instruction(_args: InitMintArgs)]
 pub struct InitMintAccountConstraints {
     #[account(mut)]
     pub payer: Signer,

--- a/tokens/token-extensions/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/lib.rs
+++ b/tokens/token-extensions/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/lib.rs
@@ -1,6 +1,4 @@
 use anchor_lang::prelude::*;
-use spl_discriminator::SplDiscriminate;
-use spl_transfer_hook_interface::instruction::ExecuteInstruction;
 
 pub mod constants;
 pub mod errors;

--- a/tokens/token-extensions/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/utils.rs
+++ b/tokens/token-extensions/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/utils.rs
@@ -7,7 +7,7 @@ use spl_tlv_account_resolution::{
 use crate::AB_WALLET_SEED;
 
 pub fn get_meta_list_size() -> Result<usize> {
-    Ok(ExtraAccountMetaList::size_of(1).map_err(|_| ProgramError::InvalidArgument)?)
+    ExtraAccountMetaList::size_of(1).map_err(|_| ProgramError::InvalidArgument)
 }
 
 pub fn get_extra_account_metas() -> Result<Vec<ExtraAccountMeta>> {

--- a/tokens/token-extensions/transfer-hook/counter/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/counter/anchor/programs/transfer-hook/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
-name = "transfer-hook"
+# Five transfer-hook examples ship a crate in `programs/transfer-hook`, and a
+# workspace cannot hold two packages with one name. The package name carries the
+# variant; `[lib] name` stays `transfer_hook`, which is what Anchor.toml, the IDL
+# and the .so are keyed on.
+name = "transfer-hook-counter"
 version = "0.1.0"
 description = "Created with Anchor"
 edition = "2021"

--- a/tokens/token-extensions/transfer-hook/counter/anchor/programs/transfer-hook/src/entrypoint.rs
+++ b/tokens/token-extensions/transfer-hook/counter/anchor/programs/transfer-hook/src/entrypoint.rs
@@ -20,11 +20,19 @@ pinocchio::default_allocator!();
 pinocchio::default_panic_handler!();
 
 /// Interface discriminator paired with the handler's own, in declaration order.
+// Read only by `entrypoint` below, which the host build cfgs out.
+#[cfg(target_os = "solana")]
 const DISCRIMINATOR_MAP: [([u8; 8], [u8; 8]); 2] = [
     // initialize_extra_account_meta_list
-    ([43, 34, 13, 49, 167, 88, 235, 235], [92, 197, 174, 197, 41, 124, 19, 3]),
+    (
+        [43, 34, 13, 49, 167, 88, 235, 235],
+        [92, 197, 174, 197, 41, 124, 19, 3],
+    ),
     // transfer_hook
-    ([105, 37, 101, 197, 75, 251, 102, 26], [220, 57, 220, 152, 126, 125, 97, 168]),
+    (
+        [105, 37, 101, 197, 75, 251, 102, 26],
+        [220, 57, 220, 152, 126, 125, 97, 168],
+    ),
 ];
 
 /// # Safety

--- a/tokens/token-extensions/transfer-hook/counter/anchor/programs/transfer-hook/src/instructions/initialize_extra_account_meta_list.rs
+++ b/tokens/token-extensions/transfer-hook/counter/anchor/programs/transfer-hook/src/instructions/initialize_extra_account_meta_list.rs
@@ -31,7 +31,7 @@ pub struct InitializeExtraAccountMetaListAccountConstraints {
 }
 
 pub fn handler(
-    mut context: &mut Context<InitializeExtraAccountMetaListAccountConstraints>,
+    context: &mut Context<InitializeExtraAccountMetaListAccountConstraints>,
 ) -> Result<()> {
     let extra_account_metas = handle_extra_account_metas()?;
 

--- a/tokens/token-extensions/transfer-hook/counter/anchor/programs/transfer-hook/src/instructions/transfer_hook.rs
+++ b/tokens/token-extensions/transfer-hook/counter/anchor/programs/transfer-hook/src/instructions/transfer_hook.rs
@@ -26,7 +26,7 @@ pub struct TransferHookAccountConstraints {
 
 pub fn handler(context: &mut Context<TransferHookAccountConstraints>, amount: u64) -> Result<()> {
     // Fail this instruction if it is not called from within a transfer hook
-    check_is_transferring(&context)?;
+    check_is_transferring(context)?;
 
     // Check if the amount is too big
     if amount > 50 {

--- a/tokens/token-extensions/transfer-hook/counter/anchor/programs/transfer-hook/src/lib.rs
+++ b/tokens/token-extensions/transfer-hook/counter/anchor/programs/transfer-hook/src/lib.rs
@@ -1,5 +1,3 @@
-use std::cell::RefMut;
-
 use anchor_lang::prelude::*;
 use anchor_spl::token_2022::spl_token_2022::{
     extension::{
@@ -7,11 +5,7 @@ use anchor_spl::token_2022::spl_token_2022::{
     },
     pod::PodAccount,
 };
-use spl_discriminator::SplDiscriminate;
 use spl_tlv_account_resolution::{account::ExtraAccountMeta, seeds::Seed};
-use spl_transfer_hook_interface::instruction::{
-    ExecuteInstruction, InitializeExtraAccountMetaListInstruction,
-};
 
 mod instructions;
 use instructions::*;

--- a/tokens/token-extensions/transfer-hook/hello-world/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/hello-world/anchor/programs/transfer-hook/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
-name = "transfer-hook"
+# Five transfer-hook examples ship a crate in `programs/transfer-hook`, and a
+# workspace cannot hold two packages with one name. The package name carries the
+# variant; `[lib] name` stays `transfer_hook`, which is what Anchor.toml, the IDL
+# and the .so are keyed on.
+name = "transfer-hook-hello-world"
 version = "0.1.0"
 description = "Created with Anchor"
 edition = "2021"

--- a/tokens/token-extensions/transfer-hook/hello-world/anchor/programs/transfer-hook/src/entrypoint.rs
+++ b/tokens/token-extensions/transfer-hook/hello-world/anchor/programs/transfer-hook/src/entrypoint.rs
@@ -20,11 +20,19 @@ pinocchio::default_allocator!();
 pinocchio::default_panic_handler!();
 
 /// Interface discriminator paired with the handler's own, in declaration order.
+// Read only by `entrypoint` below, which the host build cfgs out.
+#[cfg(target_os = "solana")]
 const DISCRIMINATOR_MAP: [([u8; 8], [u8; 8]); 2] = [
     // initialize_extra_account_meta_list
-    ([43, 34, 13, 49, 167, 88, 235, 235], [92, 197, 174, 197, 41, 124, 19, 3]),
+    (
+        [43, 34, 13, 49, 167, 88, 235, 235],
+        [92, 197, 174, 197, 41, 124, 19, 3],
+    ),
     // transfer_hook
-    ([105, 37, 101, 197, 75, 251, 102, 26], [220, 57, 220, 152, 126, 125, 97, 168]),
+    (
+        [105, 37, 101, 197, 75, 251, 102, 26],
+        [220, 57, 220, 152, 126, 125, 97, 168],
+    ),
 ];
 
 /// # Safety

--- a/tokens/token-extensions/transfer-hook/hello-world/anchor/programs/transfer-hook/src/instructions/initialize_extra_account_meta_list.rs
+++ b/tokens/token-extensions/transfer-hook/hello-world/anchor/programs/transfer-hook/src/instructions/initialize_extra_account_meta_list.rs
@@ -32,7 +32,7 @@ pub struct InitializeExtraAccountMetaListAccountConstraints {
 }
 
 pub fn handler(
-    mut context: &mut Context<InitializeExtraAccountMetaListAccountConstraints>,
+    context: &mut Context<InitializeExtraAccountMetaListAccountConstraints>,
 ) -> Result<()> {
     let extra_account_metas = handle_extra_account_metas()?;
 

--- a/tokens/token-extensions/transfer-hook/hello-world/anchor/programs/transfer-hook/src/instructions/transfer_hook.rs
+++ b/tokens/token-extensions/transfer-hook/hello-world/anchor/programs/transfer-hook/src/instructions/transfer_hook.rs
@@ -24,7 +24,7 @@ pub struct TransferHookAccountConstraints {
 
 pub fn handler(context: &mut Context<TransferHookAccountConstraints>, _amount: u64) -> Result<()> {
     // Fail this instruction if it is not called from within a transfer hook
-    check_is_transferring(&context)?;
+    check_is_transferring(context)?;
 
     msg!("Hello Transfer Hook!");
 

--- a/tokens/token-extensions/transfer-hook/hello-world/anchor/programs/transfer-hook/src/lib.rs
+++ b/tokens/token-extensions/transfer-hook/hello-world/anchor/programs/transfer-hook/src/lib.rs
@@ -1,5 +1,3 @@
-use std::cell::RefMut;
-
 use anchor_lang::prelude::*;
 use anchor_spl::token_2022::spl_token_2022::{
     extension::{
@@ -7,11 +5,7 @@ use anchor_spl::token_2022::spl_token_2022::{
     },
     pod::PodAccount,
 };
-use spl_discriminator::SplDiscriminate;
 use spl_tlv_account_resolution::account::ExtraAccountMeta;
-use spl_transfer_hook_interface::instruction::{
-    ExecuteInstruction, InitializeExtraAccountMetaListInstruction,
-};
 
 mod instructions;
 use instructions::*;

--- a/tokens/token-extensions/transfer-hook/transfer-cost/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/transfer-cost/anchor/programs/transfer-hook/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
-name = "transfer-hook"
+# Five transfer-hook examples ship a crate in `programs/transfer-hook`, and a
+# workspace cannot hold two packages with one name. The package name carries the
+# variant; `[lib] name` stays `transfer_hook`, which is what Anchor.toml, the IDL
+# and the .so are keyed on.
+name = "transfer-hook-transfer-cost"
 version = "0.1.0"
 description = "Created with Anchor"
 edition = "2021"

--- a/tokens/token-extensions/transfer-hook/transfer-cost/anchor/programs/transfer-hook/src/entrypoint.rs
+++ b/tokens/token-extensions/transfer-hook/transfer-cost/anchor/programs/transfer-hook/src/entrypoint.rs
@@ -20,11 +20,19 @@ pinocchio::default_allocator!();
 pinocchio::default_panic_handler!();
 
 /// Interface discriminator paired with the handler's own, in declaration order.
+// Read only by `entrypoint` below, which the host build cfgs out.
+#[cfg(target_os = "solana")]
 const DISCRIMINATOR_MAP: [([u8; 8], [u8; 8]); 2] = [
     // initialize_extra_account_meta_list
-    ([43, 34, 13, 49, 167, 88, 235, 235], [92, 197, 174, 197, 41, 124, 19, 3]),
+    (
+        [43, 34, 13, 49, 167, 88, 235, 235],
+        [92, 197, 174, 197, 41, 124, 19, 3],
+    ),
     // transfer_hook
-    ([105, 37, 101, 197, 75, 251, 102, 26], [220, 57, 220, 152, 126, 125, 97, 168]),
+    (
+        [105, 37, 101, 197, 75, 251, 102, 26],
+        [220, 57, 220, 152, 126, 125, 97, 168],
+    ),
 ];
 
 /// # Safety

--- a/tokens/token-extensions/transfer-hook/transfer-cost/anchor/programs/transfer-hook/src/instructions/initialize_extra_account_meta_list.rs
+++ b/tokens/token-extensions/transfer-hook/transfer-cost/anchor/programs/transfer-hook/src/instructions/initialize_extra_account_meta_list.rs
@@ -29,7 +29,7 @@ pub struct InitializeExtraAccountMetaListAccountConstraints {
 }
 
 pub fn handler(
-    mut context: &mut Context<InitializeExtraAccountMetaListAccountConstraints>,
+    context: &mut Context<InitializeExtraAccountMetaListAccountConstraints>,
 ) -> Result<()> {
     let extra_account_metas = handle_extra_account_metas()?;
 

--- a/tokens/token-extensions/transfer-hook/transfer-cost/anchor/programs/transfer-hook/src/instructions/transfer_hook.rs
+++ b/tokens/token-extensions/transfer-hook/transfer-cost/anchor/programs/transfer-hook/src/instructions/transfer_hook.rs
@@ -5,7 +5,7 @@ use anchor_spl::{
     token_interface::{transfer_checked, Mint, TokenAccount, TransferChecked},
 };
 
-use crate::{check_is_transferring, CounterAccount, TransferError};
+use crate::{check_is_transferring, CounterAccount};
 
 // Order of accounts matters for this struct.
 // The first 4 accounts are the accounts required for token transfer (source, mint, destination, owner)
@@ -55,7 +55,7 @@ pub struct TransferHookAccountConstraints {
 
 pub fn handler(context: &mut Context<TransferHookAccountConstraints>, amount: u64) -> Result<()> {
     // Fail this instruction if it is not called from within a transfer hook
-    check_is_transferring(&context)?;
+    check_is_transferring(context)?;
 
     if amount > 50 {
         msg!("The amount is too big {0}", amount);

--- a/tokens/token-extensions/transfer-hook/transfer-cost/anchor/programs/transfer-hook/src/lib.rs
+++ b/tokens/token-extensions/transfer-hook/transfer-cost/anchor/programs/transfer-hook/src/lib.rs
@@ -4,21 +4,13 @@ use anchor_spl::{
     token::Token,
     token_2022::spl_token_2022::{
         extension::{
-            transfer_hook::TransferHookAccount, BaseStateWithExtensions,
-            PodStateWithExtensions,
+            transfer_hook::TransferHookAccount, BaseStateWithExtensions, PodStateWithExtensions,
         },
         pod::PodAccount,
     },
-    token_interface::Mint,
 };
-use spl_discriminator::SplDiscriminate;
-use spl_tlv_account_resolution::{
-    account::ExtraAccountMeta, seeds::Seed, state::ExtraAccountMetaList,
-};
-use spl_transfer_hook_interface::instruction::{
-    ExecuteInstruction, InitializeExtraAccountMetaListInstruction,
-};
-use std::{cell::RefMut, str::FromStr};
+use spl_tlv_account_resolution::{account::ExtraAccountMeta, seeds::Seed};
+use std::str::FromStr;
 
 // transfer-hook program that charges a SOL fee on token transfer
 // use a delegate and wrapped SOL because signers from initial transfer are not accessible

--- a/tokens/token-extensions/transfer-hook/transfer-switch/anchor/programs/transfer-switch/src/entrypoint.rs
+++ b/tokens/token-extensions/transfer-hook/transfer-switch/anchor/programs/transfer-switch/src/entrypoint.rs
@@ -20,11 +20,19 @@ pinocchio::default_allocator!();
 pinocchio::default_panic_handler!();
 
 /// Interface discriminator paired with the handler's own, in declaration order.
+// Read only by `entrypoint` below, which the host build cfgs out.
+#[cfg(target_os = "solana")]
 const DISCRIMINATOR_MAP: [([u8; 8], [u8; 8]); 2] = [
     // initialize_extra_account_metas_list
-    ([43, 34, 13, 49, 167, 88, 235, 235], [253, 251, 47, 0, 182, 68, 159, 62]),
+    (
+        [43, 34, 13, 49, 167, 88, 235, 235],
+        [253, 251, 47, 0, 182, 68, 159, 62],
+    ),
     // transfer_hook
-    ([105, 37, 101, 197, 75, 251, 102, 26], [220, 57, 220, 152, 126, 125, 97, 168]),
+    (
+        [105, 37, 101, 197, 75, 251, 102, 26],
+        [220, 57, 220, 152, 126, 125, 97, 168],
+    ),
 ];
 
 /// # Safety

--- a/tokens/token-extensions/transfer-hook/transfer-switch/anchor/programs/transfer-switch/src/instructions/transfer_hook.rs
+++ b/tokens/token-extensions/transfer-hook/transfer-switch/anchor/programs/transfer-switch/src/instructions/transfer_hook.rs
@@ -4,8 +4,7 @@ use {
     anchor_spl::{
         token_2022::spl_token_2022::{
             extension::{
-                transfer_hook::TransferHookAccount, BaseStateWithExtensions,
-                PodStateWithExtensions,
+                transfer_hook::TransferHookAccount, BaseStateWithExtensions, PodStateWithExtensions,
             },
             pod::PodAccount,
         },

--- a/tokens/token-extensions/transfer-hook/transfer-switch/anchor/programs/transfer-switch/src/lib.rs
+++ b/tokens/token-extensions/transfer-hook/transfer-switch/anchor/programs/transfer-switch/src/lib.rs
@@ -4,10 +4,6 @@ mod state;
 
 use anchor_lang::prelude::*;
 use instructions::*;
-use spl_discriminator::SplDiscriminate;
-use spl_transfer_hook_interface::instruction::{
-    ExecuteInstruction, InitializeExtraAccountMetaListInstruction,
-};
 
 declare_id!("FjcHckEgXcBhFmSGai3FRpDLiT6hbpV893n8iTxVd81g");
 
@@ -22,9 +18,7 @@ pub mod entrypoint;
 pub mod transfer_switch {
     use super::*;
 
-    pub fn configure_admin(
-        mut context: &mut Context<ConfigureAdminAccountConstraints>,
-    ) -> Result<()> {
+    pub fn configure_admin(context: &mut Context<ConfigureAdminAccountConstraints>) -> Result<()> {
         let bump = context.bumps.admin_config;
         handle_is_admin(&mut context.accounts)?;
         handle_configure_admin(&mut context.accounts, bump)
@@ -32,19 +26,19 @@ pub mod transfer_switch {
 
     // sha256("spl-transfer-hook-interface:initialize-extra-account-metas")[..8]
     pub fn initialize_extra_account_metas_list(
-        mut context: &mut Context<InitializeExtraAccountMetasAccountConstraints>,
+        context: &mut Context<InitializeExtraAccountMetasAccountConstraints>,
     ) -> Result<()> {
         handle_initialize_extra_account_metas_list(&mut context.accounts, &context.bumps)
     }
 
-    pub fn switch(mut context: &mut Context<SwitchAccountConstraints>, on: bool) -> Result<()> {
+    pub fn switch(context: &mut Context<SwitchAccountConstraints>, on: bool) -> Result<()> {
         let bump = context.bumps.wallet_switch;
         handle_switch(&mut context.accounts, on, bump)
     }
 
     // sha256("spl-transfer-hook-interface:execute")[..8]
     pub fn transfer_hook(
-        mut context: &mut Context<TransferHookAccountConstraints>,
+        context: &mut Context<TransferHookAccountConstraints>,
         _amount: u64,
     ) -> Result<()> {
         handle_assert_is_transferring(&mut context.accounts)?;

--- a/tokens/token-extensions/transfer-hook/whitelist/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/whitelist/anchor/programs/transfer-hook/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
-name = "transfer-hook"
+# Five transfer-hook examples ship a crate in `programs/transfer-hook`, and a
+# workspace cannot hold two packages with one name. The package name carries the
+# variant; `[lib] name` stays `transfer_hook`, which is what Anchor.toml, the IDL
+# and the .so are keyed on.
+name = "transfer-hook-whitelist"
 version = "0.1.0"
 description = "Created with Anchor"
 edition = "2021"

--- a/tokens/token-extensions/transfer-hook/whitelist/anchor/programs/transfer-hook/src/entrypoint.rs
+++ b/tokens/token-extensions/transfer-hook/whitelist/anchor/programs/transfer-hook/src/entrypoint.rs
@@ -20,11 +20,19 @@ pinocchio::default_allocator!();
 pinocchio::default_panic_handler!();
 
 /// Interface discriminator paired with the handler's own, in declaration order.
+// Read only by `entrypoint` below, which the host build cfgs out.
+#[cfg(target_os = "solana")]
 const DISCRIMINATOR_MAP: [([u8; 8], [u8; 8]); 2] = [
     // initialize_extra_account_meta_list
-    ([43, 34, 13, 49, 167, 88, 235, 235], [92, 197, 174, 197, 41, 124, 19, 3]),
+    (
+        [43, 34, 13, 49, 167, 88, 235, 235],
+        [92, 197, 174, 197, 41, 124, 19, 3],
+    ),
     // transfer_hook
-    ([105, 37, 101, 197, 75, 251, 102, 26], [220, 57, 220, 152, 126, 125, 97, 168]),
+    (
+        [105, 37, 101, 197, 75, 251, 102, 26],
+        [220, 57, 220, 152, 126, 125, 97, 168],
+    ),
 ];
 
 /// # Safety

--- a/tokens/token-extensions/transfer-hook/whitelist/anchor/programs/transfer-hook/src/instructions/initialize_extra_account_meta_list.rs
+++ b/tokens/token-extensions/transfer-hook/whitelist/anchor/programs/transfer-hook/src/instructions/initialize_extra_account_meta_list.rs
@@ -29,7 +29,7 @@ pub struct InitializeExtraAccountMetaListAccountConstraints {
 }
 
 pub fn handler(
-    mut context: &mut Context<InitializeExtraAccountMetaListAccountConstraints>,
+    context: &mut Context<InitializeExtraAccountMetaListAccountConstraints>,
 ) -> Result<()> {
     // set authority field on white_list account as payer address
     context.accounts.white_list.authority = *context.accounts.payer.address();

--- a/tokens/token-extensions/transfer-hook/whitelist/anchor/programs/transfer-hook/src/instructions/transfer_hook.rs
+++ b/tokens/token-extensions/transfer-hook/whitelist/anchor/programs/transfer-hook/src/instructions/transfer_hook.rs
@@ -26,13 +26,13 @@ pub struct TransferHookAccountConstraints {
 
 pub fn handler(context: &mut Context<TransferHookAccountConstraints>, _amount: u64) -> Result<()> {
     // Fail this instruction if it is not called from within a transfer hook
-    check_is_transferring(&context)?;
+    check_is_transferring(context)?;
 
     if !context
         .accounts
         .white_list
         .white_list
-        .contains(&context.accounts.destination_token.address())
+        .contains(context.accounts.destination_token.address())
     {
         panic!("Account not in white list!");
     }

--- a/tokens/token-extensions/transfer-hook/whitelist/anchor/programs/transfer-hook/src/lib.rs
+++ b/tokens/token-extensions/transfer-hook/whitelist/anchor/programs/transfer-hook/src/lib.rs
@@ -1,5 +1,3 @@
-use std::cell::RefMut;
-
 use anchor_lang::prelude::*;
 use anchor_spl::token_2022::spl_token_2022::{
     extension::{
@@ -7,11 +5,7 @@ use anchor_spl::token_2022::spl_token_2022::{
     },
     pod::PodAccount,
 };
-use spl_discriminator::SplDiscriminate;
 use spl_tlv_account_resolution::{account::ExtraAccountMeta, seeds::Seed};
-use spl_transfer_hook_interface::instruction::{
-    ExecuteInstruction, InitializeExtraAccountMetaListInstruction,
-};
 
 mod instructions;
 use instructions::*;

--- a/tokens/token-minter/anchor/programs/token-minter/src/instructions/create.rs
+++ b/tokens/token-minter/anchor/programs/token-minter/src/instructions/create.rs
@@ -6,7 +6,7 @@ use {
             CreateMetadataAccountsV3, Metadata,
         },
         mint::{self, Mint},
-        token::{self, Token},
+        token::Token,
     },
 };
 

--- a/tokens/token-minter/native/program/Cargo.toml
+++ b/tokens/token-minter/native/program/Cargo.toml
@@ -10,10 +10,14 @@ solana-program.workspace = true
 solana-system-interface = { version = "2.0.0", features = ["bincode"] }
 spl-token-interface = "2.0.0"
 spl-associated-token-account-interface = "2.0.0"
-mpl-token-metadata = "5.1.1"
+# anchor-spl 2.0.0-rc.1 depends on `=5.1.2-alpha.2`, and a caret range excludes
+# pre-releases, so `^5.1.1` here and that exact pin cannot both be satisfied in
+# one lockfile. Matching the pin is what lets the anchor and native token
+# examples share a workspace.
+mpl-token-metadata = "=5.1.2-alpha.2"
 # Alias for the (older) solana-program version mpl-token-metadata's instruction
 # builders return, so we can name that Instruction/Pubkey type when bridging.
-mpl-solana-program = { package = "solana-program", version = "2.3" }
+mpl-solana-program = { package = "solana-program", version = "3.0" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/tokens/transfer-tokens/native/program/Cargo.toml
+++ b/tokens/transfer-tokens/native/program/Cargo.toml
@@ -10,10 +10,14 @@ solana-program.workspace = true
 solana-system-interface = { version = "2.0.0", features = ["bincode"] }
 spl-token-interface = "2.0.0"
 spl-associated-token-account-interface = "2.0.0"
-mpl-token-metadata = "5.1.1"
+# anchor-spl 2.0.0-rc.1 depends on `=5.1.2-alpha.2`, and a caret range excludes
+# pre-releases, so `^5.1.1` here and that exact pin cannot both be satisfied in
+# one lockfile. Matching the pin is what lets the anchor and native token
+# examples share a workspace.
+mpl-token-metadata = "=5.1.2-alpha.2"
 # Alias for the (older) solana-program version mpl-token-metadata's instruction
 # builders return, so we can name that Instruction/Pubkey type when bridging.
-mpl-solana-program = { package = "solana-program", version = "2.3" }
+mpl-solana-program = { package = "solana-program", version = "3.0" }
 
 [lib]
 crate-type = ["cdylib", "lib"]


### PR DESCRIPTION
**Stacked on #123.** Retarget to `main` once that merges, and do not merge this into a dead branch. The two commits here need the v2 port because the dependency conflict below only exists under `anchor-spl` 2.0.0-rc.1.

`cargo fmt --check` and `cargo clippy -- -D warnings` run from the repository root and only see members of the root workspace. 32 Anchor programs were not members, so CI had never looked at them. This takes the workspace from 61 members to 101.

They used to be members. The original workspace in `17afe2e7` (2023) listed the tokens, compression and oracles programs alongside basics. `a70c93ba` (2024), whose subject is "test: Adding test jobs github actions for anchor and solana native", deleted every member after `basics/transfer-sol` without mentioning it. The native token entries have been re-added one at a time since, as people touched them; the Anchor ones never were. No commit message, comment or issue justifies the omission.

## Three structural fixes were needed

- Five transfer-hook examples all named their crate `transfer-hook`, and one workspace cannot hold two packages with the same name. Each package name now carries its variant. `[lib] name` stays `transfer_hook`, so `Anchor.toml`, the IDL and the `.so` are untouched, and nothing path-depends on these crates.
- Six Anchor programs genuinely use `anchor-spl`'s `metadata` feature, which requires `mpl-token-metadata =5.1.2-alpha.2`. A caret range excludes pre-releases, so the five native token programs asking for `^5.1.1` could not share a lockfile with them. The native programs now match the pin. That also required bumping their aliased `mpl-solana-program` from 2.3 to 3.0: 5.1.1 accepts `solana-program >=1.14, <3.0` while the alpha requires 3.0, and the mismatch surfaced as `expected __Pubkey, found a different __Pubkey` where those programs bridge Metaplex's instruction types. **This means the native token examples now compile against a prerelease Metaplex.**
- `external-delegate-token-master` enabled the `metadata` feature without using it, so that came off.

## The lints those crates had never been run through

Unused imports, needless borrows of `.address()` (which returns a reference already), `.clone()` on `CpiHandle`/`CpiHandleMut` (both `Copy`), `mut` on bindings that are already `&mut`, `#[instruction(...)]` parameters only a `seeds` expression reads, and three crates missing the `unexpected_cfgs` check-cfg declaration the rest of the repository carries.

Two needed more than the mechanical fix. `DISCRIMINATOR_MAP`, `EXECUTE_DISCRIMINATOR` and `TX_HOOK_DISCRIMINATOR` read as dead code because their only user is the `#[cfg(target_os = "solana")]` entrypoint the host build compiles out; they are gated the same way rather than deleted. `create_collection`'s account fields were private, which made the one field no handler reads look unused; they are `pub` now, like every other accounts struct here.

One lint fix was a real bug, caught by the tests. Collapsing `transfer_tokens_from_vault`'s eight arguments to six by passing the `BorshAccount` instead of the fields read `event.event_id` after `release_borrow()`, and `BorshAccount`'s `Deref` panics once the borrow is released. All five betting-market tests failed with a panic inside `serialized_account.rs`. `EventSigner` now copies the view, ID and bump out while the borrow is live, which satisfies `too_many_arguments` and makes the ordering something a caller cannot get wrong.

## Verification

101 workspace members resolve. `cargo fmt --check` and `cargo clippy -- -D warnings -A clippy::diverging_sub_expression` both clean across all of them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbvFm2C5HPuktkz5yi1Kxu)_