### PR TITLE
Stop main's CI runs cancelling each other

### DIFF
--- a/.github/workflows/anchor-v1.yml
+++ b/.github/workflows/anchor-v1.yml
@@ -199,22 +199,8 @@ jobs:
         with:
           node-version: lts/*
       - name: Install Solana CLI
-        # The installer downloads a release tarball from release.anza.xyz; a
-        # truncated download makes it fail with "failed to iterate over
-        # archive". Retry from scratch a few times before giving up.
         run: |
-          for attempt in 1 2 3 4 5; do
-            rm -rf "$HOME/.local/share/solana/install"
-            if sh -c "$(curl -sSfL https://release.anza.xyz/v3.1.14/install)"; then
-              break
-            fi
-            if [ "$attempt" = 5 ]; then
-              echo "Solana CLI install failed after $attempt attempts"
-              exit 1
-            fi
-            echo "Solana CLI install attempt $attempt failed; retrying in $((attempt * 15))s"
-            sleep $((attempt * 15))
-          done
+          sh -c "$(curl -sSfL https://release.anza.xyz/v3.1.14/install)"
           echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
       - name: Cache Anchor toolchain
         uses: actions/cache@v4

--- a/.github/workflows/anchor-v1.yml
+++ b/.github/workflows/anchor-v1.yml
@@ -20,7 +20,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Superseded runs on a pull request branch are cancelled. Runs on main are
+  # not: a later push whose change detection skips the build (a docs-only
+  # merge) would otherwise cancel the run verifying the previous merge and
+  # leave main with no verdict.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   MAX_JOBS: 64
@@ -195,8 +199,22 @@ jobs:
         with:
           node-version: lts/*
       - name: Install Solana CLI
+        # The installer downloads a release tarball from release.anza.xyz; a
+        # truncated download makes it fail with "failed to iterate over
+        # archive". Retry from scratch a few times before giving up.
         run: |
-          sh -c "$(curl -sSfL https://release.anza.xyz/v3.1.14/install)"
+          for attempt in 1 2 3 4 5; do
+            rm -rf "$HOME/.local/share/solana/install"
+            if sh -c "$(curl -sSfL https://release.anza.xyz/v3.1.14/install)"; then
+              break
+            fi
+            if [ "$attempt" = 5 ]; then
+              echo "Solana CLI install failed after $attempt attempts"
+              exit 1
+            fi
+            echo "Solana CLI install attempt $attempt failed; retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
           echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
       - name: Cache Anchor toolchain
         uses: actions/cache@v4

--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -200,22 +200,8 @@ jobs:
         with:
           node-version: lts/*
       - name: Install Solana CLI
-        # The installer downloads a release tarball from release.anza.xyz; a
-        # truncated download makes it fail with "failed to iterate over
-        # archive". Retry from scratch a few times before giving up.
         run: |
-          for attempt in 1 2 3 4 5; do
-            rm -rf "$HOME/.local/share/solana/install"
-            if sh -c "$(curl -sSfL https://release.anza.xyz/v3.1.14/install)"; then
-              break
-            fi
-            if [ "$attempt" = 5 ]; then
-              echo "Solana CLI install failed after $attempt attempts"
-              exit 1
-            fi
-            echo "Solana CLI install attempt $attempt failed; retrying in $((attempt * 15))s"
-            sleep $((attempt * 15))
-          done
+          sh -c "$(curl -sSfL https://release.anza.xyz/v3.1.14/install)"
           echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
       - name: Cache Anchor toolchain
         uses: actions/cache@v4

--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -21,7 +21,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Superseded runs on a pull request branch are cancelled. Runs on main are
+  # not: a later push whose change detection skips the build (a docs-only
+  # merge) would otherwise cancel the run verifying the previous merge and
+  # leave main with no verdict.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   MAX_JOBS: 64
@@ -196,8 +200,22 @@ jobs:
         with:
           node-version: lts/*
       - name: Install Solana CLI
+        # The installer downloads a release tarball from release.anza.xyz; a
+        # truncated download makes it fail with "failed to iterate over
+        # archive". Retry from scratch a few times before giving up.
         run: |
-          sh -c "$(curl -sSfL https://release.anza.xyz/v3.1.14/install)"
+          for attempt in 1 2 3 4 5; do
+            rm -rf "$HOME/.local/share/solana/install"
+            if sh -c "$(curl -sSfL https://release.anza.xyz/v3.1.14/install)"; then
+              break
+            fi
+            if [ "$attempt" = 5 ]; then
+              echo "Solana CLI install failed after $attempt attempts"
+              exit 1
+            fi
+            echo "Solana CLI install attempt $attempt failed; retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
           echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
       - name: Cache Anchor toolchain
         uses: actions/cache@v4

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -36,7 +36,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Superseded runs on a pull request branch are cancelled. Runs on main are
+  # not: a later push whose change detection skips the build (a docs-only
+  # merge) would otherwise cancel the run verifying the previous merge and
+  # leave main with no verdict.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   # See https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Superseded runs on a pull request branch are cancelled. Runs on main are
+  # not: a later push whose change detection skips the build (a docs-only
+  # merge) would otherwise cancel the run verifying the previous merge and
+  # leave main with no verdict.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   MAX_JOBS: 64

--- a/.github/workflows/pinocchio.yml
+++ b/.github/workflows/pinocchio.yml
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Superseded runs on a pull request branch are cancelled. Runs on main are
+  # not: a later push whose change detection skips the build (a docs-only
+  # merge) would otherwise cancel the run verifying the previous merge and
+  # leave main with no verdict.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   MAX_JOBS: 64

--- a/.github/workflows/quasar.yml
+++ b/.github/workflows/quasar.yml
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Superseded runs on a pull request branch are cancelled. Runs on main are
+  # not: a later push whose change detection skips the build (a docs-only
+  # merge) would otherwise cancel the run verifying the previous merge and
+  # leave main with no verdict.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   MAX_JOBS: 64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,13 @@ All notable changes to this repository are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [2026-09-08] - CI: retry the Solana CLI install; main's runs no longer cancel each other
+## [2026-09-08] - CI runs on main no longer cancel each other
 
-The Anchor v1 run on `main` after the 1.2.0 merge went red without any code being
-at fault. One matrix group's Solana CLI install failed because the release
-tarball it downloaded from release.anza.xyz arrived truncated ("failed to iterate
-over archive"); the same step passed in the other thirteen groups. The next merge,
-a README-only change, then cancelled that run through the workflow's concurrency
-rule before it could finish, and skipped its own build groups, so `main` was left
-with no verdict.
-
-- The "Install Solana CLI" step in `anchor.yml` and `anchor-v1.yml` retries the
-  installer up to five times, wiping the partial install between attempts.
-- `cancel-in-progress` in every workflow with a concurrency group now applies only
-  off `main`. A superseded run on a pull request branch is still cancelled; runs on
-  `main` finish, so a docs-only merge can no longer erase the previous merge's result.
+`cancel-in-progress` in every workflow with a concurrency group now applies only
+off `main`. A superseded run on a pull request branch is still cancelled. Runs on
+`main` finish: a later push whose change detection skips the build (a docs-only
+merge) used to cancel the run verifying the previous merge and leave `main` with
+no verdict, which is how the Anchor v1 badge went red after the 1.2.0 merge.
 
 ## [2026-09-08] - Anchor v1 examples on Anchor 1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this repository are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2026-09-08] - CI: retry the Solana CLI install; main's runs no longer cancel each other
+
+The Anchor v1 run on `main` after the 1.2.0 merge went red without any code being
+at fault. One matrix group's Solana CLI install failed because the release
+tarball it downloaded from release.anza.xyz arrived truncated ("failed to iterate
+over archive"); the same step passed in the other thirteen groups. The next merge,
+a README-only change, then cancelled that run through the workflow's concurrency
+rule before it could finish, and skipped its own build groups, so `main` was left
+with no verdict.
+
+- The "Install Solana CLI" step in `anchor.yml` and `anchor-v1.yml` retries the
+  installer up to five times, wiping the partial install between attempts.
+- `cancel-in-progress` in every workflow with a concurrency group now applies only
+  off `main`. A superseded run on a pull request branch is still cancelled; runs on
+  `main` finish, so a docs-only merge can no longer erase the previous merge's result.
+
 ## [2026-09-08] - Anchor v1 examples on Anchor 1.2.0
 
 Anchor 1.2.0 is the current release of the v1 line. Every `anchor-v1/` example now


### PR DESCRIPTION
After #141 merged, one group of the Anchor v1 run on `main` failed on a truncated Solana CLI download. That on its own is a re-run. What left `main` red was the next merge: #142 (README only) landed eleven minutes later, its push cancelled #141's still-running verification through the workflow's concurrency rule, and its own run built nothing, so the previous merge's result was gone and never replaced.

## Change

`cancel-in-progress` in every workflow with a concurrency group is now `github.ref != 'refs/heads/main'`. A superseded run on a pull request branch is still cancelled; runs on `main` finish, so a docs-only merge can no longer erase the previous merge's result. CHANGELOG.md records it.

An earlier revision of this PR also added a retry loop around the Solana installer; that was dropped as not worth carrying for a one-off download failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMP1m8Tbkz3H5AJFJ3p4aX