### PR TITLE
Say when to bump the pinned anchor-v2-testing revision

### DIFF
--- a/basics/account-data/anchor/programs/anchor-program-example/Cargo.toml
+++ b/basics/account-data/anchor/programs/anchor-program-example/Cargo.toml
@@ -37,6 +37,11 @@ wincode = { version = "0.5", features = ["derive"] }
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 borsh = "1.6.1"
 solana-kite = "0.4.0"

--- a/basics/checking-accounts/anchor/programs/anchor-program-example/Cargo.toml
+++ b/basics/checking-accounts/anchor/programs/anchor-program-example/Cargo.toml
@@ -37,6 +37,11 @@ wincode = { version = "0.5", features = ["derive"] }
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 borsh = "1.6.1"
 solana-kite = "0.4.0"

--- a/basics/close-account/anchor/programs/close-account/Cargo.toml
+++ b/basics/close-account/anchor/programs/close-account/Cargo.toml
@@ -43,6 +43,11 @@ solana-address = ">=2.6, <2.7"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 

--- a/basics/counter/anchor/programs/counter_anchor/Cargo.toml
+++ b/basics/counter/anchor/programs/counter_anchor/Cargo.toml
@@ -37,6 +37,11 @@ wincode = { version = "0.5", features = ["derive"] }
 # It is published only from git: crates.io has no `anchor-v2-testing`. Pinned
 # to a revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 borsh = "1.6.1"
 solana-kite = "0.4.0"

--- a/basics/create-account/anchor/programs/create-system-account/Cargo.toml
+++ b/basics/create-account/anchor/programs/create-system-account/Cargo.toml
@@ -37,6 +37,11 @@ wincode = { version = "0.5", features = ["derive"] }
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 

--- a/basics/cross-program-invocation/anchor/programs/hand/Cargo.toml
+++ b/basics/cross-program-invocation/anchor/programs/hand/Cargo.toml
@@ -37,6 +37,11 @@ wincode = { version = "0.5", features = ["derive"] }
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 

--- a/basics/cross-program-invocation/anchor/programs/lever/Cargo.toml
+++ b/basics/cross-program-invocation/anchor/programs/lever/Cargo.toml
@@ -37,6 +37,11 @@ wincode = { version = "0.5", features = ["derive"] }
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 

--- a/basics/favorites/anchor/programs/favorites/Cargo.toml
+++ b/basics/favorites/anchor/programs/favorites/Cargo.toml
@@ -37,6 +37,11 @@ wincode = { version = "0.5", features = ["derive"] }
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 

--- a/basics/hello-solana/anchor/programs/hello-solana/Cargo.toml
+++ b/basics/hello-solana/anchor/programs/hello-solana/Cargo.toml
@@ -37,6 +37,11 @@ wincode = { version = "0.5", features = ["derive"] }
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 solana-transaction = "3.0.1"

--- a/basics/pda-rent-payer/anchor/programs/anchor-program-example/Cargo.toml
+++ b/basics/pda-rent-payer/anchor/programs/anchor-program-example/Cargo.toml
@@ -37,6 +37,11 @@ wincode = { version = "0.5", features = ["derive"] }
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 

--- a/basics/processing-instructions/anchor/programs/processing-instructions/Cargo.toml
+++ b/basics/processing-instructions/anchor/programs/processing-instructions/Cargo.toml
@@ -37,6 +37,11 @@ wincode = { version = "0.5", features = ["derive"] }
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 

--- a/basics/program-derived-addresses/anchor/programs/anchor-program-example/Cargo.toml
+++ b/basics/program-derived-addresses/anchor/programs/anchor-program-example/Cargo.toml
@@ -37,6 +37,11 @@ wincode = { version = "0.5", features = ["derive"] }
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 borsh = "1.6.1"
 solana-kite = "0.4.0"

--- a/basics/pyth/anchor/programs/pythexample/Cargo.toml
+++ b/basics/pyth/anchor/programs/pythexample/Cargo.toml
@@ -42,6 +42,11 @@ solana-address = ">=2.6, <2.7"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 # Self-dependency with no-entrypoint: host test builds otherwise export a
 # #[no_mangle] `entrypoint` symbol from this crate AND from spl-token (via

--- a/basics/realloc/anchor/programs/anchor-realloc/Cargo.toml
+++ b/basics/realloc/anchor/programs/anchor-realloc/Cargo.toml
@@ -37,6 +37,11 @@ wincode = { version = "0.5", features = ["derive"] }
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 borsh = "1.6.1"
 solana-kite = "0.4.0"

--- a/basics/rent/anchor/programs/rent-example/Cargo.toml
+++ b/basics/rent/anchor/programs/rent-example/Cargo.toml
@@ -37,6 +37,11 @@ wincode = { version = "0.5", features = ["derive"] }
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 

