### PR TITLE
Unbreak main: the perps v2 build, the Anchor install, and the Biome check

### DIFF
--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -190,28 +190,28 @@ jobs:
         with:
           path: |
             ~/.cargo/bin/anchor
-            ~/.cargo/bin/avm
-            ~/.avm
           # Pinned to match the anchor-lang/anchor-spl crate version the programs depend on.
-          key: anchor-toolchain-${{ runner.os }}-2.0.0-rc.1
+          key: anchor-cli-crates-io-${{ runner.os }}-2.0.0-rc.1
       - name: Install Anchor 2.0.0-rc.1
         run: |
-          export PATH="$HOME/.cargo/bin:$HOME/.avm/bin:$PATH"
+          export PATH="$HOME/.cargo/bin:$PATH"
           # `anchor --version` can emit more than one line; read the first line only so
           # a multi-line value never reaches downstream parsing.
           current="$(anchor --version 2>/dev/null | head -n1 | awk '{print $2}' || true)"
           if [ "$current" != "2.0.0-rc.1" ]; then
-            cargo install --git https://github.com/solana-foundation/anchor avm --force
-            # 2.0.0-rc.1 is a pre-release, so avm needs it named explicitly, and
-            # --from-source because there is no prebuilt binary published for it:
-            # a plain `avm install` 404s and takes the whole job down before any
-            # project is built. The cache above is what keeps the source build
-            # off the critical path on later runs.
-            avm install 2.0.0-rc.1 --from-source
-            avm use 2.0.0-rc.1
+            # Install the CLI from crates.io rather than through avm. avm has no
+            # prebuilt binary for this pre-release (a plain `avm install` 404s), and
+            # its --from-source path builds the CLI from the git tag, which is not
+            # the same code as the published anchor-lang 2.0.0-rc.1 the programs
+            # compile against: `anchor idl build` then emits a shim referencing
+            # `anchor_lang::IdlBuild`, which that crate does not have, and writes
+            # IDL JSON the parser rejects with "missing field `variants`".
+            # Installing the CLI from crates.io keeps it and the library on one
+            # published release. --locked builds it against its own published
+            # lockfile so the result does not drift with the registry.
+            cargo install anchor-cli --version 2.0.0-rc.1 --locked --force
           fi
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-          echo "$HOME/.avm/bin" >> "$GITHUB_PATH"
       - name: Install Surfpool
         run: curl -sL https://run.surfpool.run/ | bash
       - name: Display Versions

--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -202,8 +202,12 @@ jobs:
           current="$(anchor --version 2>/dev/null | head -n1 | awk '{print $2}' || true)"
           if [ "$current" != "2.0.0-rc.1" ]; then
             cargo install --git https://github.com/solana-foundation/anchor avm --force
-            # 2.0.0-rc.1 is a pre-release, so avm needs it named explicitly.
-            avm install 2.0.0-rc.1
+            # 2.0.0-rc.1 is a pre-release, so avm needs it named explicitly, and
+            # --from-source because there is no prebuilt binary published for it:
+            # a plain `avm install` 404s and takes the whole job down before any
+            # project is built. The cache above is what keeps the source build
+            # off the critical path on later runs.
+            avm install 2.0.0-rc.1 --from-source
             avm use 2.0.0-rc.1
           fi
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"

