### PR TITLE
docs: list Anchor v1 alongside Anchor v2 in the README example index

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The programs are examples of common financial primitives on Solana. As well as t
 
 **Start here - the best first finance program to learn on Solana.** A neutral account that holds funds until both sides deliver, like a real-estate escrow or a lawyer's trust account. The maker deposits token A and names how much token B they want; when a taker supplies token B, the program swaps both in a single all-or-nothing transaction. This swap is the core idea behind every onchain exchange.
 
-[⚓ Anchor](./finance/escrow/anchor) [💫 Quasar](./finance/escrow/quasar) [🦀 Native](./finance/escrow/native)
+[⚓ Anchor v2](./finance/escrow/anchor) [⚓ Anchor v1](./finance/escrow/anchor-v1) [💫 Quasar](./finance/escrow/quasar) [🦀 Native](./finance/escrow/native)
 
 🎬 Video: [Build a Solana program (smart contract) in 30 minutes](https://www.youtube.com/watch?v=B5eBWWQfQuM)
 
@@ -42,13 +42,13 @@ The programs are examples of common financial primitives on Solana. As well as t
 
 A borrow/lend market like Solend or Kamino: suppliers deposit a token and receive share tokens whose exchange rate rises as borrowers pay interest, borrowers post those shares as collateral to draw a different token against it up to a loan-to-value limit, and liquidators close part of any position that crosses its health threshold. Interest accrues through a utilization-based rate curve and a cumulative index, so no per-account accrual loop is needed.
 
-[⚓ Anchor](./finance/lending/anchor) [💫 Quasar](./finance/lending/quasar)
+[⚓ Anchor v2](./finance/lending/anchor) [⚓ Anchor v1](./finance/lending/anchor-v1) [💫 Quasar](./finance/lending/quasar)
 
 ### Order Book based Exchange
 
 A typical NYSE/NASDAQ-style order book-based exchange. Buyers post **bids** (the price they'll pay), sellers post **asks** (the price they'll accept), and a trade happens when a bid and an ask meet. The exchange operator collects fees from trading. Similar to popular Solana exchanges like Openbook and Phoenix.
 
-[⚓ Anchor](./finance/order-book/anchor) [💫 Quasar](./finance/order-book/quasar)
+[⚓ Anchor v2](./finance/order-book/anchor) [⚓ Anchor v1](./finance/order-book/anchor-v1) [💫 Quasar](./finance/order-book/quasar)
 
 🎬 Video: [How to make a crypto exchange on Solana](https://www.youtube.com/watch?v=ioFkpaKHXgg)
 
@@ -56,25 +56,25 @@ A typical NYSE/NASDAQ-style order book-based exchange. Buyers post **bids** (the
 
 An exchange with no order book: swaps fill instantly against a shared liquidity pool funded by **liquidity providers**, who earn a cut of the trading fees. Prices are set algorithmically by the pool's balances. Anyone can create a pool, add or remove liquidity, and swap tokens, with slippage protection on every trade. Similar to Solana exchanges like Raydium and Orca.
 
-[⚓ Anchor](./finance/token-swap/anchor) [💫 Quasar](./finance/token-swap/quasar)
+[⚓ Anchor v2](./finance/token-swap/anchor) [⚓ Anchor v1](./finance/token-swap/anchor-v1) [💫 Quasar](./finance/token-swap/quasar)
 
 ### Prop AMM
 
 A **proprietary AMM**: a market-making firm funds a venue with its own capital and quotes both sides of it, selling the base token at the oracle price plus a spread and buying it back at the oracle price minus the spread. No pricing curve, no liquidity providers, no pool shares: the operator is the only capital in the market, can re-quote or pull its quotes at will, and earns the spread instead of a fee. Because the price comes from an oracle rather than the pool's balances, trades have no price impact and nothing to sandwich. This is the design behind venues like Lifinity, SolFi, and HumidiFi, which fill most Solana swap volume through Jupiter routing.
 
-[⚓ Anchor](./finance/prop-amm/anchor) [💫 Quasar](./finance/prop-amm/quasar)
+[⚓ Anchor v2](./finance/prop-amm/anchor) [⚓ Anchor v1](./finance/prop-amm/anchor-v1) [💫 Quasar](./finance/prop-amm/quasar)
 
 ### Vault Strategy
 
 A managed investment fund onchain, like an ETF or mutual fund. Investors deposit USDC for shares, a manager allocates the pool across a basket of assets (here, stocks like TSLAx and NVDAx), and each share's value tracks the fund's net asset value. The manager earns a management fee, and investors redeem a proportional slice of the underlying assets.
 
-[⚓ Anchor](./finance/vault-strategy/anchor) [💫 Quasar](./finance/vault-strategy/quasar)
+[⚓ Anchor v2](./finance/vault-strategy/anchor) [⚓ Anchor v1](./finance/vault-strategy/anchor-v1) [💫 Quasar](./finance/vault-strategy/quasar)
 
 ### Betting Market
 
 Parimutuel (pooled) prediction market - an admin opens an event with multiple outcomes, bettors stake tokens on an outcome, and at settlement the losing pool (minus a protocol fee) is split among winners in proportion to their stake.
 
-[⚓ Anchor](./finance/betting-market/anchor) [💫 Quasar](./finance/betting-market/quasar)
+[⚓ Anchor v2](./finance/betting-market/anchor) [⚓ Anchor v1](./finance/betting-market/anchor-v1) [💫 Quasar](./finance/betting-market/quasar)
 
 🎬 Video: [How to build a PolyMarket/Kalshi style betting market on Solana](https://www.youtube.com/watch?v=jE3-IA1FBs0)
 
@@ -83,13 +83,13 @@ Parimutuel (pooled) prediction market - an admin opens an event with multiple ou
 
 A perpetual futures exchange: a venue for making leveraged bets on an asset's price without ever owning the asset. Traders post collateral and open a **long** (betting the price rises) or **short** (betting it falls) sized up to several times their collateral; their profit or loss tracks the price move and is paid in the collateral token. Rather than matching buyers to sellers, every trade is against a shared **liquidity pool** that other users fund and that is the counterparty to all of it: the pool pays winners and keeps losers' collateral, and its providers earn the trading and funding fees in return. The price comes from an oracle, positions accrue a funding fee over time, and anyone can **liquidate** a position whose collateral can no longer cover its loss. This is the design behind venues like Jupiter Perpetuals and GMX.
 
-[⚓ Anchor](./finance/perpetual-futures/anchor) [💫 Quasar](./finance/perpetual-futures/quasar)
+[⚓ Anchor v2](./finance/perpetual-futures/anchor) [⚓ Anchor v1](./finance/perpetual-futures/anchor-v1) [💫 Quasar](./finance/perpetual-futures/quasar)
 
 ### Token Fundraiser
 
 Onchain crowdfunding, like Kickstarter or GoFundMe. A creator sets a target amount in a chosen token, and contributors deposit into the fundraiser's account until the goal is reached.
 
-[⚓ Anchor](./finance/token-fundraiser/anchor) [💫 Quasar](./finance/token-fundraiser/quasar)
+[⚓ Anchor v2](./finance/token-fundraiser/anchor) [⚓ Anchor v1](./finance/token-fundraiser/anchor-v1) [💫 Quasar](./finance/token-fundraiser/quasar)
 
 ## Single concept examples
 
@@ -97,97 +97,97 @@ Onchain crowdfunding, like Kickstarter or GoFundMe. A creator sets a target amou
 
 A minimal program that logs a greeting.
 
-[⚓ Anchor](./basics/hello-solana/anchor) [💫 Quasar](./basics/hello-solana/quasar) [🤥 Pinocchio](./basics/hello-solana/pinocchio) [🦀 Native](./basics/hello-solana/native) [🧬 ASM](./basics/hello-solana/asm)
+[⚓ Anchor v2](./basics/hello-solana/anchor) [⚓ Anchor v1](./basics/hello-solana/anchor-v1) [💫 Quasar](./basics/hello-solana/quasar) [🤥 Pinocchio](./basics/hello-solana/pinocchio) [🦀 Native](./basics/hello-solana/native) [🧬 ASM](./basics/hello-solana/asm)
 
 ### Account Data
 
 Store and retrieve data using Solana accounts.
 
-[⚓ Anchor](./basics/account-data/anchor) [💫 Quasar](./basics/account-data/quasar) [🤥 Pinocchio](./basics/account-data/pinocchio) [🦀 Native](./basics/account-data/native)
+[⚓ Anchor v2](./basics/account-data/anchor) [⚓ Anchor v1](./basics/account-data/anchor-v1) [💫 Quasar](./basics/account-data/quasar) [🤥 Pinocchio](./basics/account-data/pinocchio) [🦀 Native](./basics/account-data/native)
 
 ### Counter
 
 Use a [PDA](https://solana.com/docs/terminology#program-derived-address-pda) to store global state - a counter that increments when called.
 
-[⚓ Anchor](./basics/counter/anchor) [💫 Quasar](./basics/counter/quasar) [🤥 Pinocchio](./basics/counter/pinocchio) [🦀 Native](./basics/counter/native)
+[⚓ Anchor v2](./basics/counter/anchor) [⚓ Anchor v1](./basics/counter/anchor-v1) [💫 Quasar](./basics/counter/quasar) [🤥 Pinocchio](./basics/counter/pinocchio) [🦀 Native](./basics/counter/native)
 
 ### Favorites
 
 Save and update per-user state, ensuring users can only modify their own data.
 
-[⚓ Anchor](./basics/favorites/anchor) [💫 Quasar](./basics/favorites/quasar) [🤥 Pinocchio](./basics/favorites/pinocchio) [🦀 Native](./basics/favorites/native)
+[⚓ Anchor v2](./basics/favorites/anchor) [⚓ Anchor v1](./basics/favorites/anchor-v1) [💫 Quasar](./basics/favorites/quasar) [🤥 Pinocchio](./basics/favorites/pinocchio) [🦀 Native](./basics/favorites/native)
 
 ### Checking Accounts
 
 Validate that accounts provided in incoming [instructions](https://solana.com/docs/terminology#instruction) meet specific criteria.
 
-[⚓ Anchor](./basics/checking-accounts/anchor) [💫 Quasar](./basics/checking-accounts/quasar) [🤥 Pinocchio](./basics/checking-accounts/pinocchio) [🦀 Native](./basics/checking-accounts/native) [🧬 ASM](./basics/checking-accounts/asm)
+[⚓ Anchor v2](./basics/checking-accounts/anchor) [⚓ Anchor v1](./basics/checking-accounts/anchor-v1) [💫 Quasar](./basics/checking-accounts/quasar) [🤥 Pinocchio](./basics/checking-accounts/pinocchio) [🦀 Native](./basics/checking-accounts/native) [🧬 ASM](./basics/checking-accounts/asm)
 
 ### Close Account
 
 Close an account and reclaim its [lamports](https://solana.com/docs/terminology#lamport).
 
-[⚓ Anchor](./basics/close-account/anchor) [💫 Quasar](./basics/close-account/quasar) [🤥 Pinocchio](./basics/close-account/pinocchio) [🦀 Native](./basics/close-account/native)
+[⚓ Anchor v2](./basics/close-account/anchor) [⚓ Anchor v1](./basics/close-account/anchor-v1) [💫 Quasar](./basics/close-account/quasar) [🤥 Pinocchio](./basics/close-account/pinocchio) [🦀 Native](./basics/close-account/native)
 
 ### Create Account
 
 Create new accounts on the blockchain.
 
-[⚓ Anchor](./basics/create-account/anchor) [💫 Quasar](./basics/create-account/quasar) [🤥 Pinocchio](./basics/create-account/pinocchio) [🦀 Native](./basics/create-account/native) [🧬 ASM](./basics/create-account/asm)
+[⚓ Anchor v2](./basics/create-account/anchor) [⚓ Anchor v1](./basics/create-account/anchor-v1) [💫 Quasar](./basics/create-account/quasar) [🤥 Pinocchio](./basics/create-account/pinocchio) [🦀 Native](./basics/create-account/native) [🧬 ASM](./basics/create-account/asm)
 
 ### Cross-Program Invocation
 
 Call one program from another - the hand program invokes the lever program to toggle a switch.
 
-[⚓ Anchor](./basics/cross-program-invocation/anchor) [💫 Quasar](./basics/cross-program-invocation/quasar) [🦀 Native](./basics/cross-program-invocation/native)
+[⚓ Anchor v2](./basics/cross-program-invocation/anchor) [⚓ Anchor v1](./basics/cross-program-invocation/anchor-v1) [💫 Quasar](./basics/cross-program-invocation/quasar) [🦀 Native](./basics/cross-program-invocation/native)
 
 ### PDA Rent Payer
 
 Use a PDA to pay [rent](https://solana.com/docs/terminology#rent) for creating a new account.
 
-[⚓ Anchor](./basics/pda-rent-payer/anchor) [💫 Quasar](./basics/pda-rent-payer/quasar) [🤥 Pinocchio](./basics/pda-rent-payer/pinocchio) [🦀 Native](./basics/pda-rent-payer/native)
+[⚓ Anchor v2](./basics/pda-rent-payer/anchor) [⚓ Anchor v1](./basics/pda-rent-payer/anchor-v1) [💫 Quasar](./basics/pda-rent-payer/quasar) [🤥 Pinocchio](./basics/pda-rent-payer/pinocchio) [🦀 Native](./basics/pda-rent-payer/native)
 
 ### Processing Instructions
 
 Add parameters to an [instruction handler](https://solana.com/docs/terminology#instruction-handler) and use them.
 
-[⚓ Anchor](./basics/processing-instructions/anchor) [💫 Quasar](./basics/processing-instructions/quasar) [🤥 Pinocchio](./basics/processing-instructions/pinocchio) [🦀 Native](./basics/processing-instructions/native)
+[⚓ Anchor v2](./basics/processing-instructions/anchor) [⚓ Anchor v1](./basics/processing-instructions/anchor-v1) [💫 Quasar](./basics/processing-instructions/quasar) [🤥 Pinocchio](./basics/processing-instructions/pinocchio) [🦀 Native](./basics/processing-instructions/native)
 
 ### Program Derived Addresses
 
 Store and retrieve state using PDAs as deterministic account addresses.
 
-[⚓ Anchor](./basics/program-derived-addresses/anchor) [💫 Quasar](./basics/program-derived-addresses/quasar) [🤥 Pinocchio](./basics/program-derived-addresses/pinocchio) [🦀 Native](./basics/program-derived-addresses/native)
+[⚓ Anchor v2](./basics/program-derived-addresses/anchor) [⚓ Anchor v1](./basics/program-derived-addresses/anchor-v1) [💫 Quasar](./basics/program-derived-addresses/quasar) [🤥 Pinocchio](./basics/program-derived-addresses/pinocchio) [🦀 Native](./basics/program-derived-addresses/native)
 
 ### Realloc
 
 Handle accounts that need to grow or shrink in size.
 
-[⚓ Anchor](./basics/realloc/anchor) [💫 Quasar](./basics/realloc/quasar) [🤥 Pinocchio](./basics/realloc/pinocchio) [🦀 Native](./basics/realloc/native)
+[⚓ Anchor v2](./basics/realloc/anchor) [⚓ Anchor v1](./basics/realloc/anchor-v1) [💫 Quasar](./basics/realloc/quasar) [🤥 Pinocchio](./basics/realloc/pinocchio) [🦀 Native](./basics/realloc/native)
 
 ### Rent
 
 Calculate an account's size to determine the minimum rent-exempt balance.
 
-[⚓ Anchor](./basics/rent/anchor) [💫 Quasar](./basics/rent/quasar) [🤥 Pinocchio](./basics/rent/pinocchio) [🦀 Native](./basics/rent/native)
+[⚓ Anchor v2](./basics/rent/anchor) [⚓ Anchor v1](./basics/rent/anchor-v1) [💫 Quasar](./basics/rent/quasar) [🤥 Pinocchio](./basics/rent/pinocchio) [🦀 Native](./basics/rent/native)
 
 ### Repository Layout
 
 Structure a larger Solana program across multiple files and modules.
 
-[⚓ Anchor](./basics/repository-layout/anchor) [💫 Quasar](./basics/repository-layout/quasar) [🦀 Native](./basics/repository-layout/native)
+[⚓ Anchor v2](./basics/repository-layout/anchor) [⚓ Anchor v1](./basics/repository-layout/anchor-v1) [💫 Quasar](./basics/repository-layout/quasar) [🦀 Native](./basics/repository-layout/native)
 
 ### Transfer SOL
 
 Send SOL between two accounts.
 
-[⚓ Anchor](./basics/transfer-sol/anchor) [💫 Quasar](./basics/transfer-sol/quasar) [🤥 Pinocchio](./basics/transfer-sol/pinocchio) [🦀 Native](./basics/transfer-sol/native) [🧬 ASM](./basics/transfer-sol/asm)
+[⚓ Anchor v2](./basics/transfer-sol/anchor) [⚓ Anchor v1](./basics/transfer-sol/anchor-v1) [💫 Quasar](./basics/transfer-sol/quasar) [🤥 Pinocchio](./basics/transfer-sol/pinocchio) [🦀 Native](./basics/transfer-sol/native) [🧬 ASM](./basics/transfer-sol/asm)
 
 ### Pyth Price Feeds
 
 An **oracle** brings real-world market prices - a dollar, a stock, a token - [onchain](https://solana.com/docs/terminology#onchain), like a Bloomberg terminal feeding live quotes. [Pyth](https://pyth.network/) publishes low-latency prices from institutional sources, each in its own price feed account. This example reads a feed and logs its price, confidence interval, and exponent - the building block an AMM, lending market, or vault uses to value assets.
 
-[⚓ Anchor](./basics/pyth/anchor) [💫 Quasar](./basics/pyth/quasar)
+[⚓ Anchor v2](./basics/pyth/anchor) [⚓ Anchor v1](./basics/pyth/anchor-v1) [💫 Quasar](./basics/pyth/quasar)
 
 ## Tokens
 
@@ -195,43 +195,43 @@ An **oracle** brings real-world market prices - a dollar, a stock, a token - [on
 
 Create a token mint with a symbol and icon.
 
-[⚓ Anchor](./tokens/create-token/anchor) [💫 Quasar](./tokens/create-token/quasar) [🦀 Native](./tokens/create-token/native)
+[⚓ Anchor v2](./tokens/create-token/anchor) [⚓ Anchor v1](./tokens/create-token/anchor-v1) [💫 Quasar](./tokens/create-token/quasar) [🦀 Native](./tokens/create-token/native)
 
 ### Mint NFT
 
 Mint an NFT from inside your own program using the Token and Metaplex Token Metadata programs.
 
-[⚓ Anchor](./tokens/nft-minter/anchor) [💫 Quasar](./tokens/nft-minter/quasar) [🦀 Native](./tokens/nft-minter/native)
+[⚓ Anchor v2](./tokens/nft-minter/anchor) [⚓ Anchor v1](./tokens/nft-minter/anchor-v1) [💫 Quasar](./tokens/nft-minter/quasar) [🦀 Native](./tokens/nft-minter/native)
 
 ### NFT Operations
 
 Create an NFT collection, mint NFTs, and verify NFTs as part of a collection using Metaplex Token Metadata.
 
-[⚓ Anchor](./tokens/nft-operations/anchor) [💫 Quasar](./tokens/nft-operations/quasar)
+[⚓ Anchor v2](./tokens/nft-operations/anchor) [⚓ Anchor v1](./tokens/nft-operations/anchor-v1) [💫 Quasar](./tokens/nft-operations/quasar)
 
 ### Token Minter
 
 Mint tokens from inside your own program using the [Classic Token Program](https://solana.com/docs/terminology#token-program).
 
-[⚓ Anchor](./tokens/token-minter/anchor) [💫 Quasar](./tokens/token-minter/quasar) [🦀 Native](./tokens/token-minter/native)
+[⚓ Anchor v2](./tokens/token-minter/anchor) [⚓ Anchor v1](./tokens/token-minter/anchor-v1) [💫 Quasar](./tokens/token-minter/quasar) [🦀 Native](./tokens/token-minter/native)
 
 ### Transfer Tokens
 
 Transfer tokens between accounts.
 
-[⚓ Anchor](./tokens/transfer-tokens/anchor) [💫 Quasar](./tokens/transfer-tokens/quasar) [🦀 Native](./tokens/transfer-tokens/native)
+[⚓ Anchor v2](./tokens/transfer-tokens/anchor) [⚓ Anchor v1](./tokens/transfer-tokens/anchor-v1) [💫 Quasar](./tokens/transfer-tokens/quasar) [🦀 Native](./tokens/transfer-tokens/native)
 
 ### PDA Mint Authority
 
 Mint tokens using a PDA as the mint authority, so your program controls token issuance.
 
-[⚓ Anchor](./tokens/pda-mint-authority/anchor) [💫 Quasar](./tokens/pda-mint-authority/quasar) [🦀 Native](./tokens/pda-mint-authority/native)
+[⚓ Anchor v2](./tokens/pda-mint-authority/anchor) [⚓ Anchor v1](./tokens/pda-mint-authority/anchor-v1) [💫 Quasar](./tokens/pda-mint-authority/quasar) [🦀 Native](./tokens/pda-mint-authority/native)
 
 ### External Delegate Token Master
 
 Control token transfers using an external secp256k1 delegate signature.
 
-[⚓ Anchor](./tokens/external-delegate-token-master/anchor) [💫 Quasar](./tokens/external-delegate-token-master/quasar)
+[⚓ Anchor v2](./tokens/external-delegate-token-master/anchor) [⚓ Anchor v1](./tokens/external-delegate-token-master/anchor-v1) [💫 Quasar](./tokens/external-delegate-token-master/quasar)
 
 ## Token Extensions
 
@@ -239,61 +239,61 @@ Control token transfers using an external secp256k1 delegate signature.
 
 Create token mints, mint tokens, and transfer tokens using [Token Extensions](https://solana.com/docs/terminology#token-extensions-program).
 
-[⚓ Anchor](./tokens/token-extensions/basics/anchor) [💫 Quasar](./tokens/token-extensions/basics/quasar)
+[⚓ Anchor v2](./tokens/token-extensions/basics/anchor) [⚓ Anchor v1](./tokens/token-extensions/basics/anchor-v1) [💫 Quasar](./tokens/token-extensions/basics/quasar)
 
 ### CPI Guard
 
 Prevent certain token actions from occurring within [cross-program invocations](https://solana.com/docs/terminology#cross-program-invocation-cpi).
 
-[⚓ Anchor](./tokens/token-extensions/cpi-guard/anchor) [💫 Quasar](./tokens/token-extensions/cpi-guard/quasar)
+[⚓ Anchor v2](./tokens/token-extensions/cpi-guard/anchor) [⚓ Anchor v1](./tokens/token-extensions/cpi-guard/anchor-v1) [💫 Quasar](./tokens/token-extensions/cpi-guard/quasar)
 
 ### Default Account State
 
 Create new [token accounts](https://solana.com/docs/terminology#token-account) that are frozen by default.
 
-[⚓ Anchor](./tokens/token-extensions/default-account-state/anchor) [💫 Quasar](./tokens/token-extensions/default-account-state/quasar) [🦀 Native](./tokens/token-extensions/default-account-state/native)
+[⚓ Anchor v2](./tokens/token-extensions/default-account-state/anchor) [⚓ Anchor v1](./tokens/token-extensions/default-account-state/anchor-v1) [💫 Quasar](./tokens/token-extensions/default-account-state/quasar) [🦀 Native](./tokens/token-extensions/default-account-state/native)
 
 ### Group Pointer
 
 Create tokens that belong to larger groups using the Group Pointer extension.
 
-[⚓ Anchor](./tokens/token-extensions/group/anchor) [💫 Quasar](./tokens/token-extensions/group/quasar)
+[⚓ Anchor v2](./tokens/token-extensions/group/anchor) [⚓ Anchor v1](./tokens/token-extensions/group/anchor-v1) [💫 Quasar](./tokens/token-extensions/group/quasar)
 
 ### Immutable Owner
 
 Create token accounts whose owning program cannot be changed.
 
-[⚓ Anchor](./tokens/token-extensions/immutable-owner/anchor) [💫 Quasar](./tokens/token-extensions/immutable-owner/quasar)
+[⚓ Anchor v2](./tokens/token-extensions/immutable-owner/anchor) [⚓ Anchor v1](./tokens/token-extensions/immutable-owner/anchor-v1) [💫 Quasar](./tokens/token-extensions/immutable-owner/quasar)
 
 ### Interest Bearing Tokens
 
 Create tokens that show an interest calculation, updating their displayed balance over time.
 
-[⚓ Anchor](./tokens/token-extensions/interest-bearing/anchor) [💫 Quasar](./tokens/token-extensions/interest-bearing/quasar)
+[⚓ Anchor v2](./tokens/token-extensions/interest-bearing/anchor) [⚓ Anchor v1](./tokens/token-extensions/interest-bearing/anchor-v1) [💫 Quasar](./tokens/token-extensions/interest-bearing/quasar)
 
 ### Memo Transfer
 
 Require all transfers to include a descriptive memo.
 
-[⚓ Anchor](./tokens/token-extensions/memo-transfer/anchor) [💫 Quasar](./tokens/token-extensions/memo-transfer/quasar)
+[⚓ Anchor v2](./tokens/token-extensions/memo-transfer/anchor) [⚓ Anchor v1](./tokens/token-extensions/memo-transfer/anchor-v1) [💫 Quasar](./tokens/token-extensions/memo-transfer/quasar)
 
 ### Onchain Metadata
 
 Store metadata directly inside the token [mint account](https://solana.com/docs/terminology#token-mint), without needing additional programs.
 
-[⚓ Anchor](./tokens/token-extensions/metadata/anchor)
+[⚓ Anchor v2](./tokens/token-extensions/metadata/anchor) [⚓ Anchor v1](./tokens/token-extensions/metadata/anchor-v1)
 
 ### NFT Metadata Pointer
 
 Create an NFT using the metadata pointer extension, storing onchain metadata (including custom fields) inside the mint.
 
-[⚓ Anchor](./tokens/token-extensions/nft-meta-data-pointer/anchor-example/anchor)
+[⚓ Anchor v2](./tokens/token-extensions/nft-meta-data-pointer/anchor-example/anchor) [⚓ Anchor v1](./tokens/token-extensions/nft-meta-data-pointer/anchor-example/anchor-v1)
 
 ### Mint Close Authority
 
 Allow a designated account to close a token mint.
 
-[⚓ Anchor](./tokens/token-extensions/mint-close-authority/anchor) [💫 Quasar](./tokens/token-extensions/mint-close-authority/quasar) [🦀 Native](./tokens/token-extensions/mint-close-authority/native)
+[⚓ Anchor v2](./tokens/token-extensions/mint-close-authority/anchor) [⚓ Anchor v1](./tokens/token-extensions/mint-close-authority/anchor-v1) [💫 Quasar](./tokens/token-extensions/mint-close-authority/quasar) [🦀 Native](./tokens/token-extensions/mint-close-authority/native)
 
 ### Multiple Extensions
 
@@ -305,61 +305,61 @@ Use multiple Token Extensions on a single mint at once.
 
 Create tokens that cannot be transferred between accounts.
 
-[⚓ Anchor](./tokens/token-extensions/non-transferable/anchor) [💫 Quasar](./tokens/token-extensions/non-transferable/quasar) [🦀 Native](./tokens/token-extensions/non-transferable/native)
+[⚓ Anchor v2](./tokens/token-extensions/non-transferable/anchor) [⚓ Anchor v1](./tokens/token-extensions/non-transferable/anchor-v1) [💫 Quasar](./tokens/token-extensions/non-transferable/quasar) [🦀 Native](./tokens/token-extensions/non-transferable/native)
 
 ### Permanent Delegate
 
 Create tokens that remain under the control of a designated account, even when transferred elsewhere.
 
-[⚓ Anchor](./tokens/token-extensions/permanent-delegate/anchor) [💫 Quasar](./tokens/token-extensions/permanent-delegate/quasar)
+[⚓ Anchor v2](./tokens/token-extensions/permanent-delegate/anchor) [⚓ Anchor v1](./tokens/token-extensions/permanent-delegate/anchor-v1) [💫 Quasar](./tokens/token-extensions/permanent-delegate/quasar)
 
 ### Transfer Fee
 
 Create tokens with a built-in transfer fee.
 
-[⚓ Anchor](./tokens/token-extensions/transfer-fee/anchor) [💫 Quasar](./tokens/token-extensions/transfer-fee/quasar) [🦀 Native](./tokens/token-extensions/transfer-fee/native)
+[⚓ Anchor v2](./tokens/token-extensions/transfer-fee/anchor) [⚓ Anchor v1](./tokens/token-extensions/transfer-fee/anchor-v1) [💫 Quasar](./tokens/token-extensions/transfer-fee/quasar) [🦀 Native](./tokens/token-extensions/transfer-fee/native)
 
 ### Transfer Hook - Hello World
 
 A minimal transfer hook that executes custom logic on every token transfer.
 
-[⚓ Anchor](./tokens/token-extensions/transfer-hook/hello-world/anchor) [💫 Quasar](./tokens/token-extensions/transfer-hook/hello-world/quasar)
+[⚓ Anchor v2](./tokens/token-extensions/transfer-hook/hello-world/anchor) [⚓ Anchor v1](./tokens/token-extensions/transfer-hook/hello-world/anchor-v1) [💫 Quasar](./tokens/token-extensions/transfer-hook/hello-world/quasar)
 
 ### Transfer Hook - Counter
 
 Count how many times tokens have been transferred.
 
-[⚓ Anchor](./tokens/token-extensions/transfer-hook/counter/anchor) [💫 Quasar](./tokens/token-extensions/transfer-hook/counter/quasar)
+[⚓ Anchor v2](./tokens/token-extensions/transfer-hook/counter/anchor) [⚓ Anchor v1](./tokens/token-extensions/transfer-hook/counter/anchor-v1) [💫 Quasar](./tokens/token-extensions/transfer-hook/counter/quasar)
 
 ### Transfer Hook - Account Data as Seed
 
 Use token account owner data as seeds to derive extra accounts in a transfer hook.
 
-[⚓ Anchor](./tokens/token-extensions/transfer-hook/account-data-as-seed/anchor) [💫 Quasar](./tokens/token-extensions/transfer-hook/account-data-as-seed/quasar)
+[⚓ Anchor v2](./tokens/token-extensions/transfer-hook/account-data-as-seed/anchor) [⚓ Anchor v1](./tokens/token-extensions/transfer-hook/account-data-as-seed/anchor-v1) [💫 Quasar](./tokens/token-extensions/transfer-hook/account-data-as-seed/quasar)
 
 ### Transfer Hook - Allow/Block List
 
 Restrict or allow token transfers using an onchain list managed by a list authority.
 
-[⚓ Anchor](./tokens/token-extensions/transfer-hook/allow-block-list-token/anchor) [💫 Quasar](./tokens/token-extensions/transfer-hook/allow-block-list-token/quasar)
+[⚓ Anchor v2](./tokens/token-extensions/transfer-hook/allow-block-list-token/anchor) [⚓ Anchor v1](./tokens/token-extensions/transfer-hook/allow-block-list-token/anchor-v1) [💫 Quasar](./tokens/token-extensions/transfer-hook/allow-block-list-token/quasar)
 
 ### Transfer Hook - Transfer Cost
 
 Charge an additional fee on every token transfer.
 
-[⚓ Anchor](./tokens/token-extensions/transfer-hook/transfer-cost/anchor) [💫 Quasar](./tokens/token-extensions/transfer-hook/transfer-cost/quasar)
+[⚓ Anchor v2](./tokens/token-extensions/transfer-hook/transfer-cost/anchor) [⚓ Anchor v1](./tokens/token-extensions/transfer-hook/transfer-cost/anchor-v1) [💫 Quasar](./tokens/token-extensions/transfer-hook/transfer-cost/quasar)
 
 ### Transfer Hook - Transfer Switch
 
 Enable or disable token transfers with an onchain switch.
 
-[⚓ Anchor](./tokens/token-extensions/transfer-hook/transfer-switch/anchor) [💫 Quasar](./tokens/token-extensions/transfer-hook/transfer-switch/quasar)
+[⚓ Anchor v2](./tokens/token-extensions/transfer-hook/transfer-switch/anchor) [⚓ Anchor v1](./tokens/token-extensions/transfer-hook/transfer-switch/anchor-v1) [💫 Quasar](./tokens/token-extensions/transfer-hook/transfer-switch/quasar)
 
 ### Transfer Hook - Whitelist
 
 Restrict transfers so only whitelisted accounts can receive tokens.
 
-[⚓ Anchor](./tokens/token-extensions/transfer-hook/whitelist/anchor) [💫 Quasar](./tokens/token-extensions/transfer-hook/whitelist/quasar)
+[⚓ Anchor v2](./tokens/token-extensions/transfer-hook/whitelist/anchor) [⚓ Anchor v1](./tokens/token-extensions/transfer-hook/whitelist/anchor-v1) [💫 Quasar](./tokens/token-extensions/transfer-hook/whitelist/quasar)
 
 ## Compression
 
@@ -367,19 +367,19 @@ Restrict transfers so only whitelisted accounts can receive tokens.
 
 Burn compressed NFTs.
 
-[⚓ Anchor](./compression/cnft-burn/anchor) [💫 Quasar](./compression/cnft-burn/quasar)
+[⚓ Anchor v2](./compression/cnft-burn/anchor) [⚓ Anchor v1](./compression/cnft-burn/anchor-v1) [💫 Quasar](./compression/cnft-burn/quasar)
 
 ### cNFT Vault
 
 Store Metaplex compressed NFTs inside a PDA.
 
-[⚓ Anchor](./compression/cnft-vault/anchor) [💫 Quasar](./compression/cnft-vault/quasar)
+[⚓ Anchor v2](./compression/cnft-vault/anchor) [⚓ Anchor v1](./compression/cnft-vault/anchor-v1) [💫 Quasar](./compression/cnft-vault/quasar)
 
 ### Compression Utilities
 
 Work with Metaplex compressed NFTs.
 
-[⚓ Anchor](./compression/cutils/anchor) [💫 Quasar](./compression/cutils/quasar)
+[⚓ Anchor v2](./compression/cutils/anchor) [⚓ Anchor v1](./compression/cutils/anchor-v1) [💫 Quasar](./compression/cutils/quasar)
 
 ## Tools
 


### PR DESCRIPTION
Follow-up to #135, which is merged. This is the one piece that did not make it in.

## The problem

#135 renamed the README framework list to define **Anchor v2** (`anchor/`) and
**Anchor v1** (`anchor-v1/`), but left all 55 per-example rows below reading a bare
`⚓ Anchor`, pointing only at the v2 copy. So `main` currently introduces two named
Anchor frameworks and then indexes one of them — and there is no route from the index
to any `anchor-v1/` directory except guessing the path.

## The change

Every example row now carries both:

```
[⚓ Anchor v2](./finance/escrow/anchor) [⚓ Anchor v1](./finance/escrow/anchor-v1) [💫 Quasar](./finance/escrow/quasar) [🦀 Native](./finance/escrow/native)
```

README-only: 55 rows changed, nothing else in the tree.

## Verification

- 55 `⚓ Anchor v2` links and 55 `⚓ Anchor v1` links; no bare `⚓ Anchor` remains
- all 55 examples have both directories, so no row is half-populated
- every relative link in `README.md` resolves on disk
- `git diff --stat main..` is `README.md` alone

## Why this is a separate PR

The commit was originally pushed to the #135 branch a minute after that PR merged, so
it landed on a closed PR and never reached `main` — the exact trap
[CLAUDE.md](../blob/main/CLAUDE.md) documents under "A merged PR's branch is dead". The
branch has been restarted from current `main` with the commit cherry-picked on top, so
this PR contains only the README change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMDApPWRHM1StJwtyDSrEM

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMDApPWRHM1StJwtyDSrEM)_