### PR TITLE
Move every example onto Anchor v2's LiteSVM test harness

### DIFF
--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -309,8 +309,10 @@ jobs:
               return 1
             fi
 
-            # Run anchor test
-            if ! anchor test; then
+            # Run anchor test. It regenerates the IDL too, so the skip above
+            # has to apply here as well or the projects it exempts fail at the
+            # test step instead of the build step.
+            if ! anchor test $idl_flag; then
               echo "::error::anchor test failed for $project"
               echo "$project: anchor test failed" >> $GITHUB_WORKSPACE/failed_projects.txt
               rm -rf target node_modules

--- a/basics/account-data/anchor/programs/anchor-program-example/Cargo.toml
+++ b/basics/account-data/anchor/programs/anchor-program-example/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -26,9 +28,16 @@ anchor-lang = "2.0.0-rc.1"
 wincode = { version = "0.5", features = ["derive"] }
 
 [dev-dependencies]
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 borsh = "1.6.1"
 solana-kite = "0.4.0"
 

--- a/basics/account-data/anchor/programs/anchor-program-example/tests/test_account_data.rs
+++ b/basics/account-data/anchor/programs/anchor-program-example/tests/test_account_data.rs
@@ -1,8 +1,8 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, InstructionData, ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     borsh::BorshDeserialize,
     solana_kite::{create_wallet, send_transaction_from_instructions},
 };

--- a/basics/account-data/anchor/programs/anchor-program-example/tests/test_account_data.rs
+++ b/basics/account-data/anchor/programs/anchor-program-example/tests/test_account_data.rs
@@ -1,12 +1,10 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, InstructionData, ToAccountMetas,
     },
     borsh::BorshDeserialize,
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{create_wallet, send_transaction_from_instructions},
-    solana_signer::Signer,
 };
 
 /// Deserialize the AddressInfo account (8-byte discriminator + fields).
@@ -22,7 +20,7 @@ struct AddressInfoAccount {
 #[test]
 fn test_create_address_info() {
     let program_id = account_data_anchor_program::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
     let bytes = include_bytes!("../../../target/deploy/account_data_anchor_program.so");
     svm.add_program(program_id, bytes).unwrap();
     let payer = create_wallet(&mut svm, 10_000_000_000).unwrap();

--- a/basics/checking-accounts/anchor/programs/anchor-program-example/Cargo.toml
+++ b/basics/checking-accounts/anchor/programs/anchor-program-example/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -26,9 +28,16 @@ anchor-lang = "2.0.0-rc.1"
 wincode = { version = "0.5", features = ["derive"] }
 
 [dev-dependencies]
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 borsh = "1.6.1"
 solana-kite = "0.4.0"
 

--- a/basics/checking-accounts/anchor/programs/anchor-program-example/tests/test_checking_accounts.rs
+++ b/basics/checking-accounts/anchor/programs/anchor-program-example/tests/test_checking_accounts.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::{instruction::Instruction, system_instruction},
         system_program, InstructionData, ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{create_wallet, send_transaction_from_instructions},
 };
 

--- a/basics/checking-accounts/anchor/programs/anchor-program-example/tests/test_checking_accounts.rs
+++ b/basics/checking-accounts/anchor/programs/anchor-program-example/tests/test_checking_accounts.rs
@@ -1,18 +1,16 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::{instruction::Instruction, system_instruction},
         system_program, InstructionData, ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{create_wallet, send_transaction_from_instructions},
-    solana_signer::Signer,
 };
 
 #[test]
 fn test_check_accounts() {
     let program_id = checking_account_program::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
     let bytes = include_bytes!("../../../target/deploy/checking_account_program.so");
     svm.add_program(program_id, bytes).unwrap();
     let payer = create_wallet(&mut svm, 10_000_000_000).unwrap();

--- a/basics/close-account/anchor/programs/close-account/Cargo.toml
+++ b/basics/close-account/anchor/programs/close-account/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -32,9 +34,16 @@ wincode = { version = "0.5", features = ["derive"] }
 solana-address = ">=2.6, <2.7"
 
 [dev-dependencies]
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 
 [lints.rust]

--- a/basics/close-account/anchor/programs/close-account/tests/test_close_account.rs
+++ b/basics/close-account/anchor/programs/close-account/tests/test_close_account.rs
@@ -1,17 +1,15 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{create_wallet, send_transaction_from_instructions},
-    solana_signer::Signer,
 };
 
 fn setup() -> (LiteSVM, Keypair) {
     let program_id = close_account_program::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
     let bytes = include_bytes!("../../../target/deploy/close_account_program.so");
     svm.add_program(program_id, bytes).unwrap();
     let payer = create_wallet(&mut svm, 10_000_000_000).unwrap();

--- a/basics/close-account/anchor/programs/close-account/tests/test_close_account.rs
+++ b/basics/close-account/anchor/programs/close-account/tests/test_close_account.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{create_wallet, send_transaction_from_instructions},
 };
 

--- a/basics/counter/anchor/programs/counter_anchor/Cargo.toml
+++ b/basics/counter/anchor/programs/counter_anchor/Cargo.toml
@@ -14,6 +14,8 @@ cpi = ["no-entrypoint"]
 no-entrypoint = []
 no-idl = []
 no-log-ix-name = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
@@ -26,9 +28,16 @@ anchor-lang = "2.0.0-rc.1"
 wincode = { version = "0.5", features = ["derive"] }
 
 [dev-dependencies]
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# It is published only from git: crates.io has no `anchor-v2-testing`. Pinned
+# to a revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 borsh = "1.6.1"
 solana-kite = "0.4.0"
 

--- a/basics/counter/anchor/programs/counter_anchor/tests/test_counter.rs
+++ b/basics/counter/anchor/programs/counter_anchor/tests/test_counter.rs
@@ -2,11 +2,9 @@ use {
     anchor_lang::{
         solana_program::instruction::Instruction, system_program, InstructionData, ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     borsh::BorshDeserialize,
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{create_wallet, send_transaction_from_instructions},
-    solana_signer::Signer,
 };
 
 /// Minimal deserialization of the Counter account (8-byte discriminator + u64).
@@ -18,7 +16,7 @@ struct CounterAccount {
 
 fn setup() -> (LiteSVM, anchor_lang::prelude::Address, Keypair) {
     let program_id = counter_anchor::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
     let bytes = include_bytes!("../../../target/deploy/counter_anchor.so");
     svm.add_program(program_id, bytes).unwrap();
     let payer = create_wallet(&mut svm, 10_000_000_000).unwrap();

--- a/basics/create-account/anchor/programs/create-system-account/Cargo.toml
+++ b/basics/create-account/anchor/programs/create-system-account/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -26,9 +28,16 @@ anchor-lang = "2.0.0-rc.1"
 wincode = { version = "0.5", features = ["derive"] }
 
 [dev-dependencies]
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 
 [lints.rust]

--- a/basics/create-account/anchor/programs/create-system-account/tests/test_create_account.rs
+++ b/basics/create-account/anchor/programs/create-system-account/tests/test_create_account.rs
@@ -1,18 +1,16 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::{instruction::Instruction, rent::Rent},
         system_program, InstructionData, ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{create_wallet, send_transaction_from_instructions},
-    solana_signer::Signer,
 };
 
 #[test]
 fn test_create_the_account() {
     let program_id = create_system_account::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
     let bytes = include_bytes!("../../../target/deploy/create_system_account.so");
     svm.add_program(program_id, bytes).unwrap();
     let payer = create_wallet(&mut svm, 10_000_000_000).unwrap();

--- a/basics/create-account/anchor/programs/create-system-account/tests/test_create_account.rs
+++ b/basics/create-account/anchor/programs/create-system-account/tests/test_create_account.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::{instruction::Instruction, rent::Rent},
         system_program, InstructionData, ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{create_wallet, send_transaction_from_instructions},
 };
 

--- a/basics/cross-program-invocation/anchor/programs/hand/Cargo.toml
+++ b/basics/cross-program-invocation/anchor/programs/hand/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -26,9 +28,16 @@ anchor-lang = "2.0.0-rc.1"
 wincode = { version = "0.5", features = ["derive"] }
 
 [dev-dependencies]
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 
 [lints.rust]

--- a/basics/cross-program-invocation/anchor/programs/hand/tests/test_hand.rs
+++ b/basics/cross-program-invocation/anchor/programs/hand/tests/test_hand.rs
@@ -1,12 +1,10 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::{AccountMeta, Instruction},
         system_program, Address, InstructionData, ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{create_wallet, send_transaction_from_instructions},
-    solana_signer::Signer,
 };
 
 /// PowerStatus account layout: 8-byte discriminator + 1-byte bool + 7 bytes padding.
@@ -43,7 +41,7 @@ fn test_pull_lever_cpi() {
     // The lever program ID from declare_program!(lever) inside hand crate
     let lever_program_id = hand::lever::ID;
 
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     // Load both programs
     let hand_bytes = include_bytes!("../../../target/deploy/hand.so");

--- a/basics/cross-program-invocation/anchor/programs/hand/tests/test_hand.rs
+++ b/basics/cross-program-invocation/anchor/programs/hand/tests/test_hand.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::{AccountMeta, Instruction},
         system_program, Address, InstructionData, ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{create_wallet, send_transaction_from_instructions},
 };
 

--- a/basics/cross-program-invocation/anchor/programs/lever/Cargo.toml
+++ b/basics/cross-program-invocation/anchor/programs/lever/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -26,9 +28,16 @@ anchor-lang = "2.0.0-rc.1"
 wincode = { version = "0.5", features = ["derive"] }
 
 [dev-dependencies]
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 
 [lints.rust]

--- a/basics/cross-program-invocation/anchor/programs/lever/tests/test_lever.rs
+++ b/basics/cross-program-invocation/anchor/programs/lever/tests/test_lever.rs
@@ -1,8 +1,8 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, InstructionData, ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{create_wallet, send_transaction_from_instructions},
 };
 

--- a/basics/cross-program-invocation/anchor/programs/lever/tests/test_lever.rs
+++ b/basics/cross-program-invocation/anchor/programs/lever/tests/test_lever.rs
@@ -1,11 +1,9 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, InstructionData, ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{create_wallet, send_transaction_from_instructions},
-    solana_signer::Signer,
 };
 
 /// PowerStatus account layout: 8-byte discriminator + 1-byte bool + 7 bytes padding.