--- a/basics/repository-layout/anchor/programs/carnival/Cargo.toml
+++ b/basics/repository-layout/anchor/programs/carnival/Cargo.toml
@@ -37,6 +37,11 @@ wincode = { version = "0.5", features = ["derive"] }
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 

--- a/basics/transfer-sol/anchor/programs/transfer-sol/Cargo.toml
+++ b/basics/transfer-sol/anchor/programs/transfer-sol/Cargo.toml
@@ -37,6 +37,11 @@ wincode = { version = "0.5", features = ["derive"] }
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 

--- a/compression/cnft-burn/anchor/programs/cnft-burn/Cargo.toml
+++ b/compression/cnft-burn/anchor/programs/cnft-burn/Cargo.toml
@@ -48,6 +48,11 @@ borsh = { version = "1", features = ["derive"] }
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 solana-instruction = "3.0.0"

--- a/compression/cnft-vault/anchor/programs/cnft-vault/Cargo.toml
+++ b/compression/cnft-vault/anchor/programs/cnft-vault/Cargo.toml
@@ -51,6 +51,11 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_os, values("solana"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 solana-instruction = "3.0.0"

--- a/compression/cutils/anchor/programs/cutils/Cargo.toml
+++ b/compression/cutils/anchor/programs/cutils/Cargo.toml
@@ -53,6 +53,11 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_os, values("solana"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 solana-instruction = "3.0.0"

--- a/finance/betting-market/anchor/programs/betting-market/Cargo.toml
+++ b/finance/betting-market/anchor/programs/betting-market/Cargo.toml
@@ -44,6 +44,11 @@ anchor-spl = "2.0.0-rc.1"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 # no-entrypoint: solana-kite pulls these SPL program crates into the host test
 # build, and their `entrypoint` symbols collide with this program's own

--- a/finance/escrow/anchor/programs/escrow/Cargo.toml
+++ b/finance/escrow/anchor/programs/escrow/Cargo.toml
@@ -43,6 +43,11 @@ anchor-spl = "2.0.0-rc.1"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"

--- a/finance/lending/anchor/programs/lending/Cargo.toml
+++ b/finance/lending/anchor/programs/lending/Cargo.toml
@@ -47,6 +47,11 @@ anchor-spl = "2.0.0-rc.1"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"

--- a/finance/order-book/anchor/programs/order-book/Cargo.toml
+++ b/finance/order-book/anchor/programs/order-book/Cargo.toml
@@ -49,6 +49,11 @@ static_assertions = "1.1"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 # Match the test stack used by finance/escrow and the other LiteSVM-based
 # Anchor examples so contributors can move between them without version drift.

--- a/finance/perpetual-futures/anchor/programs/perpetual-futures/Cargo.toml
+++ b/finance/perpetual-futures/anchor/programs/perpetual-futures/Cargo.toml
@@ -60,6 +60,11 @@ solana-sysvar = "3"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-clock = "3.0.1"
 solana-kite = "0.4.0"

--- a/finance/prop-amm/anchor/programs/prop-amm/Cargo.toml
+++ b/finance/prop-amm/anchor/programs/prop-amm/Cargo.toml
@@ -57,6 +57,11 @@ spl-associated-token-account = { version = "8.0.0", features = ["no-entrypoint"]
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-clock = "3.0.1"
 solana-kite = "0.4.0"

--- a/finance/token-fundraiser/anchor/programs/fundraiser/Cargo.toml
+++ b/finance/token-fundraiser/anchor/programs/fundraiser/Cargo.toml
@@ -43,6 +43,11 @@ anchor-spl = "2.0.0-rc.1"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-clock = "3.0.1"
 solana-kite = "0.4.0"

--- a/finance/token-swap/anchor/programs/token-swap/Cargo.toml
+++ b/finance/token-swap/anchor/programs/token-swap/Cargo.toml
@@ -46,6 +46,11 @@ anchor-spl = "2.0.0-rc.1"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"

--- a/finance/vault-strategy/anchor/programs/vault-strategy/Cargo.toml
+++ b/finance/vault-strategy/anchor/programs/vault-strategy/Cargo.toml
@@ -49,6 +49,11 @@ mock-swap-router = { path = "../mock-swap-router", features = ["cpi"] }
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-clock = "3.0.1"
 solana-account = "3.0.0"

--- a/tokens/create-token/anchor/programs/create-token/Cargo.toml
+++ b/tokens/create-token/anchor/programs/create-token/Cargo.toml
@@ -44,6 +44,11 @@ anchor-spl = { version = "2.0.0-rc.1", features = ["metadata"] }
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"

--- a/tokens/external-delegate-token-master/anchor/programs/external-delegate-token-master/Cargo.toml
+++ b/tokens/external-delegate-token-master/anchor/programs/external-delegate-token-master/Cargo.toml
@@ -45,6 +45,11 @@ solana-secp256k1-recover = "2.0.0"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 # Signs test transfer authorizations with a fixed secp256k1 key so tests can
 # exercise the Ethereum-signature path end to end.

--- a/tokens/nft-minter/anchor/programs/nft-minter/Cargo.toml
+++ b/tokens/nft-minter/anchor/programs/nft-minter/Cargo.toml
@@ -43,6 +43,11 @@ anchor-spl = { version = "2.0.0-rc.1", features = ["metadata"] }
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"

--- a/tokens/nft-operations/anchor/programs/mint-nft/Cargo.toml
+++ b/tokens/nft-operations/anchor/programs/mint-nft/Cargo.toml
@@ -43,6 +43,11 @@ anchor-spl = { version = "2.0.0-rc.1", features = ["metadata"] }
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"

--- a/tokens/pda-mint-authority/anchor/programs/token-minter/Cargo.toml
+++ b/tokens/pda-mint-authority/anchor/programs/token-minter/Cargo.toml
@@ -46,6 +46,11 @@ solana-program-pack = "3"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"

--- a/tokens/token-extensions/basics/anchor/programs/basics/Cargo.toml
+++ b/tokens/token-extensions/basics/anchor/programs/basics/Cargo.toml
@@ -43,6 +43,11 @@ solana-address = ">=2.6, <2.7"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"

--- a/tokens/token-extensions/cpi-guard/anchor/programs/cpi-guard/Cargo.toml
+++ b/tokens/token-extensions/cpi-guard/anchor/programs/cpi-guard/Cargo.toml
@@ -43,6 +43,11 @@ anchor-spl = "2.0.0-rc.1"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"

--- a/tokens/token-extensions/default-account-state/anchor/programs/default-account-state/Cargo.toml
+++ b/tokens/token-extensions/default-account-state/anchor/programs/default-account-state/Cargo.toml
@@ -43,6 +43,11 @@ anchor-spl = "2.0.0-rc.1"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"

--- a/tokens/token-extensions/group/anchor/programs/group/Cargo.toml
+++ b/tokens/token-extensions/group/anchor/programs/group/Cargo.toml
@@ -43,6 +43,11 @@ anchor-spl = "2.0.0-rc.1"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"

--- a/tokens/token-extensions/immutable-owner/anchor/programs/immutable-owner/Cargo.toml
+++ b/tokens/token-extensions/immutable-owner/anchor/programs/immutable-owner/Cargo.toml
@@ -43,6 +43,11 @@ anchor-spl = "2.0.0-rc.1"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"

--- a/tokens/token-extensions/interest-bearing/anchor/programs/interest-bearing/Cargo.toml
+++ b/tokens/token-extensions/interest-bearing/anchor/programs/interest-bearing/Cargo.toml
@@ -44,6 +44,11 @@ anchor-spl = "2.0.0-rc.1"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"

--- a/tokens/token-extensions/memo-transfer/anchor/programs/memo-transfer/Cargo.toml
+++ b/tokens/token-extensions/memo-transfer/anchor/programs/memo-transfer/Cargo.toml
@@ -43,6 +43,11 @@ anchor-spl = "2.0.0-rc.1"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"

--- a/tokens/token-extensions/metadata/anchor/programs/metadata/Cargo.toml
+++ b/tokens/token-extensions/metadata/anchor/programs/metadata/Cargo.toml
@@ -45,6 +45,11 @@ spl-type-length-value = "0.9.1"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"

--- a/tokens/token-extensions/mint-close-authority/anchor/programs/mint-close-authority/Cargo.toml
+++ b/tokens/token-extensions/mint-close-authority/anchor/programs/mint-close-authority/Cargo.toml
@@ -40,6 +40,11 @@ anchor-spl = "2.0.0-rc.1"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"

--- a/tokens/token-extensions/nft-meta-data-pointer/anchor-example/anchor/programs/extension_nft/Cargo.toml
+++ b/tokens/token-extensions/nft-meta-data-pointer/anchor-example/anchor/programs/extension_nft/Cargo.toml
@@ -58,6 +58,11 @@ anchor-spl = { version = "2.0.0-rc.1" }
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 # Test-side decode of the player account's borsh payload.
 borsh = "1.6.1"

--- a/tokens/token-extensions/non-transferable/anchor/programs/non-transferable/Cargo.toml
+++ b/tokens/token-extensions/non-transferable/anchor/programs/non-transferable/Cargo.toml
@@ -40,6 +40,11 @@ anchor-spl = "2.0.0-rc.1"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"

--- a/tokens/token-extensions/permanent-delegate/anchor/programs/permanent-delegate/Cargo.toml
+++ b/tokens/token-extensions/permanent-delegate/anchor/programs/permanent-delegate/Cargo.toml
@@ -44,6 +44,11 @@ anchor-spl = "2.0.0-rc.1"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"

--- a/tokens/token-extensions/transfer-fee/anchor/programs/transfer-fee/Cargo.toml
+++ b/tokens/token-extensions/transfer-fee/anchor/programs/transfer-fee/Cargo.toml
@@ -40,6 +40,11 @@ anchor-spl = "2.0.0-rc.1"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"

--- a/tokens/token-extensions/transfer-hook/account-data-as-seed/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/account-data-as-seed/anchor/programs/transfer-hook/Cargo.toml
@@ -54,6 +54,11 @@ spl-transfer-hook-interface = "0.9.0"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"

--- a/tokens/token-extensions/transfer-hook/allow-block-list-token/anchor/programs/abl-token/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/allow-block-list-token/anchor/programs/abl-token/Cargo.toml
@@ -55,6 +55,11 @@ spl-discriminator = "0.5.1"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"

--- a/tokens/token-extensions/transfer-hook/counter/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/counter/anchor/programs/transfer-hook/Cargo.toml
@@ -54,6 +54,11 @@ spl-transfer-hook-interface = "0.9.0"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"

--- a/tokens/token-extensions/transfer-hook/hello-world/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/hello-world/anchor/programs/transfer-hook/Cargo.toml
@@ -54,6 +54,11 @@ spl-transfer-hook-interface = "0.9.0"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"

--- a/tokens/token-extensions/transfer-hook/transfer-cost/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/transfer-cost/anchor/programs/transfer-hook/Cargo.toml
@@ -55,6 +55,11 @@ spl-transfer-hook-interface = "2.1.0"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"

--- a/tokens/token-extensions/transfer-hook/transfer-switch/anchor/programs/transfer-switch/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/transfer-switch/anchor/programs/transfer-switch/Cargo.toml
@@ -50,6 +50,11 @@ spl-transfer-hook-interface = "0.9.0"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"

--- a/tokens/token-extensions/transfer-hook/whitelist/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-extensions/transfer-hook/whitelist/anchor/programs/transfer-hook/Cargo.toml
@@ -54,6 +54,11 @@ spl-transfer-hook-interface = "0.9.0"
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"

--- a/tokens/token-minter/anchor/programs/token-minter/Cargo.toml
+++ b/tokens/token-minter/anchor/programs/token-minter/Cargo.toml
@@ -43,6 +43,11 @@ anchor-spl = { version = "2.0.0-rc.1", features = ["metadata"] }
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"

--- a/tokens/transfer-tokens/anchor/programs/transfer-tokens/Cargo.toml
+++ b/tokens/transfer-tokens/anchor/programs/transfer-tokens/Cargo.toml
@@ -43,6 +43,11 @@ anchor-spl = { version = "2.0.0-rc.1", features = ["metadata"] }
 # Published only from git: crates.io has no `anchor-v2-testing`. Pinned to a
 # revision rather than tracking `anchor-next`, so a CI run cannot change
 # behaviour because upstream moved between builds.
+#
+# Bump the rev deliberately, never automatically: `anchor-next` is where v2
+# development happens, so a later revision can carry breakage as easily as
+# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
+# an ordinary version.
 anchor-v2-testing = { git = "https://github.com/otter-sec/anchor.git", rev = "3e38a121b969d1a77230baeb0056baf5cc9b3c1a" }
 solana-kite = "0.4.0"
 borsh = "1.6.1"


### PR DESCRIPTION
The comment beside the pinned `anchor-v2-testing` revision explained why it is pinned but named nothing that should ever cause it to change. The `--no-idl` workaround a few lines away points at `anchor#4947` as its removal trigger; this one pointed at nothing, so a reader six months from now had no way to tell whether the revision was still the right one, or what would make it wrong.

The added lines say:

```toml
# Bump the rev deliberately, never automatically: `anchor-next` is where v2
# development happens, so a later revision can carry breakage as easily as
# fixes. When `anchor-v2-testing` reaches crates.io, drop the git source for
# an ordinary version.
```

Applied to all 56 manifests carrying the dependency. Comments only: no dependency, version or code changes, so nothing to verify beyond CI.

Two details behind the wording, in case they are worth arguing with:

**"deliberately, never automatically"** rather than "keep it current". `anchor-next` is the active v2 development branch, not a release branch. A newer revision is not automatically a better one, and this repository has no signal that would catch a regression in it beyond CI going red.

**"drop the git source"** is the real end state. The pin exists only because crates.io has no `anchor-v2-testing`. Once it is published, none of this applies and an ordinary version requirement replaces the whole block.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbvFm2C5HPuktkz5yi1Kxu)_