--- a/basics/cross-program-invocation/anchor/idls/lever.json
+++ b/basics/cross-program-invocation/anchor/idls/lever.json
@@ -9,16 +9,7 @@
   "instructions": [
     {
       "name": "initialize",
-      "discriminator": [
-        175,
-        175,
-        109,
-        31,
-        13,
-        152,
-        155,
-        237
-      ],
+      "discriminator": [175, 175, 109, 31, 13, 152, 155, 237],
       "accounts": [
         {
           "name": "power",
@@ -39,16 +30,7 @@
     },
     {
       "name": "switch_power",
-      "discriminator": [
-        226,
-        238,
-        56,
-        172,
-        191,
-        45,
-        122,
-        87
-      ],
+      "discriminator": [226, 238, 56, 172, 191, 45, 122, 87],
       "accounts": [
         {
           "name": "power",
@@ -66,16 +48,7 @@
   "accounts": [
     {
       "name": "PowerStatus",
-      "discriminator": [
-        145,
-        147,
-        198,
-        35,
-        253,
-        101,
-        231,
-        26
-      ]
+      "discriminator": [145, 147, 198, 35, 253, 101, 231, 26]
     }
   ],
   "types": [

--- a/finance/lending/anchor/programs/lending/tests/test_reserve.rs
+++ b/finance/lending/anchor/programs/lending/tests/test_reserve.rs
@@ -98,8 +98,15 @@ fn slots_per_year_scales_the_per_slot_rate() {
         env.supply(&borrower, &collateral, 1_000_000_000);
         let obligation = env.initialize_obligation(&borrower);
         env.post_collateral(&borrower, obligation, &collateral, 1_000_000_000);
-        env.try_borrow(&borrower, obligation, &[&collateral], &[], reserve, 500_000_000)
-            .unwrap();
+        env.try_borrow(
+            &borrower,
+            obligation,
+            &[&collateral],
+            &[],
+            reserve,
+            500_000_000,
+        )
+        .unwrap();
     }
 
     let elapsed = SLOTS_PER_YEAR / 100;

--- a/finance/perpetual-futures/anchor/programs/perpetual-futures/src/instructions/open_position.rs
+++ b/finance/perpetual-futures/anchor/programs/perpetual-futures/src/instructions/open_position.rs
@@ -126,7 +126,10 @@ pub fn handle_open_position(
 }
 
 #[derive(Accounts)]
-#[instruction(side: Side)]
+// The leading underscore is for rustc: `#[derive(Accounts)]` expands
+// `_side` into a path that never reads it, so the plain name warns as
+// unused. The `seeds` expression below is the real use.
+#[instruction(_side: Side)]
 pub struct OpenPositionAccountConstraints {
     #[account(mut)]
     pub owner: Signer,
@@ -142,7 +145,7 @@ pub struct OpenPositionAccountConstraints {
         init,
         payer = owner,
         space = Position::DISCRIMINATOR.len() + Position::INIT_SPACE,
-        seeds = [POSITION_SEED, pool.address().as_ref(), owner.address().as_ref(), side.as_seed()],
+        seeds = [POSITION_SEED, pool.address().as_ref(), owner.address().as_ref(), _side.as_seed()],
         bump,
     )]
     pub position: Box<BorshAccount<Position>>,

--- a/finance/perpetual-futures/anchor/programs/perpetual-futures/src/instructions/set_funding_rate.rs
+++ b/finance/perpetual-futures/anchor/programs/perpetual-futures/src/instructions/set_funding_rate.rs
@@ -14,7 +14,7 @@ use crate::state::Pool;
 /// charged at the rate that was in force for them rather than repriced by the
 /// new one.
 pub fn handle_set_funding_rate(
-    context: Context<SetFundingRateAccountConstraints>,
+    context: &mut Context<SetFundingRateAccountConstraints>,
     funding_rate_per_slot: u64,
 ) -> Result<()> {
     let pool = &mut context.accounts.pool;
@@ -24,14 +24,14 @@ pub fn handle_set_funding_rate(
 }
 
 #[derive(Accounts)]
-pub struct SetFundingRateAccountConstraints<'info> {
-    pub authority: Signer<'info>,
+pub struct SetFundingRateAccountConstraints {
+    #[account(address = pool.authority)]
+    pub authority: Signer,
 
     #[account(
         mut,
         seeds = [POOL_SEED, pool.collateral_mint.as_ref(), pool.oracle_feed.as_ref()],
         bump = pool.bump,
-        has_one = authority,
     )]
-    pub pool: Box<Account<'info, Pool>>,
+    pub pool: Box<BorshAccount<Pool>>,
 }

--- a/finance/perpetual-futures/anchor/programs/perpetual-futures/src/lib.rs
+++ b/finance/perpetual-futures/anchor/programs/perpetual-futures/src/lib.rs
@@ -86,7 +86,7 @@ pub mod perpetual_futures {
     /// Pool authority retunes the per-slot funding rate, accruing at the old
     /// rate first.
     pub fn set_funding_rate(
-        context: Context<SetFundingRateAccountConstraints>,
+        context: &mut Context<SetFundingRateAccountConstraints>,
         funding_rate_per_slot: u64,
     ) -> Result<()> {
         instructions::handle_set_funding_rate(context, funding_rate_per_slot)

--- a/finance/perpetual-futures/anchor/programs/perpetual-futures/tests/test_perpetual_futures.rs
+++ b/finance/perpetual-futures/anchor/programs/perpetual-futures/tests/test_perpetual_futures.rs
@@ -957,7 +957,10 @@ fn test_set_funding_rate_settles_at_the_old_rate_first() {
 
     let flat = funding_for(false);
     let retuned = funding_for(true);
-    assert!(flat > 0, "the flat run must pay some funding to compare against");
+    assert!(
+        flat > 0,
+        "the flat run must pay some funding to compare against"
+    );
 
     // Half the elapsed slots at 1x and half at 2x is 1.5x the flat run. Had the
     // handler skipped its accrual, the new rate would have applied to every


### PR DESCRIPTION
`main` is red in three independent ways. This PR fixes all three.

## 1. `finance/perpetual-futures` does not compile

```
error: handler context must be passed by mutable reference: use `ctx: &mut Context<T>`
```

plus eight more behind it, so `anchor build` fails for the whole project and its 28 tests never run.

`perps: let the pool authority retune the funding rate` landed on `main` *after* the Anchor v2 port and was written against v1: `Context<T>` rather than `&mut Context<T>`, `Signer<'info>`, `Box<Account<'info, Pool>>`, and `has_one = authority`.

Nothing caught it. `perpetual-futures` is not a root workspace member, so neither `cargo clippy` nor `cargo fmt --check` has ever seen the crate, and the Anchor workflow only builds projects a push actually touches.

The fix is the usual v2 port: `&mut Context<T>`, the `'info` lifetime dropped, `Box<BorshAccount<Pool>>` to match every sibling handler, and `has_one` replaced by `address = pool.authority` on the signer. Two more things the crate needed for the same reason nobody had looked at it: `#[instruction(side: Side)]` warns as an unused variable under v2's `#[derive(Accounts)]` expansion so it takes the leading underscore the other examples use, and `main`'s new lending and perps test code was never formatted.

## 2. The Anchor workflow cannot install Anchor

Runs on `main` were green only because they hit a warm toolchain cache and skipped the install entirely. That cache is gone, and the install underneath it does not work:

```
Error: No prebuilt binary found for version `2.0.0-rc.1` (HTTP 404).
```

avm has no prebuilt binary for this pre-release. Its `--from-source` path is not a substitute: it builds the CLI from the `v2.0.0-rc.1` **git tag**, which is not the same code as the `anchor-lang` 2.0.0-rc.1 **published on crates.io** that every program here compiles against. I tried that first and it took `anchor build` down across half the repository with `cannot find trait IdlBuild in crate anchor_lang` and `missing field variants`, both out of `anchor idl build`, on projects that have nothing wrong with them.

crates.io publishes `anchor-cli` 2.0.0-rc.1 alongside the library, so the workflow now installs it from there with `--locked` and drops avm. avm is a version manager and this workflow pins one version, so it was not earning its place. The cache key changes with the install method, so no run can resurrect a binary built the old way.

## 3. Biome fails on a regenerated IDL

`biome check ./` formats JSON as well as TypeScript. `anchor build` regenerated `basics/cross-program-invocation/anchor/idls/lever.json` with one array element per line, and Biome puts those on a single line, so the TypeScript workflow has failed on every commit since. Formatting only; the IDL's contents are unchanged, so `declare_program!` and the LiteSVM tests that read it see what they saw before.

## Verification

Locally: `cargo check`, `cargo clippy -- -D warnings` and `cargo fmt --check` are clean on `perpetual-futures`; repository-wide `cargo fmt --all --check` and `cargo clippy -- -D warnings -A clippy::diverging_sub_expression` pass; `biome check` over the 155 tracked files CI sees reports zero errors.

Because this touches `.github/workflows/anchor.yml`, the `changes` job builds **every** Anchor project rather than the few this diff touches, so each run here is a full 55-project sweep.

On the mismatched-CLI run, `perpetual-futures` got past the compile error this PR exists to fix and died at the same IDL stage as everyone else, with no `perpetual_futures` compile diagnostic anywhere in the log; `escrow` and `lending`, in the same group, built and tested clean. The sweep on the corrected toolchain is what will confirm it end to end.

## Relationship to #128

#128 carries the `perpetual-futures` fix as one commit among a ~100-file change that adds every Anchor program to the root workspace. Here it is on its own, so it can land without waiting on that review. The file contents are identical, so whichever merges second is a no-op for those hunks.

The remaining known breakage, the ASM workflow's `cargo install --git .../sbpf.git` picking between two binaries after upstream added an `xtask` crate, is not included here: ASM does not run on this PR, so it is not blocking. That fix sits on `claude/docs-match-implementation`.