@@ -18,7 +16,7 @@ fn read_power_is_on(svm: &LiteSVM, pubkey: &anchor_lang::prelude::Address) -> bo
 #[test]
 fn test_initialize_lever() {
     let program_id = lever::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
     let bytes = include_bytes!("../../../target/deploy/lever.so");
     svm.add_program(program_id, bytes).unwrap();
     let payer = create_wallet(&mut svm, 10_000_000_000).unwrap();
@@ -53,7 +51,7 @@ fn test_initialize_lever() {
 #[test]
 fn test_switch_power() {
     let program_id = lever::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
     let bytes = include_bytes!("../../../target/deploy/lever.so");
     svm.add_program(program_id, bytes).unwrap();
     let payer = create_wallet(&mut svm, 10_000_000_000).unwrap();

--- a/basics/favorites/anchor/programs/favorites/Cargo.toml
+++ b/basics/favorites/anchor/programs/favorites/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -26,9 +28,16 @@ anchor-lang = "2.0.0-rc.1"
 wincode = { version = "0.5", features = ["derive"] }
 
 [dev-dependencies]
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 
 [lints.rust]

--- a/basics/favorites/anchor/programs/favorites/tests/test_favorites.rs
+++ b/basics/favorites/anchor/programs/favorites/tests/test_favorites.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{LiteSVM, Signer},
     solana_kite::{create_wallet, send_transaction_from_instructions},
 };
 
@@ -50,7 +50,7 @@ fn read_favorites(svm: &LiteSVM, pda: &Address) -> FavoritesData {
     }
 }
 
-fn setup() -> (LiteSVM, Address, solana_keypair::Keypair) {
+fn setup() -> (LiteSVM, Address, anchor_v2_testing::Keypair) {
     let program_id = favorites::id();
     let mut svm = anchor_v2_testing::svm();
     let bytes = include_bytes!("../../../target/deploy/favorites.so");

--- a/basics/favorites/anchor/programs/favorites/tests/test_favorites.rs
+++ b/basics/favorites/anchor/programs/favorites/tests/test_favorites.rs
@@ -1,11 +1,10 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
-    litesvm::LiteSVM,
     solana_kite::{create_wallet, send_transaction_from_instructions},
-    solana_signer::Signer,
 };
 
 struct FavoritesData {
@@ -53,7 +52,7 @@ fn read_favorites(svm: &LiteSVM, pda: &Address) -> FavoritesData {
 
 fn setup() -> (LiteSVM, Address, solana_keypair::Keypair) {
     let program_id = favorites::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
     let bytes = include_bytes!("../../../target/deploy/favorites.so");
     svm.add_program(program_id, bytes).unwrap();
     let payer = create_wallet(&mut svm, 10_000_000_000).unwrap();

--- a/basics/hello-solana/anchor/programs/hello-solana/Cargo.toml
+++ b/basics/hello-solana/anchor/programs/hello-solana/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -26,8 +28,16 @@ anchor-lang = "2.0.0-rc.1"
 wincode = { version = "0.5", features = ["derive"] }
 
 [dev-dependencies]
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 solana-transaction = "3.0.1"
 

--- a/basics/hello-solana/anchor/programs/hello-solana/tests/test_hello.rs
+++ b/basics/hello-solana/anchor/programs/hello-solana/tests/test_hello.rs
@@ -1,15 +1,14 @@
 use {
     anchor_lang::{solana_program::instruction::Instruction, InstructionData, ToAccountMetas},
-    litesvm::LiteSVM,
+    anchor_v2_testing::{LiteSVM, Signer},
     solana_kite::create_wallet,
-    solana_signer::Signer,
     solana_transaction::Transaction,
 };
 
 #[test]
 fn test_say_hello() {
     let program_id = hello_solana::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
     let bytes = include_bytes!("../../../target/deploy/hello_solana.so");
     svm.add_program(program_id, bytes).unwrap();
     let payer = create_wallet(&mut svm, 1_000_000_000).unwrap();

--- a/basics/pda-rent-payer/anchor/programs/anchor-program-example/Cargo.toml
+++ b/basics/pda-rent-payer/anchor/programs/anchor-program-example/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -26,9 +28,16 @@ anchor-lang = "2.0.0-rc.1"
 wincode = { version = "0.5", features = ["derive"] }
 
 [dev-dependencies]
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 
 [lints.rust]

--- a/basics/pda-rent-payer/anchor/programs/anchor-program-example/tests/test_pda_rent_payer.rs
+++ b/basics/pda-rent-payer/anchor/programs/anchor-program-example/tests/test_pda_rent_payer.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{create_wallet, send_transaction_from_instructions},
 };
 

--- a/basics/pda-rent-payer/anchor/programs/anchor-program-example/tests/test_pda_rent_payer.rs
+++ b/basics/pda-rent-payer/anchor/programs/anchor-program-example/tests/test_pda_rent_payer.rs
@@ -1,17 +1,15 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{create_wallet, send_transaction_from_instructions},
-    solana_signer::Signer,
 };
 
 fn setup() -> (LiteSVM, Keypair) {
     let program_id = pda_rent_payer::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
     let bytes = include_bytes!("../../../target/deploy/pda_rent_payer.so");
     svm.add_program(program_id, bytes).unwrap();
     let payer = create_wallet(&mut svm, 10_000_000_000).unwrap();

--- a/basics/processing-instructions/anchor/programs/processing-instructions/Cargo.toml
+++ b/basics/processing-instructions/anchor/programs/processing-instructions/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -26,9 +28,16 @@ anchor-lang = "2.0.0-rc.1"
 wincode = { version = "0.5", features = ["derive"] }
 
 [dev-dependencies]
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 
 [lints.rust]

--- a/basics/processing-instructions/anchor/programs/processing-instructions/tests/test_processing_instructions.rs
+++ b/basics/processing-instructions/anchor/programs/processing-instructions/tests/test_processing_instructions.rs
@@ -1,13 +1,12 @@
 use {
     anchor_lang::{solana_program::instruction::Instruction, InstructionData, ToAccountMetas},
-    litesvm::LiteSVM,
+    anchor_v2_testing::{LiteSVM, Signer},
     solana_kite::{create_wallet, send_transaction_from_instructions},
-    solana_signer::Signer,
 };
 
 fn setup() -> (LiteSVM, solana_keypair::Keypair) {
     let program_id = processing_instructions::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
     let bytes = include_bytes!("../../../target/deploy/processing_instructions.so");
     svm.add_program(program_id, bytes).unwrap();
     let payer = create_wallet(&mut svm, 10_000_000_000).unwrap();

--- a/basics/processing-instructions/anchor/programs/processing-instructions/tests/test_processing_instructions.rs
+++ b/basics/processing-instructions/anchor/programs/processing-instructions/tests/test_processing_instructions.rs
@@ -4,7 +4,7 @@ use {
     solana_kite::{create_wallet, send_transaction_from_instructions},
 };
 
-fn setup() -> (LiteSVM, solana_keypair::Keypair) {
+fn setup() -> (LiteSVM, anchor_v2_testing::Keypair) {
     let program_id = processing_instructions::id();
     let mut svm = anchor_v2_testing::svm();
     let bytes = include_bytes!("../../../target/deploy/processing_instructions.so");

--- a/basics/program-derived-addresses/anchor/programs/anchor-program-example/Cargo.toml
+++ b/basics/program-derived-addresses/anchor/programs/anchor-program-example/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -26,9 +28,16 @@ anchor-lang = "2.0.0-rc.1"
 wincode = { version = "0.5", features = ["derive"] }
 
 [dev-dependencies]
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 borsh = "1.6.1"
 solana-kite = "0.4.0"
 

--- a/basics/program-derived-addresses/anchor/programs/anchor-program-example/tests/test_program_derived_addresses.rs
+++ b/basics/program-derived-addresses/anchor/programs/anchor-program-example/tests/test_program_derived_addresses.rs
@@ -1,17 +1,16 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
     borsh::BorshDeserialize,
-    litesvm::LiteSVM,
     solana_kite::{create_wallet, send_transaction_from_instructions},
-    solana_signer::Signer,
 };
 
 fn setup() -> (LiteSVM, solana_keypair::Keypair) {
     let program_id = program_derived_addresses_program::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
     let bytes = include_bytes!("../../../target/deploy/program_derived_addresses_program.so");
     svm.add_program(program_id, bytes).unwrap();
     let payer = create_wallet(&mut svm, 10_000_000_000).unwrap();

--- a/basics/program-derived-addresses/anchor/programs/anchor-program-example/tests/test_program_derived_addresses.rs
+++ b/basics/program-derived-addresses/anchor/programs/anchor-program-example/tests/test_program_derived_addresses.rs
@@ -1,14 +1,14 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{LiteSVM, Signer},
     borsh::BorshDeserialize,
     solana_kite::{create_wallet, send_transaction_from_instructions},
 };
 
-fn setup() -> (LiteSVM, solana_keypair::Keypair) {
+fn setup() -> (LiteSVM, anchor_v2_testing::Keypair) {
     let program_id = program_derived_addresses_program::id();
     let mut svm = anchor_v2_testing::svm();
     let bytes = include_bytes!("../../../target/deploy/program_derived_addresses_program.so");

--- a/basics/pyth/anchor/programs/pythexample/Cargo.toml
+++ b/basics/pyth/anchor/programs/pythexample/Cargo.toml
@@ -19,6 +19,8 @@ anchor-debug = []
 custom-heap = []
 custom-panic = []
 
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -31,15 +33,22 @@ wincode = { version = "0.5", features = ["derive"] }
 solana-address = ">=2.6, <2.7"
 
 [dev-dependencies]
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 # Self-dependency with no-entrypoint: host test builds otherwise export a
 # #[no_mangle] `entrypoint` symbol from this crate AND from spl-token (via
 # solana-kite), and the linker rejects the duplicate. The SBF build
 # (cargo build-sbf) ignores dev-dependencies, so the deployed program keeps
 # its entrypoint.
 pythexample = { path = ".", features = ["no-entrypoint"] }
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
 solana-account = "3.0.0"
 solana-clock = "3.0.1"
 borsh = "1.6.1"

--- a/basics/pyth/anchor/programs/pythexample/tests/test_pyth.rs
+++ b/basics/pyth/anchor/programs/pythexample/tests/test_pyth.rs
@@ -1,8 +1,8 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, Address, InstructionData, ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     pythexample::MAXIMUM_PRICE_AGE_SECONDS,
     // LiteSVM's get_sysvar wants the host-side Clock, not pinocchio's.
     solana_clock::Clock,
@@ -81,7 +81,7 @@ fn set_clock_to_price_age(svm: &mut LiteSVM, age_seconds: i64) {
 
 fn setup_with_price_account(
     owner: anchor_lang::Address,
-) -> (LiteSVM, solana_keypair::Keypair, Keypair) {
+) -> (LiteSVM, anchor_v2_testing::Keypair, Keypair) {
     let program_id = pythexample::id();
     let mut svm = anchor_v2_testing::svm();
     let bytes = include_bytes!("../../../target/deploy/pythexample.so");

--- a/basics/pyth/anchor/programs/pythexample/tests/test_pyth.rs
+++ b/basics/pyth/anchor/programs/pythexample/tests/test_pyth.rs
@@ -1,14 +1,12 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, Address, InstructionData, ToAccountMetas,
     },
-    litesvm::LiteSVM,
     pythexample::MAXIMUM_PRICE_AGE_SECONDS,
     // LiteSVM's get_sysvar wants the host-side Clock, not pinocchio's.
     solana_clock::Clock,
-    solana_keypair::Keypair,
     solana_kite::{create_wallet, send_transaction_from_instructions},
-    solana_signer::Signer,
 };
 
 /// The `publish_time` baked into the mock price update below.
@@ -85,7 +83,7 @@ fn setup_with_price_account(
     owner: anchor_lang::Address,
 ) -> (LiteSVM, solana_keypair::Keypair, Keypair) {
     let program_id = pythexample::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
     let bytes = include_bytes!("../../../target/deploy/pythexample.so");
     svm.add_program(program_id, bytes).unwrap();
     let payer = create_wallet(&mut svm, 10_000_000_000).unwrap();

--- a/basics/realloc/anchor/programs/anchor-realloc/Cargo.toml
+++ b/basics/realloc/anchor/programs/anchor-realloc/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -26,9 +28,16 @@ anchor-lang = "2.0.0-rc.1"
 wincode = { version = "0.5", features = ["derive"] }
 
 [dev-dependencies]
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 borsh = "1.6.1"
 solana-kite = "0.4.0"
 

--- a/basics/realloc/anchor/programs/anchor-realloc/tests/test_realloc.rs
+++ b/basics/realloc/anchor/programs/anchor-realloc/tests/test_realloc.rs
@@ -1,8 +1,8 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, InstructionData, ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     borsh::BorshDeserialize,
     solana_kite::{create_wallet, send_transaction_from_instructions},
 };

--- a/basics/realloc/anchor/programs/anchor-realloc/tests/test_realloc.rs
+++ b/basics/realloc/anchor/programs/anchor-realloc/tests/test_realloc.rs
@@ -1,12 +1,10 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, InstructionData, ToAccountMetas,
     },
     borsh::BorshDeserialize,
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{create_wallet, send_transaction_from_instructions},
-    solana_signer::Signer,
 };
 
 #[derive(BorshDeserialize)]
@@ -24,7 +22,7 @@ fn fetch_message(svm: &LiteSVM, pubkey: &anchor_lang::prelude::Address) -> Strin
 #[test]
 fn test_initialize() {
     let program_id = anchor_realloc::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
     let bytes = include_bytes!("../../../target/deploy/anchor_realloc.so");
     svm.add_program(program_id, bytes).unwrap();
     let payer = create_wallet(&mut svm, 10_000_000_000).unwrap();
@@ -64,7 +62,7 @@ fn test_initialize() {
 #[test]
 fn test_update_grows() {
     let program_id = anchor_realloc::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
     let bytes = include_bytes!("../../../target/deploy/anchor_realloc.so");
     svm.add_program(program_id, bytes).unwrap();
     let payer = create_wallet(&mut svm, 10_000_000_000).unwrap();
@@ -121,7 +119,7 @@ fn test_update_grows() {
 #[test]
 fn test_update_shrinks() {
     let program_id = anchor_realloc::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
     let bytes = include_bytes!("../../../target/deploy/anchor_realloc.so");
     svm.add_program(program_id, bytes).unwrap();
     let payer = create_wallet(&mut svm, 10_000_000_000).unwrap();

--- a/basics/rent/anchor/programs/rent-example/Cargo.toml
+++ b/basics/rent/anchor/programs/rent-example/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -26,9 +28,16 @@ anchor-lang = "2.0.0-rc.1"
 wincode = { version = "0.5", features = ["derive"] }
 
 [dev-dependencies]
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 
 [lints.rust]

--- a/basics/rent/anchor/programs/rent-example/tests/test_rent.rs
+++ b/basics/rent/anchor/programs/rent-example/tests/test_rent.rs
@@ -1,8 +1,8 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, InstructionData, ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{create_wallet, send_transaction_from_instructions},
 };
 

--- a/basics/rent/anchor/programs/rent-example/tests/test_rent.rs
+++ b/basics/rent/anchor/programs/rent-example/tests/test_rent.rs
@@ -1,17 +1,15 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, InstructionData, ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{create_wallet, send_transaction_from_instructions},
-    solana_signer::Signer,
 };
 
 #[test]
 fn test_create_system_account() {
     let program_id = rent_example::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
     let bytes = include_bytes!("../../../target/deploy/rent_example.so");
     svm.add_program(program_id, bytes).unwrap();
     let payer = create_wallet(&mut svm, 10_000_000_000).unwrap();

--- a/basics/repository-layout/anchor/programs/carnival/Cargo.toml
+++ b/basics/repository-layout/anchor/programs/carnival/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -26,9 +28,16 @@ anchor-lang = "2.0.0-rc.1"
 wincode = { version = "0.5", features = ["derive"] }
 
 [dev-dependencies]
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 
 [lints.rust]

--- a/basics/repository-layout/anchor/programs/carnival/tests/test_carnival.rs
+++ b/basics/repository-layout/anchor/programs/carnival/tests/test_carnival.rs
@@ -1,13 +1,12 @@
 use {
     anchor_lang::{solana_program::instruction::Instruction, InstructionData, ToAccountMetas},
-    litesvm::LiteSVM,
+    anchor_v2_testing::{LiteSVM, Signer},
     solana_kite::{create_wallet, send_transaction_from_instructions},
-    solana_signer::Signer,
 };
 
 fn setup() -> (LiteSVM, solana_keypair::Keypair) {
     let program_id = carnival::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
     let bytes = include_bytes!("../../../target/deploy/carnival.so");
     svm.add_program(program_id, bytes).unwrap();
     let payer = create_wallet(&mut svm, 10_000_000_000).unwrap();

--- a/basics/repository-layout/anchor/programs/carnival/tests/test_carnival.rs
+++ b/basics/repository-layout/anchor/programs/carnival/tests/test_carnival.rs
@@ -4,7 +4,7 @@ use {
     solana_kite::{create_wallet, send_transaction_from_instructions},
 };
 
-fn setup() -> (LiteSVM, solana_keypair::Keypair) {
+fn setup() -> (LiteSVM, anchor_v2_testing::Keypair) {
     let program_id = carnival::id();
     let mut svm = anchor_v2_testing::svm();
     let bytes = include_bytes!("../../../target/deploy/carnival.so");
@@ -14,7 +14,7 @@ fn setup() -> (LiteSVM, solana_keypair::Keypair) {
 }
 
 fn go_on_ride_ix(
-    payer: &solana_keypair::Keypair,
+    payer: &anchor_v2_testing::Keypair,
     name: &str,
     height: u32,
     ticket_count: u32,
@@ -38,7 +38,7 @@ fn go_on_ride_ix(
 }
 
 fn play_game_ix(
-    payer: &solana_keypair::Keypair,
+    payer: &anchor_v2_testing::Keypair,
     name: &str,
     ticket_count: u32,
     game_name: &str,
@@ -60,7 +60,7 @@ fn play_game_ix(
 }
 
 fn eat_food_ix(
-    payer: &solana_keypair::Keypair,
+    payer: &anchor_v2_testing::Keypair,
     name: &str,
     ticket_count: u32,
     food_stand_name: &str,

--- a/basics/transfer-sol/anchor/programs/transfer-sol/Cargo.toml
+++ b/basics/transfer-sol/anchor/programs/transfer-sol/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -26,9 +28,16 @@ anchor-lang = "2.0.0-rc.1"
 wincode = { version = "0.5", features = ["derive"] }
 
 [dev-dependencies]
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 
 [lints.rust]

--- a/basics/transfer-sol/anchor/programs/transfer-sol/tests/test_transfer_sol.rs
+++ b/basics/transfer-sol/anchor/programs/transfer-sol/tests/test_transfer_sol.rs
@@ -1,11 +1,9 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, InstructionData, ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{create_wallet, send_transaction_from_instructions},
-    solana_signer::Signer,
 };
 
 const LAMPORTS_PER_SOL: u64 = 1_000_000_000;
@@ -13,7 +11,7 @@ const LAMPORTS_PER_SOL: u64 = 1_000_000_000;
 #[test]
 fn test_transfer_sol_with_cpi() {
     let program_id = transfer_sol::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
     let bytes = include_bytes!("../../../target/deploy/transfer_sol.so");
     svm.add_program(program_id, bytes).unwrap();
     let payer = create_wallet(&mut svm, 10 * LAMPORTS_PER_SOL).unwrap();
@@ -44,7 +42,7 @@ fn test_transfer_sol_with_cpi() {
 #[test]
 fn test_transfer_sol_with_program() {
     let program_id = transfer_sol::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
     let bytes = include_bytes!("../../../target/deploy/transfer_sol.so");
     svm.add_program(program_id, bytes).unwrap();
     let payer = create_wallet(&mut svm, 10 * LAMPORTS_PER_SOL).unwrap();
@@ -93,7 +91,7 @@ fn test_transfer_sol_with_program() {
 #[test]
 fn test_transfer_sol_with_program_rejects_insufficient_funds() {
     let program_id = transfer_sol::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
     let bytes = include_bytes!("../../../target/deploy/transfer_sol.so");
     svm.add_program(program_id, bytes).unwrap();
     let payer = create_wallet(&mut svm, 10 * LAMPORTS_PER_SOL).unwrap();

--- a/basics/transfer-sol/anchor/programs/transfer-sol/tests/test_transfer_sol.rs
+++ b/basics/transfer-sol/anchor/programs/transfer-sol/tests/test_transfer_sol.rs
@@ -1,8 +1,8 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, InstructionData, ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{create_wallet, send_transaction_from_instructions},
 };
 

--- a/compression/cnft-burn/anchor/programs/cnft-burn/Cargo.toml
+++ b/compression/cnft-burn/anchor/programs/cnft-burn/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = { version = "2.0.0-rc.1", features = ["compat"] }
@@ -37,15 +39,22 @@ solana-address = { version = ">=2.6, <2.7", features = ["borsh"] }
 borsh = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
-litesvm = "0.13.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 solana-instruction = "3.0.0"
-solana-keypair = "3.0.1"
 solana-pubkey = "3.0.0"
 solana-transaction = "3.0.0"
 solana-account = "3.0.0"
 solana-native-token = "3.0.0"
-solana-signer = "3.0.0"
 solana-message = "3.0.0"
 solana-keccak-hasher = "3.0.0"
 

--- a/compression/cnft-burn/anchor/programs/cnft-burn/tests/test_burn.rs
+++ b/compression/cnft-burn/anchor/programs/cnft-burn/tests/test_burn.rs
@@ -13,14 +13,12 @@
 //!      transaction succeeds and a second burn fails (leaf already zeroed).
 
 use {
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     borsh::BorshSerialize,
-    litesvm::LiteSVM,
     solana_instruction::{account_meta::AccountMeta, Instruction},
     solana_keccak_hasher::hashv,
-    solana_keypair::Keypair,
     solana_kite::{create_wallet, send_transaction_from_instructions},
     solana_pubkey::{pubkey, Pubkey},
-    solana_signer::Signer,
 };
 
 // ---- Program IDs ----------------------------------------------------------
@@ -240,7 +238,7 @@ fn read_current_root(data: &[u8]) -> [u8; 32] {
 
 #[test]
 fn test_burn_cnft() {
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     // Load the cnft-burn program and the three mainnet fixtures.
     svm.add_program(

--- a/compression/cnft-vault/anchor/programs/cnft-vault/Cargo.toml
+++ b/compression/cnft-vault/anchor/programs/cnft-vault/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -40,14 +42,21 @@ borsh = { version = "1", features = ["derive"] }
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_os, values("solana"))'] }
 
 [dev-dependencies]
-litesvm = "0.13.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 solana-instruction = "3.0.0"
-solana-keypair = "3.0.1"
 solana-pubkey = "3.0.0"
 solana-transaction = "3.0.0"
 solana-account = "3.0.0"
 solana-native-token = "3.0.0"
-solana-signer = "3.0.0"
 solana-message = "3.0.0"
 solana-keccak-hasher = "3.0.0"

--- a/compression/cnft-vault/anchor/programs/cnft-vault/tests/test_vault.rs
+++ b/compression/cnft-vault/anchor/programs/cnft-vault/tests/test_vault.rs
@@ -26,15 +26,13 @@
 //!     of panicking inside `split_at`
 
 use {
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     borsh::BorshSerialize,
     cnft_vault::error::VaultError,
-    litesvm::LiteSVM,
     solana_instruction::{account_meta::AccountMeta, Instruction},
     solana_keccak_hasher::hashv,
-    solana_keypair::Keypair,
     solana_kite::{create_wallet, send_transaction_from_instructions, SolanaKiteError},
     solana_pubkey::{pubkey, Pubkey},
-    solana_signer::Signer,
 };
 
 // ---- Program IDs ----------------------------------------------------------
@@ -284,7 +282,7 @@ struct VaultTestContext {
 }
 
 fn setup_vault() -> VaultTestContext {
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     // Load the cnft-vault program and the three mainnet fixtures.
     svm.add_program(

--- a/compression/cutils/anchor/programs/cutils/Cargo.toml
+++ b/compression/cutils/anchor/programs/cutils/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -42,14 +44,21 @@ sha3 = "0.10"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_os, values("solana"))'] }
 
 [dev-dependencies]
-litesvm = "0.13.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 solana-instruction = "3.0.0"
-solana-keypair = "3.0.1"
 solana-pubkey = "3.0.0"
 solana-transaction = "3.0.0"
 solana-account = "3.0.0"
 solana-native-token = "3.0.0"
-solana-signer = "3.0.0"
 solana-message = "3.0.0"
 solana-keccak-hasher = "3.0.0"

--- a/compression/cutils/anchor/programs/cutils/tests/test_cutils.rs
+++ b/compression/cutils/anchor/programs/cutils/tests/test_cutils.rs
@@ -26,14 +26,12 @@
 //!      fail.
 
 use {
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     borsh::BorshSerialize,
-    litesvm::LiteSVM,
     solana_instruction::{account_meta::AccountMeta, Instruction},
     solana_keccak_hasher::hashv,
-    solana_keypair::Keypair,
     solana_kite::{create_wallet, send_transaction_from_instructions},
     solana_pubkey::{pubkey, Pubkey},
-    solana_signer::Signer,
 };
 
 // ---- Program IDs ----------------------------------------------------------
@@ -464,7 +462,7 @@ fn create_collection_nft(
 
 #[test]
 fn test_cutils_mint_and_verify() {
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     // Load the cutils program and the mainnet fixtures.
     svm.add_program(

--- a/finance/betting-market/anchor/programs/betting-market/Cargo.toml
+++ b/finance/betting-market/anchor/programs/betting-market/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 # init-if-needed: place_bet and the lazy User index create accounts only on first use.
@@ -33,15 +35,22 @@ solana-address = ">=2.6, <2.7"
 anchor-spl = "2.0.0-rc.1"
 
 [dev-dependencies]
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 # no-entrypoint: solana-kite pulls these SPL program crates into the host test
 # build, and their `entrypoint` symbols collide with this program's own
 # entrypoint at link time. Feature unification turns their entrypoints off
 # across the test build; the dependencies exist only for that.
 spl-token = { version = "9.0.0", features = ["no-entrypoint"] }
 spl-associated-token-account = { version = "8.0.0", features = ["no-entrypoint"] }
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
 solana-kite = "0.4.0"
 borsh = "1.6.1"
 

--- a/finance/betting-market/anchor/programs/betting-market/tests/test_betting_market.rs
+++ b/finance/betting-market/anchor/programs/betting-market/tests/test_betting_market.rs
@@ -1,17 +1,15 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, AccountDeserialize, Address,
         InstructionData, ToAccountMetas,
     },
     betting_market::{User, MAX_BETS_PER_USER},
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{
         create_associated_token_account, create_token_mint, create_wallet,
         get_token_account_balance, mint_tokens_to_token_account,
         send_transaction_from_instructions,
     },
-    solana_signer::Signer,
 };
 
 const DECIMALS: u8 = 6;
@@ -76,7 +74,7 @@ struct Market {
 // Spin up the SVM with the program loaded, an admin wallet, the stake-token mint
 // (admin is the mint authority), and a fee-recipient wallet with an ATA.
 fn setup() -> Market {
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
     let program_bytes = include_bytes!("../../../target/deploy/betting_market.so");
     svm.add_program(betting_market::id(), program_bytes)
         .unwrap();

--- a/finance/betting-market/anchor/programs/betting-market/tests/test_betting_market.rs
+++ b/finance/betting-market/anchor/programs/betting-market/tests/test_betting_market.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, AccountDeserialize, Address,
         InstructionData, ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     betting_market::{User, MAX_BETS_PER_USER},
     solana_kite::{
         create_associated_token_account, create_token_mint, create_wallet,

--- a/finance/escrow/anchor/programs/escrow/Cargo.toml
+++ b/finance/escrow/anchor/programs/escrow/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -32,9 +34,16 @@ solana-address = ">=2.6, <2.7"
 anchor-spl = "2.0.0-rc.1"
 
 [dev-dependencies]
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"
 

--- a/finance/escrow/anchor/programs/escrow/tests/test_escrow.rs
+++ b/finance/escrow/anchor/programs/escrow/tests/test_escrow.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{
         create_associated_token_account, create_token_mint, create_wallet,
         get_token_account_balance, mint_tokens_to_token_account,

--- a/finance/escrow/anchor/programs/escrow/tests/test_escrow.rs
+++ b/finance/escrow/anchor/programs/escrow/tests/test_escrow.rs
@@ -1,16 +1,14 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{
         create_associated_token_account, create_token_mint, create_wallet,
         get_token_account_balance, mint_tokens_to_token_account,
         send_transaction_from_instructions,
     },
-    solana_signer::Signer,
 };
 
 fn token_program_id() -> Address {
@@ -39,7 +37,7 @@ fn derive_ata(wallet: &Address, mint: &Address) -> Address {
 
 fn setup() -> (LiteSVM, Address, Keypair) {
     let program_id = escrow::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/escrow.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/finance/lending/anchor/programs/lending/Cargo.toml
+++ b/finance/lending/anchor/programs/lending/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 # init-if-needed: the obligation share vault and the test price feed are created lazily.
@@ -36,9 +38,16 @@ pinocchio = "0.11"
 anchor-spl = "2.0.0-rc.1"
 
 [dev-dependencies]
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"
 # Test-side only: LiteSVM's get_sysvar/set_sysvar want the host-side sysvar

--- a/finance/lending/anchor/programs/lending/tests/common/mod.rs
+++ b/finance/lending/anchor/programs/lending/tests/common/mod.rs
@@ -11,13 +11,11 @@ use anchor_lang::{
     system_program, AccountDeserialize, InstructionData, ToAccountMetas,
 };
 use anchor_spl::token::ID as TOKEN_PROGRAM_ID;
-use litesvm::LiteSVM;
-use solana_keypair::Keypair;
+use anchor_v2_testing::{Keypair, LiteSVM, Signer};
 use solana_kite::{
     create_associated_token_account, create_token_mint, create_wallet, get_token_account_balance,
     mint_tokens_to_token_account, send_transaction_from_instructions,
 };
-use solana_signer::Signer;
 
 use lending::constants::{
     LENDING_MARKET_SEED, LIQUIDITY_VAULT_SEED, OBLIGATION_SEED, OBLIGATION_SHARE_VAULT_SEED,
@@ -107,7 +105,7 @@ pub struct Env {
 
 impl Env {
     pub fn new() -> Self {
-        let mut svm = LiteSVM::new();
+        let mut svm = anchor_v2_testing::svm();
         let program_bytes = include_bytes!("../../../../target/deploy/lending.so");
         svm.add_program(lending::id(), program_bytes).unwrap();
 

--- a/finance/lending/anchor/programs/lending/tests/test_borrow_repay.rs
+++ b/finance/lending/anchor/programs/lending/tests/test_borrow_repay.rs
@@ -1,10 +1,9 @@
 mod common;
 
+use anchor_v2_testing::{Keypair, Signer};
 use lending::errors::LendingError;
 
 use common::{ata, default_config, dollars, Env, ReserveHandle};
-use solana_keypair::Keypair;
-use solana_signer::Signer;
 
 /// One market with a collateral reserve and a separately-supplied borrow
 /// reserve, plus a borrower who has posted 1000 units of collateral (value

--- a/finance/lending/anchor/programs/lending/tests/test_interest.rs
+++ b/finance/lending/anchor/programs/lending/tests/test_interest.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use anchor_v2_testing::{Signer};
+use anchor_v2_testing::Signer;
 use common::{ata, default_config, dollars, Env, SLOTS_PER_YEAR};
 use lending::constants::FIXED_POINT_SCALE;
 

--- a/finance/lending/anchor/programs/lending/tests/test_interest.rs
+++ b/finance/lending/anchor/programs/lending/tests/test_interest.rs
@@ -1,8 +1,8 @@
 mod common;
 
+use anchor_v2_testing::{Signer};
 use common::{ata, default_config, dollars, Env, SLOTS_PER_YEAR};
 use lending::constants::FIXED_POINT_SCALE;
-use solana_signer::Signer;
 
 /// Borrowing at non-zero utilization, then letting slots pass, must grow the
 /// reserve's accumulation factor, the borrower's debt, and the share exchange rate.

--- a/finance/lending/anchor/programs/lending/tests/test_liquidation.rs
+++ b/finance/lending/anchor/programs/lending/tests/test_liquidation.rs
@@ -1,10 +1,9 @@
 mod common;
 
+use anchor_v2_testing::{Keypair, Signer};
 use lending::errors::LendingError;
 
 use common::{ata, cents, default_config, dollars, Env, ReserveHandle};
-use solana_keypair::Keypair;
-use solana_signer::Signer;
 
 /// A borrower with $1000 of collateral who has borrowed $700 (healthy at 80%
 /// liquidation threshold), plus a liquidator funded with the borrow token.

--- a/finance/lending/anchor/programs/lending/tests/test_rounding.rs
+++ b/finance/lending/anchor/programs/lending/tests/test_rounding.rs
@@ -1,9 +1,9 @@
 mod common;
 
+use anchor_v2_testing::{Signer};
 use lending::errors::LendingError;
 
 use common::{ata, default_config, dollars, Env};
-use solana_signer::Signer;
 
 /// After interest makes the pool worth more than its share supply, a deposit so
 /// small it would mint zero shares is rejected rather than silently giving the

--- a/finance/lending/anchor/programs/lending/tests/test_rounding.rs
+++ b/finance/lending/anchor/programs/lending/tests/test_rounding.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use anchor_v2_testing::{Signer};
+use anchor_v2_testing::Signer;
 use lending::errors::LendingError;
 
 use common::{ata, default_config, dollars, Env};

--- a/finance/lending/anchor/programs/lending/tests/test_security.rs
+++ b/finance/lending/anchor/programs/lending/tests/test_security.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use anchor_v2_testing::{Signer};
+use anchor_v2_testing::Signer;
 use lending::errors::LendingError;
 
 use anchor_lang::{

--- a/finance/lending/anchor/programs/lending/tests/test_security.rs
+++ b/finance/lending/anchor/programs/lending/tests/test_security.rs
@@ -1,12 +1,12 @@
 mod common;
 
+use anchor_v2_testing::{Signer};
 use lending::errors::LendingError;
 
 use anchor_lang::{
     solana_program::instruction::Instruction, system_program, InstructionData, ToAccountMetas,
 };
 use common::{default_config, dollars, Env};
-use solana_signer::Signer;
 
 /// A reserve from one lending market cannot be used with an obligation from
 /// another: lending markets are isolation boundaries.

--- a/finance/order-book/anchor/programs/order-book/Cargo.toml
+++ b/finance/order-book/anchor/programs/order-book/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = { version = "2.0.0-rc.1", features = ["compat"] }
@@ -38,11 +40,18 @@ bytemuck = { version = "1.18", features = ["derive", "min_const_generics"] }
 static_assertions = "1.1"
 
 [dev-dependencies]
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 # Match the test stack used by finance/escrow and the other LiteSVM-based
 # Anchor examples so contributors can move between them without version drift.
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
 solana-kite = "0.4.0"
 
 [lints.rust]

--- a/finance/order-book/anchor/programs/order-book/tests/test_order_book.rs
+++ b/finance/order-book/anchor/programs/order-book/tests/test_order_book.rs
@@ -11,6 +11,7 @@
 
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::{
             instruction::{AccountMeta, Instruction},
             system_instruction,
@@ -23,14 +24,11 @@ use {
         InstructionData,
         ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{
         create_associated_token_account, create_token_mint, create_wallet,
         get_token_account_balance, mint_tokens_to_token_account,
         send_transaction_from_instructions,
     },
-    solana_signer::Signer,
 };
 
 // Keep test-side seeds in sync with `programs/order_book/src/state/*`. Duplicated
@@ -153,7 +151,7 @@ struct Scenario {
 
 fn full_setup() -> Scenario {
     let program_id = order_book::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
     let program_bytes = include_bytes!("../../../target/deploy/order_book.so");
     svm.add_program(program_id, program_bytes).unwrap();
 

--- a/finance/order-book/anchor/programs/order-book/tests/test_order_book.rs
+++ b/finance/order-book/anchor/programs/order-book/tests/test_order_book.rs
@@ -11,7 +11,6 @@
 
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::{
             instruction::{AccountMeta, Instruction},
             system_instruction,
@@ -24,6 +23,7 @@ use {
         InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{
         create_associated_token_account, create_token_mint, create_wallet,
         get_token_account_balance, mint_tokens_to_token_account,

--- a/finance/perpetual-futures/anchor/programs/perpetual-futures/Cargo.toml
+++ b/finance/perpetual-futures/anchor/programs/perpetual-futures/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 # init-if-needed lets add_liquidity create the provider's liquidity-provider
@@ -49,10 +51,17 @@ spl-associated-token-account = { version = "8.0.0", features = ["no-entrypoint"]
 solana-sysvar = "3"
 
 [dev-dependencies]
-litesvm = "0.13.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-clock = "3.0.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
 solana-kite = "0.4.0"
 borsh = "1.6.1"
 # The LiteSVM tests load the compiled mock oracle program; depending on the

--- a/finance/perpetual-futures/anchor/programs/perpetual-futures/tests/test_perpetual_futures.rs
+++ b/finance/perpetual-futures/anchor/programs/perpetual-futures/tests/test_perpetual_futures.rs
@@ -1,17 +1,15 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, AccountDeserialize, Address,
         InstructionData, ToAccountMetas,
     },
-    litesvm::LiteSVM,
     perpetual_futures::{instructions::initialize_pool::PoolParameters, state::Pool, state::Side},
-    solana_keypair::Keypair,
     solana_kite::{
         create_associated_token_account, create_token_mint, create_wallet,
         get_token_account_balance, mint_tokens_to_token_account,
         send_transaction_from_instructions,
     },
-    solana_signer::Signer,
 };
 
 // Collateral token has 6 decimals (like USDC), so one whole unit is 1_000_000
@@ -82,7 +80,7 @@ impl Market {
     /// `initialize_pool` rejection instead of panicking, so tests can probe the
     /// parameter validation.
     fn try_new(initial_price: i128, parameters: PoolParameters) -> Result<Market, ()> {
-        let mut svm = LiteSVM::new();
+        let mut svm = anchor_v2_testing::svm();
         svm.add_program(
             perpetual_futures::id(),
             include_bytes!("../../../target/deploy/perpetual_futures.so"),

--- a/finance/perpetual-futures/anchor/programs/perpetual-futures/tests/test_perpetual_futures.rs
+++ b/finance/perpetual-futures/anchor/programs/perpetual-futures/tests/test_perpetual_futures.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, AccountDeserialize, Address,
         InstructionData, ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     perpetual_futures::{instructions::initialize_pool::PoolParameters, state::Pool, state::Side},
     solana_kite::{
         create_associated_token_account, create_token_mint, create_wallet,

--- a/finance/prop-amm/anchor/programs/prop-amm/Cargo.toml
+++ b/finance/prop-amm/anchor/programs/prop-amm/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 # init-if-needed: swap creates the trader's destination token account when it
@@ -46,10 +48,17 @@ spl-token = { version = "9.0.0", features = ["no-entrypoint"] }
 spl-associated-token-account = { version = "8.0.0", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-litesvm = "0.13.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-clock = "3.0.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
 solana-kite = "0.4.0"
 borsh = "1.6.1"
 # The LiteSVM tests load the compiled mock oracle program; depending on the

--- a/finance/prop-amm/anchor/programs/prop-amm/tests/test_prop_amm.rs
+++ b/finance/prop-amm/anchor/programs/prop-amm/tests/test_prop_amm.rs
@@ -1,20 +1,18 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, AccountDeserialize, Address,
         InstructionData, ToAccountMetas,
     },
-    litesvm::LiteSVM,
     prop_amm::{
         instructions::initialize_market::MarketParameters,
         state::{Direction, Market as MarketState},
     },
-    solana_keypair::Keypair,
     solana_kite::{
         create_associated_token_account, create_token_mint, create_wallet,
         get_token_account_balance, mint_tokens_to_token_account,
         send_transaction_from_instructions,
     },
-    solana_signer::Signer,
 };
 
 // Both tokens have 6 decimals: the base is NVDAx (tokenized NVIDIA stock) and
@@ -86,7 +84,7 @@ impl Market {
     /// `initialize_market` rejection instead of panicking, so tests can probe
     /// the parameter validation.
     fn try_new(initial_price: i128, parameters: MarketParameters) -> Result<Market, ()> {
-        let mut svm = LiteSVM::new();
+        let mut svm = anchor_v2_testing::svm();
         svm.add_program(
             prop_amm::id(),
             include_bytes!("../../../target/deploy/prop_amm.so"),

--- a/finance/prop-amm/anchor/programs/prop-amm/tests/test_prop_amm.rs
+++ b/finance/prop-amm/anchor/programs/prop-amm/tests/test_prop_amm.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, AccountDeserialize, Address,
         InstructionData, ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     prop_amm::{
         instructions::initialize_market::MarketParameters,
         state::{Direction, Market as MarketState},

--- a/finance/token-fundraiser/anchor/programs/fundraiser/Cargo.toml
+++ b/finance/token-fundraiser/anchor/programs/fundraiser/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = { version = "2.0.0-rc.1", features = ["compat"] }
@@ -32,10 +34,17 @@ solana-address = ">=2.6, <2.7"
 anchor-spl = "2.0.0-rc.1"
 
 [dev-dependencies]
-litesvm = "0.13.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-clock = "3.0.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
 solana-kite = "0.4.0"
 borsh = "1.6.1"
 # solana-kite depends on these SPL program crates without "no-entrypoint",

--- a/finance/token-fundraiser/anchor/programs/fundraiser/tests/test_fundraiser.rs
+++ b/finance/token-fundraiser/anchor/programs/fundraiser/tests/test_fundraiser.rs
@@ -1,20 +1,18 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
     borsh::BorshDeserialize,
     fundraiser::SECONDS_TO_DAYS,
-    litesvm::LiteSVM,
     // LiteSVM's get_sysvar wants the host-side Clock, not pinocchio's.
     solana_clock::Clock,
-    solana_keypair::Keypair,
     solana_kite::{
         create_associated_token_account, create_token_mint, create_wallet,
         get_token_account_balance, mint_tokens_to_token_account,
         send_transaction_from_instructions,
     },
-    solana_signer::Signer,
 };
 
 const MINT_DECIMALS: u8 = 6;
@@ -98,7 +96,7 @@ struct FundraiserSetup {
 
 fn full_setup() -> FundraiserSetup {
     let program_id = fundraiser::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/fundraiser.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/finance/token-fundraiser/anchor/programs/fundraiser/tests/test_fundraiser.rs
+++ b/finance/token-fundraiser/anchor/programs/fundraiser/tests/test_fundraiser.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     borsh::BorshDeserialize,
     fundraiser::SECONDS_TO_DAYS,
     // LiteSVM's get_sysvar wants the host-side Clock, not pinocchio's.

--- a/finance/token-swap/anchor/programs/token-swap/Cargo.toml
+++ b/finance/token-swap/anchor/programs/token-swap/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = { version = "2.0.0-rc.1", features = ["compat"] }
@@ -35,9 +37,16 @@ anchor-spl = "2.0.0-rc.1"
 # fixed-point types are not used for money in this program.
 
 [dev-dependencies]
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"
 

--- a/finance/token-swap/anchor/programs/token-swap/tests/test_swap.rs
+++ b/finance/token-swap/anchor/programs/token-swap/tests/test_swap.rs
@@ -2,17 +2,15 @@ use swap_example::errors::AmmError;
 
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{
         create_associated_token_account, create_token_mint, create_wallet,
         get_token_account_balance, mint_tokens_to_token_account,
         send_transaction_from_instructions,
     },
-    solana_signer::Signer,
 };
 
 fn token_program_id() -> Address {
@@ -37,7 +35,7 @@ fn derive_ata(wallet: &Address, mint: &Address) -> Address {
 
 fn setup() -> (LiteSVM, Address, Keypair) {
     let program_id = swap_example::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/swap_example.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/finance/token-swap/anchor/programs/token-swap/tests/test_swap.rs
+++ b/finance/token-swap/anchor/programs/token-swap/tests/test_swap.rs
@@ -2,10 +2,10 @@ use swap_example::errors::AmmError;
 
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{
         create_associated_token_account, create_token_mint, create_wallet,
         get_token_account_balance, mint_tokens_to_token_account,

--- a/finance/vault-strategy/anchor/programs/vault-strategy/Cargo.toml
+++ b/finance/vault-strategy/anchor/programs/vault-strategy/Cargo.toml
@@ -23,6 +23,8 @@ idl-build = ["anchor-lang/idl-build", "mock-swap-router/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = { version = "2.0.0-rc.1", features = ["compat"] }
@@ -38,11 +40,18 @@ anchor-spl = "2.0.0-rc.1"
 mock-swap-router = { path = "../mock-swap-router", features = ["cpi"] }
 
 [dev-dependencies]
-litesvm = "0.13.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-clock = "3.0.1"
 solana-account = "3.0.0"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
 solana-kite = "0.4.0"
 borsh = "1.6.1"
 

--- a/finance/vault-strategy/anchor/programs/vault-strategy/tests/vault_strategy.rs
+++ b/finance/vault-strategy/anchor/programs/vault-strategy/tests/vault_strategy.rs
@@ -1,10 +1,10 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::{instruction::AccountMeta, instruction::Instruction},
         system_program, AccountDeserialize, Address, InstructionData, ToAccountMetas,
     },
     anchor_spl::token::spl_token,
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_account::Account as SolanaAccount,
     // LiteSVM's get_sysvar / set_sysvar want the host-side Clock, not pinocchio's.
     solana_clock::Clock,

--- a/finance/vault-strategy/anchor/programs/vault-strategy/tests/vault_strategy.rs
+++ b/finance/vault-strategy/anchor/programs/vault-strategy/tests/vault_strategy.rs
@@ -1,20 +1,18 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::{instruction::AccountMeta, instruction::Instruction},
         system_program, AccountDeserialize, Address, InstructionData, ToAccountMetas,
     },
     anchor_spl::token::spl_token,
-    litesvm::LiteSVM,
     solana_account::Account as SolanaAccount,
     // LiteSVM's get_sysvar / set_sysvar want the host-side Clock, not pinocchio's.
     solana_clock::Clock,
-    solana_keypair::Keypair,
     solana_kite::{
         create_associated_token_account, create_token_mint, create_wallet,
         get_token_account_balance, mint_tokens_to_token_account,
         send_transaction_from_instructions,
     },
-    solana_signer::Signer,
 };
 
 fn token_program_id() -> Address {
@@ -134,7 +132,7 @@ fn setup_full() -> TestContext {
     let vault_program_id = vault_strategy::id();
     let router_program_id = mock_swap_router::id();
 
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
     svm.add_program(
         vault_program_id,
         include_bytes!("../../../target/deploy/vault_strategy.so"),

--- a/tokens/create-token/anchor/programs/create-token/Cargo.toml
+++ b/tokens/create-token/anchor/programs/create-token/Cargo.toml
@@ -19,6 +19,8 @@ anchor-debug = []
 custom-heap = []
 custom-panic = []
 
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -33,9 +35,16 @@ solana-address = ">=2.6, <2.7"
 anchor-spl = { version = "2.0.0-rc.1", features = ["metadata"] }
 
 [dev-dependencies]
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"
 

--- a/tokens/create-token/anchor/programs/create-token/tests/test_create_token.rs
+++ b/tokens/create-token/anchor/programs/create-token/tests/test_create_token.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{create_wallet, send_transaction_from_instructions},
 };
 

--- a/tokens/create-token/anchor/programs/create-token/tests/test_create_token.rs
+++ b/tokens/create-token/anchor/programs/create-token/tests/test_create_token.rs
@@ -1,12 +1,10 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{create_wallet, send_transaction_from_instructions},
-    solana_signer::Signer,
 };
 
 fn metadata_program_id() -> Address {
@@ -29,7 +27,7 @@ fn rent_sysvar_id() -> Address {
 
 fn setup() -> (LiteSVM, Address, Keypair) {
     let program_id = create_token::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/create_token.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/tokens/external-delegate-token-master/anchor/programs/external-delegate-token-master/Cargo.toml
+++ b/tokens/external-delegate-token-master/anchor/programs/external-delegate-token-master/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -34,12 +36,19 @@ sha3 = "0.10.8"
 solana-secp256k1-recover = "2.0.0"
 
 [dev-dependencies]
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 # Signs test transfer authorizations with a fixed secp256k1 key so tests can
 # exercise the Ethereum-signature path end to end.
 libsecp256k1 = "0.7.2"
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
 solana-kite = "0.4.0"
 borsh = "1.6.1"
 

--- a/tokens/external-delegate-token-master/anchor/programs/external-delegate-token-master/tests/test_external_delegate.rs
+++ b/tokens/external-delegate-token-master/anchor/programs/external-delegate-token-master/tests/test_external_delegate.rs
@@ -1,18 +1,16 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
     borsh::BorshDeserialize,
-    litesvm::LiteSVM,
     sha3::{Digest, Keccak256},
-    solana_keypair::Keypair,
     solana_kite::{
         create_associated_token_account, create_token_mint, create_wallet,
         get_token_account_balance, mint_tokens_to_token_account,
         send_transaction_from_instructions,
     },
-    solana_signer::Signer,
 };
 
 const WALLET_LAMPORTS: u64 = 10_000_000_000;
@@ -93,7 +91,7 @@ fn sign_transfer_authorization(
 
 fn setup() -> (LiteSVM, Address, Keypair) {
     let program_id = external_delegate_token_master::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/external_delegate_token_master.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/tokens/external-delegate-token-master/anchor/programs/external-delegate-token-master/tests/test_external_delegate.rs
+++ b/tokens/external-delegate-token-master/anchor/programs/external-delegate-token-master/tests/test_external_delegate.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     borsh::BorshDeserialize,
     sha3::{Digest, Keccak256},
     solana_kite::{

--- a/tokens/nft-minter/anchor/programs/nft-minter/Cargo.toml
+++ b/tokens/nft-minter/anchor/programs/nft-minter/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -32,9 +34,16 @@ solana-address = ">=2.6, <2.7"
 anchor-spl = { version = "2.0.0-rc.1", features = ["metadata"] }
 
 [dev-dependencies]
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"
 

--- a/tokens/nft-minter/anchor/programs/nft-minter/tests/test_nft_minter.rs
+++ b/tokens/nft-minter/anchor/programs/nft-minter/tests/test_nft_minter.rs
@@ -1,12 +1,10 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{create_wallet, get_token_account_balance, send_transaction_from_instructions},
-    solana_signer::Signer,
 };
 
 fn token_program_id() -> Address {
@@ -66,7 +64,7 @@ fn derive_edition_pda(mint: &Address) -> Address {
 
 fn setup() -> (LiteSVM, Address, Keypair) {
     let program_id = nft_minter::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/nft_minter.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/tokens/nft-minter/anchor/programs/nft-minter/tests/test_nft_minter.rs
+++ b/tokens/nft-minter/anchor/programs/nft-minter/tests/test_nft_minter.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{create_wallet, get_token_account_balance, send_transaction_from_instructions},
 };
 

--- a/tokens/nft-operations/anchor/programs/mint-nft/Cargo.toml
+++ b/tokens/nft-operations/anchor/programs/mint-nft/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = { version = "2.0.0-rc.1", features = ["compat"] }
@@ -32,9 +34,16 @@ solana-address = ">=2.6, <2.7"
 anchor-spl = { version = "2.0.0-rc.1", features = ["metadata"] }
 
 [dev-dependencies]
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"
 

--- a/tokens/nft-operations/anchor/programs/mint-nft/tests/test_nft_operations.rs
+++ b/tokens/nft-operations/anchor/programs/mint-nft/tests/test_nft_operations.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{create_wallet, get_token_account_balance, send_transaction_from_instructions},
 };
 

--- a/tokens/nft-operations/anchor/programs/mint-nft/tests/test_nft_operations.rs
+++ b/tokens/nft-operations/anchor/programs/mint-nft/tests/test_nft_operations.rs
@@ -1,12 +1,10 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{create_wallet, get_token_account_balance, send_transaction_from_instructions},
-    solana_signer::Signer,
 };
 
 fn token_program_id() -> Address {
@@ -75,7 +73,7 @@ fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
 
 fn setup() -> (LiteSVM, Address, Keypair) {
     let program_id = mint_nft::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/mint_nft.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/tokens/pda-mint-authority/anchor/programs/token-minter/Cargo.toml
+++ b/tokens/pda-mint-authority/anchor/programs/token-minter/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -35,9 +37,16 @@ anchor-spl = { version = "2.0.0-rc.1", features = ["metadata"] }
 solana-program-pack = "3"
 
 [dev-dependencies]
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"
 

--- a/tokens/pda-mint-authority/anchor/programs/token-minter/tests/test_pda_mint.rs
+++ b/tokens/pda-mint-authority/anchor/programs/token-minter/tests/test_pda_mint.rs
@@ -1,12 +1,10 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{create_wallet, get_token_account_balance, send_transaction_from_instructions},
-    solana_signer::Signer,
 };
 
 /// Decimals configured by the program's `mint::decimals` constraint in
@@ -62,7 +60,7 @@ fn derive_ata(wallet: &Address, mint: &Address) -> Address {
 
 fn setup() -> (LiteSVM, Address, Keypair) {
     let program_id = token_minter::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/token_minter.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/tokens/pda-mint-authority/anchor/programs/token-minter/tests/test_pda_mint.rs
+++ b/tokens/pda-mint-authority/anchor/programs/token-minter/tests/test_pda_mint.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{create_wallet, get_token_account_balance, send_transaction_from_instructions},
 };
 

--- a/tokens/token-extensions/basics/anchor/programs/basics/Cargo.toml
+++ b/tokens/token-extensions/basics/anchor/programs/basics/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-spl = "2.0.0-rc.1"
@@ -32,10 +34,17 @@ wincode = { version = "0.5", features = ["derive"] }
 solana-address = ">=2.6, <2.7"
 
 [dev-dependencies]
-litesvm = "0.13.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
 borsh = "1.6.1"
 
 [lints.rust]

--- a/tokens/token-extensions/basics/anchor/programs/basics/tests/test_basics.rs
+++ b/tokens/token-extensions/basics/anchor/programs/basics/tests/test_basics.rs
@@ -1,15 +1,13 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{
         assert_token_account_balance, create_wallet, send_transaction_from_instructions,
         token_extensions::{get_token_extensions_account_address, TOKEN_EXTENSIONS_PROGRAM_ID},
     },
-    solana_signer::Signer,
 };
 
 fn associated_token_program_id() -> Address {
@@ -20,7 +18,7 @@ fn associated_token_program_id() -> Address {
 
 fn setup() -> (LiteSVM, Address, Keypair) {
     let program_id = anchor::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/anchor.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/tokens/token-extensions/basics/anchor/programs/basics/tests/test_basics.rs
+++ b/tokens/token-extensions/basics/anchor/programs/basics/tests/test_basics.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{
         assert_token_account_balance, create_wallet, send_transaction_from_instructions,
         token_extensions::{get_token_extensions_account_address, TOKEN_EXTENSIONS_PROGRAM_ID},

--- a/tokens/token-extensions/cpi-guard/anchor/programs/cpi-guard/Cargo.toml
+++ b/tokens/token-extensions/cpi-guard/anchor/programs/cpi-guard/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -32,10 +34,17 @@ solana-address = ">=2.6, <2.7"
 anchor-spl = "2.0.0-rc.1"
 
 [dev-dependencies]
-litesvm = "0.13.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
 borsh = "1.6.1"
 
 [lints.rust]

--- a/tokens/token-extensions/cpi-guard/anchor/programs/cpi-guard/tests/test_cpi_guard.rs
+++ b/tokens/token-extensions/cpi-guard/anchor/programs/cpi-guard/tests/test_cpi_guard.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::{AccountMeta, Instruction},
         system_program, Address, InstructionData, ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{
         assert_token_account_balance, create_wallet, send_transaction_from_instructions,
         token_extensions::{

--- a/tokens/token-extensions/cpi-guard/anchor/programs/cpi-guard/tests/test_cpi_guard.rs
+++ b/tokens/token-extensions/cpi-guard/anchor/programs/cpi-guard/tests/test_cpi_guard.rs
@@ -1,10 +1,9 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::{AccountMeta, Instruction},
         system_program, Address, InstructionData, ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{
         assert_token_account_balance, create_wallet, send_transaction_from_instructions,
         token_extensions::{
@@ -12,12 +11,11 @@ use {
             TOKEN_EXTENSIONS_PROGRAM_ID,
         },
     },
-    solana_signer::Signer,
 };
 
 fn setup() -> (LiteSVM, Address, Keypair) {
     let program_id = cpi_guard::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/cpi_guard.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/tokens/token-extensions/default-account-state/anchor/programs/default-account-state/Cargo.toml
+++ b/tokens/token-extensions/default-account-state/anchor/programs/default-account-state/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -32,10 +34,17 @@ solana-address = ">=2.6, <2.7"
 anchor-spl = "2.0.0-rc.1"
 
 [dev-dependencies]
-litesvm = "0.13.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
 borsh = "1.6.1"
 
 [lints.rust]

--- a/tokens/token-extensions/default-account-state/anchor/programs/default-account-state/tests/test_default_account_state.rs
+++ b/tokens/token-extensions/default-account-state/anchor/programs/default-account-state/tests/test_default_account_state.rs
@@ -1,15 +1,13 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::{AccountMeta, Instruction},
         system_program, Address, InstructionData, ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{
         assert_token_account_balance, create_wallet, send_transaction_from_instructions,
         token_extensions::{mint_tokens_to_token_extensions_account, TOKEN_EXTENSIONS_PROGRAM_ID},
     },
-    solana_signer::Signer,
 };
 
 /// Create a Token Extensions token account (165 bytes, no extra extensions).
@@ -45,7 +43,7 @@ fn create_token_account_instruction(
 
 fn setup() -> (LiteSVM, Address, Keypair) {
     let program_id = default_account_state::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/default_account_state.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/tokens/token-extensions/default-account-state/anchor/programs/default-account-state/tests/test_default_account_state.rs
+++ b/tokens/token-extensions/default-account-state/anchor/programs/default-account-state/tests/test_default_account_state.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::{AccountMeta, Instruction},
         system_program, Address, InstructionData, ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{
         assert_token_account_balance, create_wallet, send_transaction_from_instructions,
         token_extensions::{mint_tokens_to_token_extensions_account, TOKEN_EXTENSIONS_PROGRAM_ID},

--- a/tokens/token-extensions/group/anchor/programs/group/Cargo.toml
+++ b/tokens/token-extensions/group/anchor/programs/group/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -32,10 +34,17 @@ solana-address = ">=2.6, <2.7"
 anchor-spl = "2.0.0-rc.1"
 
 [dev-dependencies]
-litesvm = "0.13.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
 borsh = "1.6.1"
 
 [lints.rust]

--- a/tokens/token-extensions/group/anchor/programs/group/tests/test_group.rs
+++ b/tokens/token-extensions/group/anchor/programs/group/tests/test_group.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{LiteSVM, Signer},
     solana_kite::{
         create_wallet, send_transaction_from_instructions,
         token_extensions::TOKEN_EXTENSIONS_PROGRAM_ID,

--- a/tokens/token-extensions/group/anchor/programs/group/tests/test_group.rs
+++ b/tokens/token-extensions/group/anchor/programs/group/tests/test_group.rs
@@ -1,20 +1,19 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
-    litesvm::LiteSVM,
     solana_kite::{
         create_wallet, send_transaction_from_instructions,
         token_extensions::TOKEN_EXTENSIONS_PROGRAM_ID,
     },
-    solana_signer::Signer,
 };
 
 #[test]
 fn test_initialize_group() {
     let program_id = group::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/group.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/tokens/token-extensions/immutable-owner/anchor/programs/immutable-owner/Cargo.toml
+++ b/tokens/token-extensions/immutable-owner/anchor/programs/immutable-owner/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -32,10 +34,17 @@ solana-address = ">=2.6, <2.7"
 anchor-spl = "2.0.0-rc.1"
 
 [dev-dependencies]
-litesvm = "0.13.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
 borsh = "1.6.1"
 
 [lints.rust]

--- a/tokens/token-extensions/immutable-owner/anchor/programs/immutable-owner/tests/test_immutable_owner.rs
+++ b/tokens/token-extensions/immutable-owner/anchor/programs/immutable-owner/tests/test_immutable_owner.rs
@@ -1,15 +1,13 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::{AccountMeta, Instruction},
         system_program, Address, InstructionData, ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{
         create_wallet, send_transaction_from_instructions,
         token_extensions::{create_token_extensions_mint, TOKEN_EXTENSIONS_PROGRAM_ID},
     },
-    solana_signer::Signer,
 };
 
 /// SetAuthority instruction for Token Extensions (instruction 6).
@@ -42,7 +40,7 @@ fn set_authority_instruction(
 
 fn setup() -> (LiteSVM, Address, Keypair) {
     let program_id = immutable_owner::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/immutable_owner.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/tokens/token-extensions/immutable-owner/anchor/programs/immutable-owner/tests/test_immutable_owner.rs
+++ b/tokens/token-extensions/immutable-owner/anchor/programs/immutable-owner/tests/test_immutable_owner.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::{AccountMeta, Instruction},
         system_program, Address, InstructionData, ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{
         create_wallet, send_transaction_from_instructions,
         token_extensions::{create_token_extensions_mint, TOKEN_EXTENSIONS_PROGRAM_ID},

--- a/tokens/token-extensions/interest-bearing/anchor/programs/interest-bearing/Cargo.toml
+++ b/tokens/token-extensions/interest-bearing/anchor/programs/interest-bearing/Cargo.toml
@@ -19,6 +19,8 @@ anchor-debug = []
 custom-heap = []
 custom-panic = []
 
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -33,10 +35,17 @@ solana-address = ">=2.6, <2.7"
 anchor-spl = "2.0.0-rc.1"
 
 [dev-dependencies]
-litesvm = "0.13.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
 borsh = "1.6.1"
 
 [lints.rust]

--- a/tokens/token-extensions/interest-bearing/anchor/programs/interest-bearing/tests/test_interest_bearing.rs
+++ b/tokens/token-extensions/interest-bearing/anchor/programs/interest-bearing/tests/test_interest_bearing.rs
@@ -1,20 +1,18 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{
         create_wallet, send_transaction_from_instructions,
         token_extensions::TOKEN_EXTENSIONS_PROGRAM_ID,
     },
-    solana_signer::Signer,
 };
 
 fn setup() -> (LiteSVM, Address, Keypair) {
     let program_id = interest_bearing::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/interest_bearing.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/tokens/token-extensions/interest-bearing/anchor/programs/interest-bearing/tests/test_interest_bearing.rs
+++ b/tokens/token-extensions/interest-bearing/anchor/programs/interest-bearing/tests/test_interest_bearing.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{
         create_wallet, send_transaction_from_instructions,
         token_extensions::TOKEN_EXTENSIONS_PROGRAM_ID,

--- a/tokens/token-extensions/memo-transfer/anchor/programs/memo-transfer/Cargo.toml
+++ b/tokens/token-extensions/memo-transfer/anchor/programs/memo-transfer/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -32,10 +34,17 @@ solana-address = ">=2.6, <2.7"
 anchor-spl = "2.0.0-rc.1"
 
 [dev-dependencies]
-litesvm = "0.13.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
 borsh = "1.6.1"
 
 [lints.rust]

--- a/tokens/token-extensions/memo-transfer/anchor/programs/memo-transfer/tests/test_memo_transfer.rs
+++ b/tokens/token-extensions/memo-transfer/anchor/programs/memo-transfer/tests/test_memo_transfer.rs
@@ -1,10 +1,9 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::{AccountMeta, Instruction},
         system_program, Address, InstructionData, ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{
         assert_token_account_balance, create_wallet, send_transaction_from_instructions,
         token_extensions::{
@@ -12,7 +11,6 @@ use {
             TOKEN_EXTENSIONS_PROGRAM_ID,
         },
     },
-    solana_signer::Signer,
 };
 
 fn memo_program_id() -> Address {
@@ -88,7 +86,7 @@ fn memo_instruction(memo_text: &str, signers: &[&Address]) -> Instruction {
 
 fn setup() -> (LiteSVM, Address, Keypair) {
     let program_id = memo_transfer::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/memo_transfer.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/tokens/token-extensions/memo-transfer/anchor/programs/memo-transfer/tests/test_memo_transfer.rs
+++ b/tokens/token-extensions/memo-transfer/anchor/programs/memo-transfer/tests/test_memo_transfer.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::{AccountMeta, Instruction},
         system_program, Address, InstructionData, ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{
         assert_token_account_balance, create_wallet, send_transaction_from_instructions,
         token_extensions::{

--- a/tokens/token-extensions/metadata/anchor/programs/metadata/Cargo.toml
+++ b/tokens/token-extensions/metadata/anchor/programs/metadata/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -34,10 +36,17 @@ spl-token-metadata-interface = "0.8.0"
 spl-type-length-value = "0.9.1"
 
 [dev-dependencies]
-litesvm = "0.13.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
 borsh = "1.6.1"
 
 [lints.rust]

--- a/tokens/token-extensions/metadata/anchor/programs/metadata/tests/test_metadata.rs
+++ b/tokens/token-extensions/metadata/anchor/programs/metadata/tests/test_metadata.rs
@@ -1,20 +1,18 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{
         create_wallet, send_transaction_from_instructions,
         token_extensions::TOKEN_EXTENSIONS_PROGRAM_ID,
     },
-    solana_signer::Signer,
 };
 
 fn setup() -> (LiteSVM, Address, Keypair) {
     let program_id = metadata::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/metadata.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/tokens/token-extensions/metadata/anchor/programs/metadata/tests/test_metadata.rs
+++ b/tokens/token-extensions/metadata/anchor/programs/metadata/tests/test_metadata.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{
         create_wallet, send_transaction_from_instructions,
         token_extensions::TOKEN_EXTENSIONS_PROGRAM_ID,

--- a/tokens/token-extensions/mint-close-authority/anchor/programs/mint-close-authority/Cargo.toml
+++ b/tokens/token-extensions/mint-close-authority/anchor/programs/mint-close-authority/Cargo.toml
@@ -15,6 +15,8 @@ no-entrypoint = []
 no-idl = []
 no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build"]
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -29,10 +31,17 @@ solana-address = ">=2.6, <2.7"
 anchor-spl = "2.0.0-rc.1"
 
 [dev-dependencies]
-litesvm = "0.13.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
 borsh = "1.6.1"
 
 [lints.rust]

--- a/tokens/token-extensions/mint-close-authority/anchor/programs/mint-close-authority/tests/test_mint_close_authority.rs
+++ b/tokens/token-extensions/mint-close-authority/anchor/programs/mint-close-authority/tests/test_mint_close_authority.rs
@@ -1,20 +1,18 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{
         create_wallet, send_transaction_from_instructions,
         token_extensions::TOKEN_EXTENSIONS_PROGRAM_ID,
     },
-    solana_signer::Signer,
 };
 
 fn setup() -> (LiteSVM, Address, Keypair) {
     let program_id = mint_close_authority::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/mint_close_authority.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/tokens/token-extensions/mint-close-authority/anchor/programs/mint-close-authority/tests/test_mint_close_authority.rs
+++ b/tokens/token-extensions/mint-close-authority/anchor/programs/mint-close-authority/tests/test_mint_close_authority.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{
         create_wallet, send_transaction_from_instructions,
         token_extensions::TOKEN_EXTENSIONS_PROGRAM_ID,

--- a/tokens/token-extensions/nft-meta-data-pointer/anchor-example/anchor/programs/extension_nft/Cargo.toml
+++ b/tokens/token-extensions/nft-meta-data-pointer/anchor-example/anchor/programs/extension_nft/Cargo.toml
@@ -19,6 +19,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = { version = "2.0.0-rc.1", features = ["compat"] }
@@ -47,11 +49,18 @@ anchor-spl = { version = "2.0.0-rc.1" }
 # re-exports keeps a single, consistent type universe.
 
 [dev-dependencies]
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 # Test-side decode of the player account's borsh payload.
 borsh = "1.6.1"
-litesvm = "0.13.1"
-solana-keypair = "3.0.1"
-solana-signer = "3.0.0"
 solana-instruction = "3.0.0"
 solana-pubkey = "3.0.0"
 solana-kite = "0.4.0"

--- a/tokens/token-extensions/nft-meta-data-pointer/anchor-example/anchor/programs/extension_nft/tests/test_extension_nft.rs
+++ b/tokens/token-extensions/nft-meta-data-pointer/anchor-example/anchor/programs/extension_nft/tests/test_extension_nft.rs
@@ -23,11 +23,9 @@ use {
     // `system_program` moved to the crate root in v2, and `Pubkey` is
     // compat-only: `Address` is the same 32-byte type.
     anchor_lang::{system_program, Address as Pubkey, InstructionData, ToAccountMetas},
-    litesvm::LiteSVM,
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_instruction::Instruction,
-    solana_keypair::Keypair,
     solana_kite::{create_wallet, get_pda_and_bump, send_transaction_from_instructions, Seed},
-    solana_signer::Signer,
 };
 
 // Token Extensions and Associated-Token-Account program ids (the modern, fixed
@@ -42,7 +40,7 @@ const LEVEL_SEED: &str = "level1";
 
 fn setup() -> (LiteSVM, Pubkey) {
     let program_id = extension_nft::ID;
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
     let bytes = include_bytes!("../../../target/deploy/extension_nft.so");
     svm.add_program(program_id, bytes).unwrap();
     (svm, program_id)

--- a/tokens/token-extensions/non-transferable/anchor/programs/non-transferable/Cargo.toml
+++ b/tokens/token-extensions/non-transferable/anchor/programs/non-transferable/Cargo.toml
@@ -15,6 +15,8 @@ no-entrypoint = []
 no-idl = []
 no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build"]
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -29,10 +31,17 @@ solana-address = ">=2.6, <2.7"
 anchor-spl = "2.0.0-rc.1"
 
 [dev-dependencies]
-litesvm = "0.13.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
 borsh = "1.6.1"
 
 [lints.rust]

--- a/tokens/token-extensions/non-transferable/anchor/programs/non-transferable/tests/test_non_transferable.rs
+++ b/tokens/token-extensions/non-transferable/anchor/programs/non-transferable/tests/test_non_transferable.rs
@@ -1,10 +1,9 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{
         create_wallet, send_transaction_from_instructions,
         token_extensions::{
@@ -13,12 +12,11 @@ use {
             TOKEN_EXTENSIONS_PROGRAM_ID,
         },
     },
-    solana_signer::Signer,
 };
 
 fn setup() -> (LiteSVM, Address, Keypair) {
     let program_id = non_transferable::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/non_transferable.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/tokens/token-extensions/non-transferable/anchor/programs/non-transferable/tests/test_non_transferable.rs
+++ b/tokens/token-extensions/non-transferable/anchor/programs/non-transferable/tests/test_non_transferable.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{
         create_wallet, send_transaction_from_instructions,
         token_extensions::{

--- a/tokens/token-extensions/permanent-delegate/anchor/programs/permanent-delegate/Cargo.toml
+++ b/tokens/token-extensions/permanent-delegate/anchor/programs/permanent-delegate/Cargo.toml
@@ -19,6 +19,8 @@ anchor-debug = []
 custom-heap = []
 custom-panic = []
 
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -33,10 +35,17 @@ solana-address = ">=2.6, <2.7"
 anchor-spl = "2.0.0-rc.1"
 
 [dev-dependencies]
-litesvm = "0.13.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
 borsh = "1.6.1"
 
 [lints.rust]

--- a/tokens/token-extensions/permanent-delegate/anchor/programs/permanent-delegate/tests/test_permanent_delegate.rs
+++ b/tokens/token-extensions/permanent-delegate/anchor/programs/permanent-delegate/tests/test_permanent_delegate.rs
@@ -1,20 +1,18 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::{AccountMeta, Instruction},
         system_program, Address, InstructionData, ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{
         assert_token_account_balance, create_wallet, send_transaction_from_instructions,
         token_extensions::{mint_tokens_to_token_extensions_account, TOKEN_EXTENSIONS_PROGRAM_ID},
     },
-    solana_signer::Signer,
 };
 
 fn setup() -> (LiteSVM, Address, Keypair) {
     let program_id = permanent_delegate::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/permanent_delegate.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/tokens/token-extensions/permanent-delegate/anchor/programs/permanent-delegate/tests/test_permanent_delegate.rs
+++ b/tokens/token-extensions/permanent-delegate/anchor/programs/permanent-delegate/tests/test_permanent_delegate.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::{AccountMeta, Instruction},
         system_program, Address, InstructionData, ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{
         assert_token_account_balance, create_wallet, send_transaction_from_instructions,
         token_extensions::{mint_tokens_to_token_extensions_account, TOKEN_EXTENSIONS_PROGRAM_ID},

--- a/tokens/token-extensions/transfer-fee/anchor/programs/transfer-fee/Cargo.toml
+++ b/tokens/token-extensions/transfer-fee/anchor/programs/transfer-fee/Cargo.toml
@@ -15,6 +15,8 @@ no-entrypoint = []
 no-idl = []
 no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build"]
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -29,10 +31,17 @@ solana-address = ">=2.6, <2.7"
 anchor-spl = "2.0.0-rc.1"
 
 [dev-dependencies]
-litesvm = "0.13.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
 borsh = "1.6.1"
 
 [lints.rust]

--- a/tokens/token-extensions/transfer-fee/anchor/programs/transfer-fee/tests/test_transfer_fee.rs
+++ b/tokens/token-extensions/transfer-fee/anchor/programs/transfer-fee/tests/test_transfer_fee.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::{AccountMeta, Instruction},
         system_program, Address, InstructionData, ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{
         create_wallet, send_transaction_from_instructions,
         token_extensions::{

--- a/tokens/token-extensions/transfer-fee/anchor/programs/transfer-fee/tests/test_transfer_fee.rs
+++ b/tokens/token-extensions/transfer-fee/anchor/programs/transfer-fee/tests/test_transfer_fee.rs
@@ -1,10 +1,9 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::{AccountMeta, Instruction},
         system_program, Address, InstructionData, ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{
         create_wallet, send_transaction_from_instructions,
         token_extensions::{
@@ -12,7 +11,6 @@ use {
             mint_tokens_to_token_extensions_account, TOKEN_EXTENSIONS_PROGRAM_ID,
         },
     },
-    solana_signer::Signer,
 };
 
 fn associated_token_program_id() -> Address {
@@ -23,7 +21,7 @@ fn associated_token_program_id() -> Address {
 
 fn setup() -> (LiteSVM, Address, Keypair) {
     let program_id = transfer_fee::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/transfer_fee.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/tokens/token-extensions/transfer-hook/account-data-as-seed/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/account-data-as-seed/anchor/programs/transfer-hook/Cargo.toml
@@ -26,6 +26,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = { version = "2.0.0-rc.1", features = ["compat"] }
@@ -43,10 +45,17 @@ spl-tlv-account-resolution = "0.9.0"
 spl-transfer-hook-interface = "0.9.0"
 
 [dev-dependencies]
-litesvm = "0.13.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
 borsh = "1.6.1"
 
 [lints.rust]

--- a/tokens/token-extensions/transfer-hook/account-data-as-seed/anchor/programs/transfer-hook/tests/test_transfer_hook.rs
+++ b/tokens/token-extensions/transfer-hook/account-data-as-seed/anchor/programs/transfer-hook/tests/test_transfer_hook.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     borsh::BorshDeserialize,
     solana_kite::{
         create_wallet, send_transaction_from_instructions,

--- a/tokens/token-extensions/transfer-hook/account-data-as-seed/anchor/programs/transfer-hook/tests/test_transfer_hook.rs
+++ b/tokens/token-extensions/transfer-hook/account-data-as-seed/anchor/programs/transfer-hook/tests/test_transfer_hook.rs
@@ -1,11 +1,10 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
     borsh::BorshDeserialize,
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{
         create_wallet, send_transaction_from_instructions,
         token_extensions::{
@@ -15,7 +14,6 @@ use {
         },
         transfer_hook::{build_hook_accounts, get_hook_accounts_address, HookAccount},
     },
-    solana_signer::Signer,
 };
 
 /// Deserialize the CounterAccount (8-byte discriminator + fields).
@@ -41,7 +39,7 @@ fn associated_token_program_id() -> Address {
 
 fn setup() -> (LiteSVM, Address, Keypair) {
     let program_id = transfer_hook::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/transfer_hook.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/tokens/token-extensions/transfer-hook/allow-block-list-token/anchor/programs/abl-token/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/allow-block-list-token/anchor/programs/abl-token/Cargo.toml
@@ -23,6 +23,8 @@ anchor-debug = []
 custom-heap = []
 custom-panic = []
 
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 # interface-instructions feature was removed in Anchor 1.0 and does not exist in v2
@@ -44,10 +46,17 @@ spl-transfer-hook-interface = { version = "2.1.0" }
 spl-discriminator = "0.5.1"
 
 [dev-dependencies]
-litesvm = "0.13.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
 borsh = "1.6.1"
 
 [lints.rust]

--- a/tokens/token-extensions/transfer-hook/allow-block-list-token/anchor/programs/abl-token/tests/test_abl_token.rs
+++ b/tokens/token-extensions/transfer-hook/allow-block-list-token/anchor/programs/abl-token/tests/test_abl_token.rs
@@ -1,20 +1,18 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{
         create_wallet, send_transaction_from_instructions,
         token_extensions::TOKEN_EXTENSIONS_PROGRAM_ID,
     },
-    solana_signer::Signer,
 };
 
 fn setup() -> (LiteSVM, Address, Keypair) {
     let program_id = abl_token::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/abl_token.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/tokens/token-extensions/transfer-hook/allow-block-list-token/anchor/programs/abl-token/tests/test_abl_token.rs
+++ b/tokens/token-extensions/transfer-hook/allow-block-list-token/anchor/programs/abl-token/tests/test_abl_token.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{
         create_wallet, send_transaction_from_instructions,
         token_extensions::TOKEN_EXTENSIONS_PROGRAM_ID,

--- a/tokens/token-extensions/transfer-hook/counter/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/counter/anchor/programs/transfer-hook/Cargo.toml
@@ -26,6 +26,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = { version = "2.0.0-rc.1", features = ["compat"] }
@@ -43,10 +45,17 @@ spl-tlv-account-resolution = "0.9.0"
 spl-transfer-hook-interface = "0.9.0"
 
 [dev-dependencies]
-litesvm = "0.13.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
 borsh = "1.6.1"
 
 [lints.rust]

--- a/tokens/token-extensions/transfer-hook/counter/anchor/programs/transfer-hook/tests/test_transfer_hook_counter.rs
+++ b/tokens/token-extensions/transfer-hook/counter/anchor/programs/transfer-hook/tests/test_transfer_hook_counter.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     borsh::BorshDeserialize,
     solana_kite::{
         create_wallet, send_transaction_from_instructions,

--- a/tokens/token-extensions/transfer-hook/counter/anchor/programs/transfer-hook/tests/test_transfer_hook_counter.rs
+++ b/tokens/token-extensions/transfer-hook/counter/anchor/programs/transfer-hook/tests/test_transfer_hook_counter.rs
@@ -1,11 +1,10 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
     borsh::BorshDeserialize,
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{
         create_wallet, send_transaction_from_instructions,
         token_extensions::{
@@ -15,7 +14,6 @@ use {
         },
         transfer_hook::{build_hook_accounts, get_hook_accounts_address, HookAccount},
     },
-    solana_signer::Signer,
 };
 
 /// Deserialize the CounterAccount (8-byte discriminator + fields).
@@ -41,7 +39,7 @@ fn associated_token_program_id() -> Address {
 
 fn setup() -> (LiteSVM, Address, Keypair) {
     let program_id = transfer_hook::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/transfer_hook.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/tokens/token-extensions/transfer-hook/hello-world/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/hello-world/anchor/programs/transfer-hook/Cargo.toml
@@ -26,6 +26,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = { version = "2.0.0-rc.1", features = ["compat"] }
@@ -43,10 +45,17 @@ spl-tlv-account-resolution = "0.9.0"
 spl-transfer-hook-interface = "0.9.0"
 
 [dev-dependencies]
-litesvm = "0.13.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
 borsh = "1.6.1"
 
 [lints.rust]

--- a/tokens/token-extensions/transfer-hook/hello-world/anchor/programs/transfer-hook/tests/test_transfer_hook.rs
+++ b/tokens/token-extensions/transfer-hook/hello-world/anchor/programs/transfer-hook/tests/test_transfer_hook.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{
         create_wallet, send_transaction_from_instructions,
         token_extensions::{

--- a/tokens/token-extensions/transfer-hook/hello-world/anchor/programs/transfer-hook/tests/test_transfer_hook.rs
+++ b/tokens/token-extensions/transfer-hook/hello-world/anchor/programs/transfer-hook/tests/test_transfer_hook.rs
@@ -1,10 +1,9 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{
         create_wallet, send_transaction_from_instructions,
         token_extensions::{
@@ -14,7 +13,6 @@ use {
         },
         transfer_hook::{build_hook_accounts, get_hook_accounts_address},
     },
-    solana_signer::Signer,
 };
 
 fn associated_token_program_id() -> Address {
@@ -25,7 +23,7 @@ fn associated_token_program_id() -> Address {
 
 fn setup() -> (LiteSVM, Address, Keypair) {
     let program_id = transfer_hook::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/transfer_hook.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/tokens/token-extensions/transfer-hook/transfer-cost/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/transfer-cost/anchor/programs/transfer-hook/Cargo.toml
@@ -26,6 +26,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = { version = "2.0.0-rc.1", features = ["compat"] }
@@ -44,10 +46,17 @@ spl-tlv-account-resolution = "0.11.1"
 spl-transfer-hook-interface = "2.1.0"
 
 [dev-dependencies]
-litesvm = "0.13.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
 borsh = "1.6.1"
 
 [lints.rust]

--- a/tokens/token-extensions/transfer-hook/transfer-cost/anchor/programs/transfer-hook/tests/test_transfer_hook.rs
+++ b/tokens/token-extensions/transfer-hook/transfer-cost/anchor/programs/transfer-hook/tests/test_transfer_hook.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{
         create_wallet, send_transaction_from_instructions,
         token_extensions::{

--- a/tokens/token-extensions/transfer-hook/transfer-cost/anchor/programs/transfer-hook/tests/test_transfer_hook.rs
+++ b/tokens/token-extensions/transfer-hook/transfer-cost/anchor/programs/transfer-hook/tests/test_transfer_hook.rs
@@ -1,10 +1,9 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{
         create_wallet, send_transaction_from_instructions,
         token_extensions::{
@@ -12,12 +11,11 @@ use {
         },
         transfer_hook::get_hook_accounts_address,
     },
-    solana_signer::Signer,
 };
 
 fn setup() -> (LiteSVM, Address, Keypair) {
     let program_id = transfer_hook::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/transfer_hook.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/tokens/token-extensions/transfer-hook/transfer-switch/anchor/programs/transfer-switch/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/transfer-switch/anchor/programs/transfer-switch/Cargo.toml
@@ -22,6 +22,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = { version = "2.0.0-rc.1", features = ["compat"] }
@@ -39,10 +41,17 @@ spl-tlv-account-resolution = "0.9.0"
 spl-transfer-hook-interface = "0.9.0"
 
 [dev-dependencies]
-litesvm = "0.13.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
 borsh = "1.6.1"
 
 [lints.rust]

--- a/tokens/token-extensions/transfer-hook/transfer-switch/anchor/programs/transfer-switch/tests/test_transfer_switch.rs
+++ b/tokens/token-extensions/transfer-hook/transfer-switch/anchor/programs/transfer-switch/tests/test_transfer_switch.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{
         create_wallet, send_transaction_from_instructions,
         token_extensions::{

--- a/tokens/token-extensions/transfer-hook/transfer-switch/anchor/programs/transfer-switch/tests/test_transfer_switch.rs
+++ b/tokens/token-extensions/transfer-hook/transfer-switch/anchor/programs/transfer-switch/tests/test_transfer_switch.rs
@@ -1,10 +1,9 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{
         create_wallet, send_transaction_from_instructions,
         token_extensions::{
@@ -14,12 +13,11 @@ use {
         },
         transfer_hook::{build_hook_accounts, get_hook_accounts_address, HookAccount},
     },
-    solana_signer::Signer,
 };
 
 fn setup() -> (LiteSVM, Address, Keypair) {
     let program_id = transfer_switch::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/transfer_switch.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/tokens/token-extensions/transfer-hook/whitelist/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/whitelist/anchor/programs/transfer-hook/Cargo.toml
@@ -26,6 +26,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = { version = "2.0.0-rc.1", features = ["compat"] }
@@ -43,10 +45,17 @@ spl-tlv-account-resolution = "0.9.0"
 spl-transfer-hook-interface = "0.9.0"
 
 [dev-dependencies]
-litesvm = "0.13.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
 borsh = "1.6.1"
 
 [lints.rust]

--- a/tokens/token-extensions/transfer-hook/whitelist/anchor/programs/transfer-hook/tests/test_transfer_hook.rs
+++ b/tokens/token-extensions/transfer-hook/whitelist/anchor/programs/transfer-hook/tests/test_transfer_hook.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{
         create_wallet, send_transaction_from_instructions,
         token_extensions::{

--- a/tokens/token-extensions/transfer-hook/whitelist/anchor/programs/transfer-hook/tests/test_transfer_hook.rs
+++ b/tokens/token-extensions/transfer-hook/whitelist/anchor/programs/transfer-hook/tests/test_transfer_hook.rs
@@ -1,10 +1,9 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{
         create_wallet, send_transaction_from_instructions,
         token_extensions::{
@@ -14,12 +13,11 @@ use {
         },
         transfer_hook::{build_hook_accounts, get_hook_accounts_address, HookAccount},
     },
-    solana_signer::Signer,
 };
 
 fn setup() -> (LiteSVM, Address, Keypair) {
     let program_id = transfer_hook::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/transfer_hook.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/tokens/token-minter/anchor/programs/token-minter/Cargo.toml
+++ b/tokens/token-minter/anchor/programs/token-minter/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -32,9 +34,16 @@ solana-address = ">=2.6, <2.7"
 anchor-spl = { version = "2.0.0-rc.1", features = ["metadata"] }
 
 [dev-dependencies]
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"
 

--- a/tokens/token-minter/anchor/programs/token-minter/tests/test_token_minter.rs
+++ b/tokens/token-minter/anchor/programs/token-minter/tests/test_token_minter.rs
@@ -1,12 +1,10 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{create_wallet, get_token_account_balance, send_transaction_from_instructions},
-    solana_signer::Signer,
 };
 
 /// Decimals configured by the program's `mint::decimals` constraint in
@@ -62,7 +60,7 @@ fn derive_ata(wallet: &Address, mint: &Address) -> Address {
 
 fn setup() -> (LiteSVM, Address, Keypair) {
     let program_id = token_minter::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/token_minter.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/tokens/token-minter/anchor/programs/token-minter/tests/test_token_minter.rs
+++ b/tokens/token-minter/anchor/programs/token-minter/tests/test_token_minter.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{create_wallet, get_token_account_balance, send_transaction_from_instructions},
 };
 

--- a/tokens/transfer-tokens/anchor/programs/transfer-tokens/Cargo.toml
+++ b/tokens/transfer-tokens/anchor/programs/transfer-tokens/Cargo.toml
@@ -18,6 +18,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+# Forwards to the harness so `anchor test --profile` can turn tracing on.
+profile = ["anchor-v2-testing/profile"]
 
 [dependencies]
 anchor-lang = "2.0.0-rc.1"
@@ -32,9 +34,16 @@ solana-address = ">=2.6, <2.7"
 anchor-spl = { version = "2.0.0-rc.1", features = ["metadata"] }
 
 [dev-dependencies]
-litesvm = "0.13.1"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
+# Anchor v2's own LiteSVM harness. `svm()` is `LiteSVM::new()` until the
+# `profile` feature is on, when it also records the SBF register traces that
+# `anchor test --profile`, `anchor debugger` and `anchor coverage` read. Tests
+# that call `LiteSVM::new()` directly still pass but produce no traces, so
+# those three tools see nothing.
+#
+# Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
+# revision rather than tracking `anchor-next`, so a CI run cannot change
+# behaviour because upstream moved between builds.
+anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"
 

--- a/tokens/transfer-tokens/anchor/programs/transfer-tokens/tests/test_transfer_tokens.rs
+++ b/tokens/transfer-tokens/anchor/programs/transfer-tokens/tests/test_transfer_tokens.rs
@@ -1,12 +1,10 @@
 use {
     anchor_lang::{
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
-    litesvm::LiteSVM,
-    solana_keypair::Keypair,
     solana_kite::{create_wallet, get_token_account_balance, send_transaction_from_instructions},
-    solana_signer::Signer,
 };
 
 /// Decimals configured by the program's `mint::decimals` constraint in
@@ -62,7 +60,7 @@ fn derive_ata(wallet: &Address, mint: &Address) -> Address {
 
 fn setup() -> (LiteSVM, Address, Keypair) {
     let program_id = transfer_tokens::id();
-    let mut svm = LiteSVM::new();
+    let mut svm = anchor_v2_testing::svm();
 
     let program_bytes = include_bytes!("../../../target/deploy/transfer_tokens.so");
     svm.add_program(program_id, program_bytes).unwrap();

--- a/tokens/transfer-tokens/anchor/programs/transfer-tokens/tests/test_transfer_tokens.rs
+++ b/tokens/transfer-tokens/anchor/programs/transfer-tokens/tests/test_transfer_tokens.rs
@@ -1,9 +1,9 @@
 use {
     anchor_lang::{
-    anchor_v2_testing::{Keypair, LiteSVM, Signer},
         solana_program::instruction::Instruction, system_program, Address, InstructionData,
         ToAccountMetas,
     },
+    anchor_v2_testing::{Keypair, LiteSVM, Signer},
     solana_kite::{create_wallet, get_token_account_balance, send_transaction_from_instructions},
 };
 


### PR DESCRIPTION
Anchor v2 ships its own LiteSVM wrapper, `anchor-v2-testing`. Tests that call `LiteSVM::new()` directly still run and still pass, but they record nothing, so `anchor test --profile`, `anchor debugger` and `anchor coverage` all come back empty. Going through `anchor_v2_testing::svm()` is what connects a test to those three tools, and it is `LiteSVM::new()` until the `profile` feature turns tracing on, so the default path costs nothing.

## What changes

Per program crate, the dev-dependencies drop `litesvm`, `solana-signer` and `solana-keypair`, which the harness re-exports, and gain the harness plus a `profile` feature forwarding to it:

```toml
[dev-dependencies]
anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }

[features]
profile = ["anchor-v2-testing/profile"]
```

Tests swap `LiteSVM::new()` for `anchor_v2_testing::svm()` and their imports follow. The execution model does not change: same in-process LiteSVM, same `solana-kite` helpers, which take the same `LiteSVM` value.

## Why a git dependency, and why a pinned rev

crates.io has no `anchor-v2-testing`; a git dependency is what the [v2 testing documentation](https://v2.anchor-lang.com/docs/v2/testing/litesvm/) prescribes. That documentation says `branch = "anchor-next"`. This pins a revision instead, because `Cargo.lock` is not tracked here, so CI resolves fresh on every run and a branch would let an upstream push change a build with no commit in this repository to explain it. Bumping the rev then becomes a deliberate, reviewable change. Happy to switch to the branch if you would rather track it.

## What this unlocks

None of these work today, because nothing records traces:

- `anchor test --profile` writes per-test SBF traces and renders flamegraphs
- `anchor debugger` opens an instruction stepper with DWARF source mapping and CPI frames
- `anchor coverage` emits LCOV at `target/coverage/sbf.lcov`

Verified on `basics/counter`: `anchor coverage` resolved 294 of 312 program counters to source across 19 files, 91 lines covered, with per-line hit counts in the LCOV.

## Verification

A full local build-and-test sweep over all 55 Anchor projects: **54 pass, 286 tests.**

The one failure, `finance/vault-strategy`'s `test_add_asset_enforces_max_assets`, is not caused by this change. It fails identically on unmigrated `origin/main` with `ProgramLoad("Entrypoint out of bounds")` while loading `mock_swap_router.so`, and it passes in CI, so it is an artefact of the locally-built `cargo-build-sbf` 4.2.0 rather than the Solana 3.1.14 toolchain CI installs. Flagging it rather than folding a fix into this PR.

The sweep earned its keep. The first pass of this migration failed on 44 of 51 projects with `unresolved import anchor_lang::anchor_v2_testing`: the import was being inserted at the first alphabetically-later entry without regard to nesting depth, so in a block like

```rust
use {
    anchor_lang::{
        solana_program::instruction::Instruction, ...
    },
```

it landed inside `anchor_lang`. Five further files named the replaced crates by full path rather than importing them, mostly in helper signatures like `fn setup() -> (LiteSVM, solana_keypair::Keypair)`, and dropping the dev-dependencies left those dangling. Both are fixed in the second commit.

## Not included

The one test importing `solana_transaction::Transaction` keeps that dependency, because the harness re-exports `VersionedTransaction` and not `Transaction`. `mock-swap-router` has no tests, so it gains nothing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbvFm2C5HPuktkz5yi1Kxu)_