### PR TITLE
Add virtual shares and virtual assets to the vault strategy's share math

### DIFF
--- a/finance/vault-strategy/VIDEO_SCRIPT.md
+++ b/finance/vault-strategy/VIDEO_SCRIPT.md
@@ -121,14 +121,14 @@ NARRATION:
 
 Alice wants exposure to both stocks without buying and rebalancing them herself, so she calls `deposit` with 900 USDC. `deposit` is permissionless: any user can call it. This is buying into the strategy.
 
-The handler prices her shares against net asset value. It walks the complete asset set, index zero then index one, reading each vault's balance and each Pyth price, and it will not proceed unless every asset's accounts are present, so nothing can be hidden from the valuation. The strategy is empty, so net asset value is zero, and the first deposit is defined as one to one. Alice gets 900 shares. Shares carry six decimals, so under the hood that is 900 million minor units, but think of it as 900 shares worth a dollar each.
+The handler prices her shares against net asset value. It walks the complete asset set, index zero then index one, reading each vault's balance and each Pyth price, and it will not proceed unless every asset's accounts are present, so nothing can be hidden from the valuation. The strategy is empty, so net asset value is zero, and the share price comes from the program's virtual offset: a thousand virtual shares standing behind one virtual minor unit of USDC, added to every share-price division so that an empty strategy already has a price and a donation into a vault cannot be used to inflate it. Alice gets 900 shares. Shares carry nine decimals, USDC's six plus the offset's three, so under the hood that is 900 billion minor units, but think of it as 900 shares worth a dollar each.
 
 Checks, effects, interactions: the handler raises `total_shares` first, then pulls her USDC into the USDC vault, then mints her the shares with the strategy PDA signing.
 
 ON SCREEN:
 
 ```
-UPDATED - Strategy        total_shares: 0 -> 900,000,000
+UPDATED - Strategy        total_shares: 0 -> 900,000,000,000
 UPDATED - vault_usdc      0 -> 900 USDC
 UPDATED - Alice share ATA 0 -> 900 shares
 
@@ -179,13 +179,13 @@ ON SCREEN:
 ```
 Net asset value before Bob: 0 + 1.44 x 250 + 3.0 x 200 = 360 + 600 = 960 USDC
 
-UPDATED - Strategy        total_shares: 900,000,000 -> 1,350,000,000
+UPDATED - Strategy        total_shares: 900,000,000,000 -> 1,350,000,000,031
 UPDATED - vault_usdc      0 -> 480 USDC
 UPDATED - Bob share ATA   0 -> 450 shares
 
 TOKEN MOVEMENT:
     Bob USDC ATA -> vault_usdc        480 USDC
-    share_mint   -> Bob share ATA     450 shares   (480 x 900 / 960 = 450)
+    share_mint   -> Bob share ATA     450 shares   (480 x (900 + 1,000 virtual minor units) / (960 + 1 virtual minor unit) = 450.000000031)
 
 Fee generated: none
 ```
@@ -227,9 +227,9 @@ ON SCREEN:
 ```
 elapsed: 1 year (illustrative)
 fee_shares = total_shares x fee_bps x elapsed / (10,000 x seconds_per_year)
-           = 1,350,000,000 x 100 x 1yr / (10,000 x 1yr) = 13,500,000  (13.5 shares)
+           = 1,350,000,000,031 x 100 x 1yr / (10,000 x 1yr) = 13,500,000,000  (13.5 shares; the virtual shares earn nothing)
 
-UPDATED - Strategy        total_shares: 1,350,000,000 -> 1,363,500,000
+UPDATED - Strategy        total_shares: 1,350,000,000,031 -> 1,363,500,000,031
                           last_fee_accrual_timestamp: updated
 UPDATED - Maria share ATA 0 -> 13.5 shares
 
@@ -244,18 +244,18 @@ NARRATION:
 
 Alice calls `withdraw` and burns all 900 of her shares. Here is the part people miss: withdrawal is in kind and proportional. She does not get cash. She gets her exact fraction of every balance the strategy holds, across the USDC vault and both asset vaults. It is the same move an ETF makes when it redeems in kind, handing back the underlying holdings instead of cash. Just like deposit, the handler insists on seeing every asset, so her slice is computed against the whole strategy.
 
-Her fraction is 900 shares out of the 1,363.5 that now exist. The handler floors each amount in the protocol's favor, so any rounding dust stays with the remaining holders.
+Her fraction is 900 shares out of the 1,363.5 that now exist, plus the thousand virtual minor units that never leave, which is where the dust of the first-depositor defense goes. The handler floors each amount in the protocol's favor, so any rounding dust stays with the remaining holders.
 
 ON SCREEN:
 
 ```
-Alice fraction = 900,000,000 / 1,363,500,000
+Alice fraction = 900,000,000,000 / (1,363,500,000,031 + 1,000 virtual)
 
-amount_usdc = 480,000,000 x 900,000,000 / 1,363,500,000 = 316,831,683  (316.83 USDC, floor)
-amount_tsla =   1,080,000 x 900,000,000 / 1,363,500,000 =     712,871  (0.712871 TSLAx, floor)
-amount_nvda =   3,500,000 x 900,000,000 / 1,363,500,000 =   2,310,231  (2.310231 NVDAx, floor)
+amount_usdc = 480,000,000 x 900,000,000,000 / 1,363,500,001,031 = 316,831,682  (316.83 USDC, floor)
+amount_tsla =   1,080,000 x 900,000,000,000 / 1,363,500,001,031 =     712,871  (0.712871 TSLAx, floor)
+amount_nvda =   3,500,000 x 900,000,000,000 / 1,363,500,001,031 =   2,310,231  (2.310231 NVDAx, floor)
 
-UPDATED - Strategy        total_shares: 1,363,500,000 -> 463,500,000
+UPDATED - Strategy        total_shares: 1,363,500,000,031 -> 463,500,000,031
 UPDATED - Alice share ATA 900 shares -> 0   (burned)
 
 TOKEN MOVEMENT:

--- a/finance/vault-strategy/anchor-v1/CHANGELOG.md
+++ b/finance/vault-strategy/anchor-v1/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2026-09-08
+
+### Changed
+
+- **Virtual shares and virtual assets.** Every share-price division now adds `VIRTUAL_SHARES` (1,000, `10^SHARE_DECIMALS_OFFSET`) to the real supply and `VIRTUAL_ASSETS` (one USDC minor unit) to the net asset value: `deposit` mints `usdc × (total_shares + 1,000) / (NAV + 1)` and `withdraw` pays `balance × shares / (total_shares + 1,000)` per vault. This is the defense against the first-depositor inflation attack (a dust deposit, a donation straight into a vault, then a deposit that floors to zero shares): a deposit now floors to zero only when the strategy already holds more than a thousand times it, and whoever inflated it that far loses about a thousand times what the depositor loses. The `total_shares == 0` special case in `deposit` is gone; `minimum_shares` and `SlippageTooHigh` stay.
+- **Share mint decimals 6 → 9** (`SHARE_DECIMALS`, USDC's six plus the offset of three), so one whole share still tracks one USDC at launch: a 900 USDC first deposit mints 900,000,000,000 share minor units, which reads as 900 shares. Clients that formatted shares at six decimals must use nine.
+- `collect_fees` is unchanged and dilutes the real supply only; the virtual shares earn the manager nothing.
+
+### Added
+
+- `test_donation_does_not_inflate_share_price` runs the attack against the live program: one minor unit deposited, 1,000 USDC transferred straight to the USDC vault, then a 1,000 USDC deposit with `minimum_shares` = 0. The victim's shares are nonzero and redeem for about 999.75 USDC; the attacker's redeem for about 500 USDC.
+- The Kani proof crate models the offset and adds `proof_first_deposit_is_priced_by_the_offset` and `proof_donation_cannot_zero_a_deposit`.
+
 ## 2026-07-20
 
 - **`WhitelistEntry` renamed `ApprovedAsset`** (and `whitelist_asset` renamed `approve_asset`, PDA seed `"whitelist"` renamed `"approved_asset"`), naming the account after what it is: one curator-approved asset bound to its official price feed. The unused `AssetNotWhitelisted` error is removed; approval is checked by the `ApprovedAsset` account's existence. Doc comments and README now state that the `Registry` account is the curator record at the root of the approved set, not the list itself.

--- a/finance/vault-strategy/anchor-v1/PRODUCT.md
+++ b/finance/vault-strategy/anchor-v1/PRODUCT.md
@@ -41,7 +41,7 @@ Program instructions the frontend can surface:
 Rules the UI must respect and reflect:
 
 - Deposits are accepted only when target weights sum to **exactly 10,000 bps**; a strategy is either still being configured or fully allocated and live (`StrategyNotFullyAllocated` otherwise).
-- Shares: first deposit is 1:1 with USDC minor units; later deposits mint `deposit_usdc × total_shares / NAV`. Share mint is a PDA owned by the strategy PDA.
+- Shares: every deposit, the first included, mints `deposit_usdc × (total_shares + 1,000 virtual shares) / (NAV + 1 virtual minor unit)`, floored. The share mint has 9 decimals (`SHARE_DECIMALS`: USDC's 6 plus a 3-decimal offset), so one whole share tracks one USDC at launch and a 900 USDC first deposit shows as 900 shares. The virtual offset is the first-depositor inflation defense; withdrawals divide by `total_shares` + 1,000 so the virtual shares' slice of each vault stays behind. Share mint is a PDA owned by the strategy PDA.
 - Management fee is charged by minting new shares to the manager (dilution), fixed at creation, capped at `MAX_FEE_BPS` = 1,000 bps (10%), no setter to raise it. `collect_fees` is permissionless.
 - Slippage floors are computed on-chain from the Pyth price and `max_slippage_bps` (capped at 1,000 bps); a manager-supplied minimum is not trusted.
 - `MAX_ASSETS` = 16. `deposit` re-derives the full `0..asset_count` PDA range and refuses to run if any asset account is missing (`IncompleteAssetAccounts`), so NAV can't be understated.

--- a/finance/vault-strategy/anchor-v1/README.md
+++ b/finance/vault-strategy/anchor-v1/README.md
@@ -37,8 +37,10 @@ Prices come from [Pyth Network](https://pyth.network/) `PriceUpdateV2` accounts.
 
 A [share](https://www.investopedia.com/terms/s/shares.asp) represents a fraction of the whole strategy. Hold 1% of shares and you own 1% of every vault.
 
-- **First deposit**: shares are issued 1:1 with USDC minor units (initial price of 1 USDC per share).
-- **Later deposits**: `shares_to_mint = deposit_usdc × total_shares / NAV`.
+- **Every deposit**, the first included: `shares_to_mint = deposit_usdc × (total_shares + VIRTUAL_SHARES) / (NAV + VIRTUAL_ASSETS)`, floored.
+- **The virtual offset** is the defense against the first-depositor inflation attack. `VIRTUAL_SHARES` is 1,000 (`10^SHARE_DECIMALS_OFFSET`) and `VIRTUAL_ASSETS` is one USDC minor unit, so an empty strategy already has a share price and there is no special case for the first deposit. The share mint has `SHARE_DECIMALS` = 9 decimals, USDC's six plus the offset of three, so one whole share still tracks one USDC at launch: a 900 USDC first deposit mints 900,000,000,000 share minor units, which reads as 900 shares.
+- **Why it is safe**: tokens sent straight to a vault count as fund value the moment they arrive, so without the offset a dust first deposit followed by a donation could price one share above the next deposit, which would floor to zero shares. With it, a deposit floors to zero only when the strategy already holds more than a thousand times it, and a donation is split between the real shares and the virtual ones, so an attacker loses about a thousand times what the next depositor loses. Deposit one minor unit, donate 1,000 USDC, and a following 1,000 USDC deposit still mints 1,999 share minor units that redeem for about 999.75 USDC; the attacker's 1,000 share minor units redeem for about 500 USDC. Pinned by `test_donation_does_not_inflate_share_price`.
+- **Withdrawals** pay `vault_balance × shares / (total_shares + VIRTUAL_SHARES)` per vault, floored, so the virtual shares' slice of every vault (at most 1,000 parts in `total_shares` + 1,000) is never paid out.
 - Shares are [SPL tokens](https://solana.com/docs/terminology#token); the share mint's address is a [PDA](https://solana.com/docs/terminology#program-derived-address-pda), so it is deterministic and the strategy PDA is its mint authority.
 
 ### Management Fee
@@ -49,7 +51,7 @@ A [management fee](https://www.investopedia.com/terms/m/managementfee.asp), in [
 fee_shares = total_shares × fee_bps × elapsed_seconds / (10_000 × 31_536_000)
 ```
 
-`collect_fees` is permissionless. The fee is fixed at creation and capped at `MAX_FEE_BPS` (1,000 bps = 10%); there is no setter to raise it later.
+The fee dilutes the real supply only: the virtual shares hold nothing of anyone's and earn the manager nothing. `collect_fees` is permissionless. The fee is fixed at creation and capped at `MAX_FEE_BPS` (1,000 bps = 10%); there is no setter to raise it later.
 
 ### Weights and Rebalancing
 
@@ -92,7 +94,7 @@ An [in-kind distribution](https://www.investopedia.com/terms/i/in-kind.asp) retu
 
 ### Alice deposits, and her money is deployed at once
 
-`deposit(usdc_amount, minimum_shares)`, with each asset's `[asset_config, vault, mint, rate, price_feed]` passed as remaining accounts, plus the router accounts. The handler requires the strategy to be fully allocated, values every asset for NAV (first deposit is 1:1), mints shares to Alice, then deploys her USDC across the basket at its target weights through the router, each leg under an oracle slippage floor. With the weights at 40/60, a 900 USDC deposit lands as 1.44 TSLAx and 3.0 NVDAx with no idle USDC.
+`deposit(usdc_amount, minimum_shares)`, with each asset's `[asset_config, vault, mint, rate, price_feed]` passed as remaining accounts, plus the router accounts. The handler requires the strategy to be fully allocated, values every asset for NAV, prices her shares with the virtual offset (900 USDC into the empty strategy mints 900 whole shares), mints them to Alice, then deploys her USDC across the basket at its target weights through the router, each leg under an oracle slippage floor. With the weights at 40/60, a 900 USDC deposit lands as 1.44 TSLAx and 3.0 NVDAx with no idle USDC.
 
 ### Bob deposits at the current share price
 
@@ -157,7 +159,7 @@ cargo build-sbf --manifest-path programs/vault-strategy/Cargo.toml
 cargo test --manifest-path programs/vault-strategy/Cargo.toml
 ```
 
-Tests live in `programs/vault-strategy/tests/vault_strategy.rs` and use [LiteSVM](https://github.com/LiteSVM/litesvm). Both `.so` files are loaded from `target/deploy/`, so build before testing. The suite covers the full lifecycle end to end (deposit with auto-deployment, a price move, rebalance back to target, a second depositor priced at the new NAV, a year's fee, in-kind withdrawal), retiring an asset with `set_weight` and reallocating to reopen deposits, and the rejection paths: unapproved asset, weight overflow, over-cap fee and slippage, oracle-bounded deposit slippage, an under-allocated strategy, non-manager `set_weight`, unregistered router, and incomplete asset accounts on deposit.
+Tests live in `programs/vault-strategy/tests/vault_strategy.rs` and use [LiteSVM](https://github.com/LiteSVM/litesvm). Both `.so` files are loaded from `target/deploy/`, so build before testing. The suite covers the full lifecycle end to end (deposit with auto-deployment, a price move, rebalance back to target, a second depositor priced at the new NAV, a year's fee, in-kind withdrawal), retiring an asset with `set_weight` and reallocating to reopen deposits, and the rejection paths: unapproved asset, weight overflow, over-cap fee and slippage, oracle-bounded deposit slippage, an under-allocated strategy, non-manager `set_weight`, unregistered router, and incomplete asset accounts on deposit. `test_donation_does_not_inflate_share_price` runs the first-depositor inflation attack (a one-minor-unit deposit, a 1,000 USDC donation straight into the USDC vault, then a 1,000 USDC deposit with no `minimum_shares` floor) and checks that the victim's shares are nonzero and redeem for all but a fraction of a dollar while the attacker loses about a thousand times as much.
 
 ## FAQ
 
@@ -167,7 +169,7 @@ A manager creates a strategy with `initialize_strategy`, registers curator-appro
 
 ### How are share prices calculated?
 
-Shares are priced at the strategy's net asset value: the total value of the vault balances at current prices divided by shares outstanding. A later depositor pays the current share price rather than diluting earlier ones.
+Shares are priced at the strategy's net asset value: the total value of the vault balances at current prices, plus one virtual minor unit, divided by shares outstanding plus 1,000 virtual shares. A later depositor pays the current share price rather than diluting earlier ones, and the virtual offset keeps the price defined and the first depositor honest when the strategy is empty.
 
 ### How does the manager operate the fund?
 

--- a/finance/vault-strategy/anchor-v1/app/src/components/ActionTicket.tsx
+++ b/finance/vault-strategy/anchor-v1/app/src/components/ActionTicket.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { applyToleranceFloor, estimateRedeem, estimateSharesOut, parseAmount } from "../lib/amounts";
 import { describeError } from "../lib/tx";
+import { SHARE_DECIMALS } from "../solana/config";
 import { formatShares, formatUnits, formatUsdc, shortAddress } from "../solana/format";
 import type { Position, StrategyView } from "../solana/strategy";
 import { Button, Segmented, StatusLine, TextField, type TxStatus } from "./atoms";
@@ -61,7 +62,7 @@ export function ActionTicket({ view, connected, walletUsdc, position, onDeposit,
     (walletUsdc === null || usdcMinor <= walletUsdc);
 
   // redeem derivations
-  const sharesMinor = parseAmount(redeemInput, 6);
+  const sharesMinor = parseAmount(redeemInput, SHARE_DECIMALS);
   const redeemInvalid = redeemInput.trim() !== "" && sharesMinor === null;
   const redeemEst = sharesMinor !== null && sharesMinor > 0n ? estimateRedeem(sharesMinor, view) : null;
 
@@ -167,7 +168,7 @@ export function ActionTicket({ view, connected, walletUsdc, position, onDeposit,
               right={
                 <button
                   type="button"
-                  onClick={() => setRedeemInput(rawAmount(shares))}
+                  onClick={() => setRedeemInput(rawAmount(shares, SHARE_DECIMALS))}
                   className="tabular-nums transition-colors hover:text-accent"
                 >
                   Balance {formatShares(shares)} · Max

--- a/finance/vault-strategy/anchor-v1/app/src/lib/amounts.ts
+++ b/finance/vault-strategy/anchor-v1/app/src/lib/amounts.ts
@@ -1,3 +1,4 @@
+import { VIRTUAL_ASSETS, VIRTUAL_SHARES } from "../solana/config";
 import type { StrategyView } from "../solana/strategy";
 
 /** Parse a decimal string into minor units. Returns null if malformed or over-precise. */
@@ -12,17 +13,19 @@ export function parseAmount(input: string, decimals: number): bigint | null {
   return w * 10n ** BigInt(decimals) + f;
 }
 
-/** Shares a deposit would mint, matching the program: first deposit 1:1, else usdc*shares/nav. */
+/**
+ * Shares a deposit would mint, matching the program:
+ * usdc * (shares + VIRTUAL_SHARES) / (nav + VIRTUAL_ASSETS), floored. The virtual
+ * offset prices the empty strategy too, so there is no first-deposit special case.
+ */
 export function estimateSharesOut(usdcMinor: bigint, navMinor: bigint, totalShares: bigint): bigint {
-  if (totalShares === 0n) return usdcMinor;
-  if (navMinor === 0n) return 0n;
-  return (usdcMinor * totalShares) / navMinor;
+  return (usdcMinor * (totalShares + VIRTUAL_SHARES)) / (navMinor + VIRTUAL_ASSETS);
 }
 
 export interface RedeemLeg {
   index: number;
   mint: string;
-  amountMinor: bigint; // 6dp
+  amountMinor: bigint; // the asset's own minor units (6dp for the example assets)
 }
 
 export interface RedeemEstimate {
@@ -30,7 +33,11 @@ export interface RedeemEstimate {
   legs: RedeemLeg[];
 }
 
-/** The in-kind slice a redemption pays out, matching withdraw's proportional math. */
+/**
+ * The in-kind slice a redemption pays out, matching withdraw's proportional math:
+ * balance * shares / (totalShares + VIRTUAL_SHARES) per vault, so the virtual
+ * shares' slice of every vault stays behind.
+ */
 export function estimateRedeem(sharesMinor: bigint, view: StrategyView): RedeemEstimate {
   if (view.totalShares === 0n || sharesMinor <= 0n) {
     return {
@@ -38,11 +45,12 @@ export function estimateRedeem(sharesMinor: bigint, view: StrategyView): RedeemE
       legs: view.assets.map((a) => ({ index: a.index, mint: a.mint.toBase58(), amountMinor: 0n })),
     };
   }
-  const usdcMinor = (view.usdcAmount * sharesMinor) / view.totalShares;
+  const divisor = view.totalShares + VIRTUAL_SHARES;
+  const usdcMinor = (view.usdcAmount * sharesMinor) / divisor;
   const legs = view.assets.map((a) => ({
     index: a.index,
     mint: a.mint.toBase58(),
-    amountMinor: (a.vaultAmount * sharesMinor) / view.totalShares,
+    amountMinor: (a.vaultAmount * sharesMinor) / divisor,
   }));
   return { usdcMinor, legs };
 }

--- a/finance/vault-strategy/anchor-v1/app/src/solana/config.ts
+++ b/finance/vault-strategy/anchor-v1/app/src/solana/config.ts
@@ -34,4 +34,13 @@ export const MAX_SLIPPAGE_BPS = 1_000; // 10%
 export const BPS_DENOMINATOR = 10_000;
 export const PYTH_PRICE_PRECISION = 100_000_000n; // 10^8, Pyth exponent -8
 export const MAX_PRICE_AGE_SECONDS = 60;
-export const SHARE_DECIMALS = 6; // share_mint is created with mint::decimals = 6
+// The share mint has USDC's 6 decimals plus SHARE_DECIMALS_OFFSET, so one whole
+// share tracks one USDC at launch (state/strategy.rs: SHARE_DECIMALS).
+export const SHARE_DECIMALS_OFFSET = 3;
+export const SHARE_DECIMALS = 6 + SHARE_DECIMALS_OFFSET;
+/** One whole share in share-mint minor units. */
+export const SHARE_UNIT = 10n ** BigInt(SHARE_DECIMALS);
+// The virtual offset every share-price division carries (state/strategy.rs):
+// 10^SHARE_DECIMALS_OFFSET virtual shares behind one virtual USDC minor unit.
+export const VIRTUAL_SHARES = 10n ** BigInt(SHARE_DECIMALS_OFFSET);
+export const VIRTUAL_ASSETS = 1n;

--- a/finance/vault-strategy/anchor-v1/app/src/solana/format.ts
+++ b/finance/vault-strategy/anchor-v1/app/src/solana/format.ts
@@ -1,5 +1,5 @@
 import type { PublicKey } from "@solana/web3.js";
-import { CLUSTER, RPC_URL } from "./config";
+import { CLUSTER, RPC_URL, SHARE_DECIMALS } from "./config";
 
 function groupThousands(intDigits: string): string {
   return intDigits.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
@@ -19,9 +19,9 @@ export function formatUnits(minor: bigint, decimals: number, frac = 2): string {
 /** USDC amount (6dp minor units) → "1,363.50". */
 export const formatUsdc = (minor: bigint, frac = 2): string => formatUnits(minor, 6, frac);
 
-/** Share amount (6dp minor units) → "900.000000", trailing zeros trimmed to `minFrac`. */
+/** Share amount (SHARE_DECIMALS minor units) → "900.000000000", trailing zeros trimmed to `minFrac`. */
 export function formatShares(minor: bigint, minFrac = 2): string {
-  const full = formatUnits(minor, 6, 6);
+  const full = formatUnits(minor, SHARE_DECIMALS, SHARE_DECIMALS);
   if (!full.includes(".")) return full;
   const [w, f] = full.split(".");
   const trimmed = f.replace(/0+$/, "");

--- a/finance/vault-strategy/anchor-v1/app/src/solana/strategy.ts
+++ b/finance/vault-strategy/anchor-v1/app/src/solana/strategy.ts
@@ -1,7 +1,14 @@
 import type { BN } from "@coral-xyz/anchor";
 import type { Connection, PublicKey } from "@solana/web3.js";
 import type { AssetConfigAccount, StrategyAccount } from "../idl/vaultStrategy";
-import { MAX_PRICE_AGE_SECONDS, PYTH_PRICE_PRECISION, STRATEGY_INDEX } from "./config";
+import {
+  MAX_PRICE_AGE_SECONDS,
+  PYTH_PRICE_PRECISION,
+  SHARE_UNIT,
+  STRATEGY_INDEX,
+  VIRTUAL_ASSETS,
+  VIRTUAL_SHARES,
+} from "./config";
 import { assetConfigPda, shareMintPda, strategyPda, userAta, vaultAta } from "./pdas";
 import type { VaultProgram } from "./program";
 import { parsePriceUpdateV2, readTokenAmount } from "./pyth";
@@ -176,7 +183,9 @@ export async function loadStrategyView(
   }
 
   const totalShares = toBig(account.totalShares);
-  const navPerShareMinor = totalShares > 0n ? (navMinor * 1_000_000n) / totalShares : 1_000_000n;
+  // USDC minor units per whole share, priced the way the program prices a deposit:
+  // (nav + VIRTUAL_ASSETS) / (shares + VIRTUAL_SHARES), scaled to one whole share.
+  const navPerShareMinor = ((navMinor + VIRTUAL_ASSETS) * SHARE_UNIT) / (totalShares + VIRTUAL_SHARES);
 
   return {
     exists: true,

--- a/finance/vault-strategy/anchor-v1/programs/vault-strategy/src/instructions/collect_fees.rs
+++ b/finance/vault-strategy/anchor-v1/programs/vault-strategy/src/instructions/collect_fees.rs
@@ -61,6 +61,10 @@ pub fn handle_collect_fees(context: Context<CollectFeesAccountConstraints>) -> R
     let strategy_bump = context.accounts.strategy.bump;
 
     // fee_shares = total_shares * fee_bps * elapsed / (10_000 * SECONDS_PER_YEAR)
+    //
+    // The fee is a percentage of what depositors hold, so it dilutes against the
+    // real supply only. The virtual shares that price deposits and withdrawals
+    // hold nothing of anyone's and earn the manager nothing.
     let denominator = (10_000u128)
         .checked_mul(SECONDS_PER_YEAR as u128)
         .ok_or(VaultError::MathOverflow)?;

--- a/finance/vault-strategy/anchor-v1/programs/vault-strategy/src/instructions/deposit.rs
+++ b/finance/vault-strategy/anchor-v1/programs/vault-strategy/src/instructions/deposit.rs
@@ -9,7 +9,7 @@ use mock_swap_router::cpi::accounts::SwapUsdcForAssetAccountConstraints as Route
 
 use crate::error::VaultError;
 use crate::oracle::{asset_value_in_usdc, load_price, read_token_amount, PYTH_PRICE_PRECISION};
-use crate::state::{AssetConfig, Strategy};
+use crate::state::{AssetConfig, Strategy, VIRTUAL_ASSETS, VIRTUAL_SHARES};
 
 #[derive(Accounts)]
 pub struct DepositAccountConstraints<'info> {
@@ -151,16 +151,30 @@ pub fn handle_deposit<'info>(
             .ok_or(VaultError::MathOverflow)?;
     }
 
-    // shares = usdc_amount * total_shares / nav (floor); first deposit is 1:1.
-    let shares_to_mint: u64 = if total_shares == 0 {
-        usdc_amount
-    } else {
-        (usdc_amount as u128)
-            .checked_mul(total_shares as u128)
-            .ok_or(VaultError::MathOverflow)?
-            .checked_div(nav)
-            .ok_or(VaultError::MathOverflow)? as u64
-    };
+    // shares = usdc_amount * (total_shares + VIRTUAL_SHARES) / (nav + VIRTUAL_ASSETS),
+    // floored in the fund's favour.
+    //
+    // The virtual offset is the defense against the first-depositor inflation
+    // attack. Tokens sent straight to a vault count as fund value the moment they
+    // arrive, so without it a dust-sized first deposit followed by a donation
+    // could price one share at more than the next deposit, which then floors to
+    // zero shares. With `VIRTUAL_SHARES` (10^3) standing behind one virtual minor
+    // unit, an empty fund already has a share price: the first deposit mints a
+    // thousand share minor units per USDC minor unit, which at nine share
+    // decimals is one whole share per USDC, and a donation is split between the
+    // real shares and the virtual ones. A deposit floors to zero only when the
+    // fund already holds more than a thousand times it, and whoever inflated the
+    // fund that far loses about a thousand times what the depositor loses.
+    let shares_to_mint: u64 = (usdc_amount as u128)
+        .checked_mul(total_shares as u128 + VIRTUAL_SHARES as u128)
+        .ok_or(VaultError::MathOverflow)?
+        .checked_div(
+            nav.checked_add(VIRTUAL_ASSETS as u128)
+                .ok_or(VaultError::MathOverflow)?,
+        )
+        .ok_or(VaultError::MathOverflow)?
+        .try_into()
+        .map_err(|_| VaultError::MathOverflow)?;
 
     require!(
         shares_to_mint >= minimum_shares,

--- a/finance/vault-strategy/anchor-v1/programs/vault-strategy/src/instructions/initialize_strategy.rs
+++ b/finance/vault-strategy/anchor-v1/programs/vault-strategy/src/instructions/initialize_strategy.rs
@@ -5,7 +5,7 @@ use anchor_spl::{
 };
 
 use crate::error::VaultError;
-use crate::state::{Registry, Strategy};
+use crate::state::{Registry, Strategy, SHARE_DECIMALS};
 
 /// Highest annual management fee a manager may set, in basis points (10%).
 /// `collect_fees` mints shares to the manager and dilutes every depositor,
@@ -42,7 +42,7 @@ pub struct InitializeStrategyAccountConstraints<'info> {
     #[account(
         init,
         payer = manager,
-        mint::decimals = 6,
+        mint::decimals = SHARE_DECIMALS,
         mint::authority = strategy,
         mint::freeze_authority = strategy,
         mint::token_program = token_program,

--- a/finance/vault-strategy/anchor-v1/programs/vault-strategy/src/instructions/withdraw.rs
+++ b/finance/vault-strategy/anchor-v1/programs/vault-strategy/src/instructions/withdraw.rs
@@ -8,7 +8,7 @@ use anchor_spl::{
 
 use crate::error::VaultError;
 use crate::oracle::{read_mint_decimals, read_token_amount, read_token_mint_and_owner};
-use crate::state::{AssetConfig, Strategy};
+use crate::state::{AssetConfig, Strategy, VIRTUAL_SHARES};
 
 #[derive(Accounts)]
 pub struct WithdrawAccountConstraints<'info> {
@@ -89,7 +89,11 @@ pub fn handle_withdraw<'info>(
     );
 
     let shares_u128 = shares_to_burn as u128;
-    let total_u128 = total_shares as u128;
+    // Every leg pays balance * shares / (total_shares + VIRTUAL_SHARES). The
+    // virtual shares hold their slice of every vault and are never burned, so
+    // even the last real holder leaves that slice behind: at most
+    // VIRTUAL_SHARES parts in (total_shares + VIRTUAL_SHARES) of each balance.
+    let total_u128 = total_shares as u128 + VIRTUAL_SHARES as u128;
 
     // USDC leg, floored in the protocol's favour.
     let amount_usdc: u64 = (vault_usdc_amount as u128)

--- a/finance/vault-strategy/anchor-v1/programs/vault-strategy/src/state/strategy.rs
+++ b/finance/vault-strategy/anchor-v1/programs/vault-strategy/src/state/strategy.rs
@@ -11,6 +11,33 @@ use anchor_lang::prelude::*;
 /// currency, held separately, and does not count against this.
 pub const MAX_ASSETS: u8 = 16;
 
+/// Decimals of the share mint: USDC's six plus `SHARE_DECIMALS_OFFSET`, so one
+/// whole share still tracks one USDC at launch (a 900 USDC first deposit reads
+/// as 900 shares) while the supply carries three more digits than the USDC it
+/// prices.
+pub const SHARE_DECIMALS: u8 = 6 + SHARE_DECIMALS_OFFSET;
+
+/// How many more decimals the share mint has than USDC. This is the vault's
+/// first-depositor defense (virtual shares and virtual assets, the ERC-4626
+/// "decimals offset"): every exchange-rate division adds `VIRTUAL_SHARES` to
+/// the share supply and `VIRTUAL_ASSETS` to the net asset value, so an empty
+/// fund already has a share price (one minor unit of USDC per `10^OFFSET` share
+/// minor units), the `total_shares == 0` case needs no special branch, and a
+/// donation straight into a vault is shared with shares nobody holds. An
+/// attacker inflating the share price loses about `10^OFFSET` times whatever
+/// the next depositor loses to rounding. Three leaves `total_shares: u64` room
+/// for about eighteen billion whole shares.
+pub const SHARE_DECIMALS_OFFSET: u8 = 3;
+
+/// Virtual shares added to the real supply in every share-price division:
+/// `10^SHARE_DECIMALS_OFFSET`. They are never minted, never burned, and their
+/// slice of every vault is never paid out.
+pub const VIRTUAL_SHARES: u64 = 10u64.pow(SHARE_DECIMALS_OFFSET as u32);
+
+/// Virtual assets added to the net asset value in every share-price division:
+/// one USDC minor unit, backing the virtual shares.
+pub const VIRTUAL_ASSETS: u64 = 1;
+
 /// One strategy (basket). Its address is a PDA seeded by a caller-chosen index,
 /// e.g. seeds `"strategy" + 0`, so strategies are addressed by a simple counter
 /// rather than by the manager's key. The index is stored here so every handler

--- a/finance/vault-strategy/anchor-v1/programs/vault-strategy/tests/vault_strategy.rs
+++ b/finance/vault-strategy/anchor-v1/programs/vault-strategy/tests/vault_strategy.rs
@@ -16,6 +16,7 @@ use {
         send_transaction_from_instructions,
     },
     solana_signer::Signer,
+    vault_strategy::state::{SHARE_DECIMALS, VIRTUAL_SHARES},
 };
 
 fn token_program_id() -> Pubkey {
@@ -88,6 +89,11 @@ const TSLA_PRICE: i64 = 25_000_000_000; // $250
 const NVDA_PRICE: i64 = 18_000_000_000; // $180
 const TSLA_RATE: u64 = 250; // router usdc per token
 const NVDA_RATE: u64 = 180;
+
+/// One whole share in share-mint minor units. The share mint has USDC's six
+/// decimals plus the program's three-decimal virtual-share offset, so a 900
+/// USDC first deposit mints 900 whole shares, or 900 * SHARE_UNIT minor units.
+const SHARE_UNIT: u64 = 10u64.pow(SHARE_DECIMALS as u32);
 
 const FEE_BPS: u16 = 100; // 1%
 const SLIPPAGE_BPS: u16 = 100; // 1%
@@ -737,6 +743,15 @@ fn test_initialize_and_add_assets() {
     assert_eq!(strategy.max_slippage_bps, SLIPPAGE_BPS);
     assert_eq!(strategy.registry, ctx.registry_pda);
 
+    // The share mint carries USDC's six decimals plus the virtual-share offset.
+    // Token mint layout: supply is the u64 at bytes 36..44, decimals the byte at 44.
+    let share_mint = ctx.svm.get_account(&ctx.share_mint_pda).unwrap().data;
+    assert_eq!(
+        u64::from_le_bytes(share_mint[36..44].try_into().unwrap()),
+        0
+    );
+    assert_eq!(share_mint[44], SHARE_DECIMALS);
+
     let cfg0 = ctx.svm.get_account(&ctx.asset_config(0)).unwrap();
     let asset0 = vault_strategy::state::AssetConfig::try_deserialize(&mut &cfg0.data[..]).unwrap();
     assert_eq!(asset0.mint, ctx.tsla_mint);
@@ -911,13 +926,19 @@ fn test_deposit_first() {
 
     let amount = 1_000_000u64; // 1 USDC
     let user = fund_user(&mut ctx, amount);
-    let user_share = do_deposit(&mut ctx, &user, amount, amount);
+    let user_share = do_deposit(&mut ctx, &user, amount, SHARE_UNIT);
 
-    // First deposit is 1:1, then deployed at 40/60: 0.4 USDC -> TSLAx, 0.6 -> NVDAx,
-    // leaving no idle USDC.
+    // The first deposit is priced by the virtual offset: 1 USDC minor unit buys
+    // VIRTUAL_SHARES share minor units, so 1 USDC mints exactly one whole share.
+    // It is then deployed at 40/60: 0.4 USDC -> TSLAx, 0.6 -> NVDAx, leaving no
+    // idle USDC.
     assert_eq!(
         get_token_account_balance(&ctx.svm, &user_share).unwrap(),
-        amount
+        amount * VIRTUAL_SHARES
+    );
+    assert_eq!(
+        get_token_account_balance(&ctx.svm, &user_share).unwrap(),
+        SHARE_UNIT
     );
     assert_eq!(
         get_token_account_balance(&ctx.svm, &ctx.vault_usdc).unwrap(),
@@ -1009,34 +1030,37 @@ fn test_deposit_fair_pricing() {
     let mut ctx = setup_full();
     standard_strategy(&mut ctx);
 
-    // Alice deposits 900 USDC (first deposit 1:1 -> 900,000,000 shares), auto-deployed
-    // 40/60: 1.44 TSLAx + 3.0 NVDAx. NAV = 900 USDC.
+    // Alice deposits 900 USDC into the empty fund: 900,000,000 minor units times
+    // (0 + 1000 virtual shares) over (0 + 1 virtual minor unit) = 900 whole shares.
+    // Auto-deployed 40/60: 1.44 TSLAx + 3.0 NVDAx. NAV = 900 USDC.
     let alice = fund_user(&mut ctx, 900_000_000);
     let alice_share = do_deposit(&mut ctx, &alice, 900_000_000, 1);
     assert_eq!(
         get_token_account_balance(&ctx.svm, &alice_share).unwrap(),
-        900_000_000
+        900 * SHARE_UNIT
     );
 
     // NVDAx rises 180 -> 200. NAV rises to 0 + 1.44*250 + 3.0*200 = 960 USDC.
     set_nvda_price(&mut ctx, 20_000_000_000, 200);
 
-    // Bob deposits 480 USDC at the higher NAV: shares = 480 * 900 / 960 = 450,000,000.
-    // He pays today's price, so he does not dilute Alice's gain.
+    // Bob deposits 480 USDC at the higher NAV: shares = 480 * 900 / 960 = 450 whole
+    // shares. He pays today's price, so he does not dilute Alice's gain. The
+    // virtual offset shows up 10 digits down: 480,000,000 * (900 * SHARE_UNIT +
+    // 1000) / (960,000,000 + 1) floors to 450,000,000,031 minor units.
     let bob = fund_user(&mut ctx, 480_000_000);
     let bob_share = do_deposit(&mut ctx, &bob, 480_000_000, 1);
-    assert_eq!(
-        get_token_account_balance(&ctx.svm, &bob_share).unwrap(),
-        450_000_000
-    );
+    let bob_shares = get_token_account_balance(&ctx.svm, &bob_share).unwrap();
+    assert_eq!(bob_shares / SHARE_UNIT, 450);
+    assert_eq!(bob_shares, 450_000_000_031);
 
     // Alice's shares are untouched; supply is the two deposits combined.
     assert_eq!(
         get_token_account_balance(&ctx.svm, &alice_share).unwrap(),
-        900_000_000
+        900 * SHARE_UNIT
     );
     let strategy = read_strategy(&ctx);
-    assert_eq!(strategy.total_shares, 1_350_000_000);
+    assert_eq!(strategy.total_shares, 900 * SHARE_UNIT + bob_shares);
+    assert_eq!(strategy.total_shares / SHARE_UNIT, 1_350);
 }
 
 #[test]
@@ -1081,10 +1105,11 @@ fn test_collect_fees() {
     advance_one_year(&mut ctx);
     let manager_share = do_collect_fees(&mut ctx);
 
-    // 1% of 1,000,000,000 = 10,000,000 fee shares.
+    // 1% of the 1,000 whole shares the deposit minted = 10 whole shares. The fee
+    // dilutes the real supply only; the virtual shares earn the manager nothing.
     assert_eq!(
         get_token_account_balance(&ctx.svm, &manager_share).unwrap(),
-        10_000_000
+        10 * SHARE_UNIT
     );
 }
 
@@ -1144,16 +1169,27 @@ fn test_withdraw() {
     );
     send_transaction_from_instructions(&mut ctx.svm, vec![ix], &[&user], &user.pubkey()).unwrap();
 
-    // Sole holder withdraws everything in kind: all 16000 TSLAx + 33333 NVDAx, no USDC.
+    // The sole holder withdraws everything in kind. Each leg pays balance * shares
+    // / (shares + 1000 virtual shares), so the virtual shares' slice of each vault
+    // stays behind: one minor unit of TSLAx and one of NVDAx, and no USDC.
     assert_eq!(get_token_account_balance(&ctx.svm, &user_usdc).unwrap(), 0);
     assert_eq!(
         get_token_account_balance(&ctx.svm, &derive_ata(&user.pubkey(), &ctx.tsla_mint)).unwrap(),
-        16_000
+        15_999
     );
     assert_eq!(
         get_token_account_balance(&ctx.svm, &derive_ata(&user.pubkey(), &ctx.nvda_mint)).unwrap(),
-        33_333
+        33_332
     );
+    assert_eq!(
+        get_token_account_balance(&ctx.svm, &ctx.vault_tsla).unwrap(),
+        1
+    );
+    assert_eq!(
+        get_token_account_balance(&ctx.svm, &ctx.vault_nvda).unwrap(),
+        1
+    );
+    assert_eq!(read_strategy(&ctx).total_shares, 0);
 }
 
 #[test]
@@ -1334,12 +1370,12 @@ fn test_full_lifecycle() {
     let mut ctx = setup_full();
     standard_strategy(&mut ctx);
 
-    // Alice deposits 900 USDC -> 900,000,000 shares, deployed to 1.44 TSLAx + 3.0 NVDAx.
+    // Alice deposits 900 USDC -> 900 whole shares, deployed to 1.44 TSLAx + 3.0 NVDAx.
     let alice = fund_user(&mut ctx, 900_000_000);
     let alice_share = do_deposit(&mut ctx, &alice, 900_000_000, 1);
     assert_eq!(
         get_token_account_balance(&ctx.svm, &alice_share).unwrap(),
-        900_000_000
+        900 * SHARE_UNIT
     );
     assert_eq!(
         get_token_account_balance(&ctx.svm, &ctx.vault_tsla).unwrap(),
@@ -1362,13 +1398,13 @@ fn test_full_lifecycle() {
         2_880_000
     );
 
-    // Bob deposits 480 USDC at NAV 960 -> 450,000,000 shares, deployed 40/60.
+    // Bob deposits 480 USDC at NAV 960 -> 450 whole shares (450,000,000,031 minor
+    // units, the last two digits being the virtual offset's rounding), deployed 40/60.
     let bob = fund_user(&mut ctx, 480_000_000);
     let bob_share = do_deposit(&mut ctx, &bob, 480_000_000, 1);
-    assert_eq!(
-        get_token_account_balance(&ctx.svm, &bob_share).unwrap(),
-        450_000_000
-    );
+    let bob_shares = get_token_account_balance(&ctx.svm, &bob_share).unwrap();
+    assert_eq!(bob_shares / SHARE_UNIT, 450);
+    assert_eq!(bob_shares, 450_000_000_031);
     assert_eq!(
         get_token_account_balance(&ctx.svm, &ctx.vault_tsla).unwrap(),
         2_304_000
@@ -1378,17 +1414,20 @@ fn test_full_lifecycle() {
         4_320_000
     );
 
-    // A year passes; the manager collects 1% of the 1,350,000,000 supply = 13,500,000.
+    // A year passes; the manager collects 1% of the 1,350 whole-share supply = 13.5
+    // whole shares. The 31 minor units of Bob's rounding earn 0.31, which floors away.
     advance_one_year(&mut ctx);
     let manager_share = do_collect_fees(&mut ctx);
-    assert_eq!(
-        get_token_account_balance(&ctx.svm, &manager_share).unwrap(),
-        13_500_000
-    );
-    assert_eq!(read_strategy(&ctx).total_shares, 1_363_500_000);
+    let fee_shares = get_token_account_balance(&ctx.svm, &manager_share).unwrap();
+    assert_eq!(fee_shares, 13_500_000_000);
+    assert_eq!(fee_shares * 10 / SHARE_UNIT, 135);
+    let supply = 900 * SHARE_UNIT + bob_shares + fee_shares;
+    assert_eq!(read_strategy(&ctx).total_shares, supply);
+    assert_eq!(supply, 1_363_500_000_031);
 
-    // Alice withdraws all 900,000,000 shares in kind: her 900/1363.5 slice of each vault.
-    do_withdraw(&mut ctx, &alice, 900_000_000, 0);
+    // Alice withdraws all 900 whole shares in kind: her 900/1363.5 slice of each
+    // vault, the divisor being the real supply plus the 1000 virtual shares.
+    do_withdraw(&mut ctx, &alice, 900 * SHARE_UNIT, 0);
     assert_eq!(
         get_token_account_balance(&ctx.svm, &derive_ata(&alice.pubkey(), &ctx.tsla_mint)).unwrap(),
         1_520_792
@@ -1401,5 +1440,113 @@ fn test_full_lifecycle() {
         get_token_account_balance(&ctx.svm, &derive_ata(&alice.pubkey(), &ctx.usdc_mint)).unwrap(),
         0
     );
-    assert_eq!(read_strategy(&ctx).total_shares, 463_500_000);
+    assert_eq!(read_strategy(&ctx).total_shares, supply - 900 * SHARE_UNIT);
+}
+
+/// A share-price value in USDC minor units, at the test's oracle prices: USDC
+/// plus TSLAx at $250 plus NVDAx at $180.
+fn value_in_usdc(usdc: u64, tsla: u64, nvda: u64) -> u64 {
+    usdc + tsla * (TSLA_PRICE as u64 / 100_000_000) + nvda * (NVDA_PRICE as u64 / 100_000_000)
+}
+
+/// The first-depositor inflation attack: a dust deposit, then a donation straight
+/// into the strategy's USDC vault, then a 1,000 USDC deposit with no
+/// `minimum_shares` floor. The virtual offset prices the dust deposit at 1000
+/// share minor units, splits the donation between those and the 1000 virtual
+/// shares, and keeps the victim's shares nonzero: they redeem for all but a
+/// fraction of a dollar, while the attacker recovers about half of the donation
+/// and loses the rest to the virtual shares. Modeled on the lending example's
+/// `raw_token_donation_does_not_inflate_exchange_rate`.
+#[test]
+fn test_donation_does_not_inflate_share_price() {
+    let mut ctx = setup_full();
+    standard_strategy(&mut ctx);
+
+    let donation = 1_000_000_000u64; // 1,000 USDC
+    let victim_deposit = 1_000_000_000u64; // 1,000 USDC
+
+    // The attacker deposits one minor unit through the handler. Both deploy legs
+    // floor to zero, so the minor unit stays in the USDC vault, and the offset
+    // prices it at 1 * (0 + 1000) / (0 + 1) = 1000 share minor units.
+    let attacker = fund_user(&mut ctx, 1 + donation);
+    let attacker_share = do_deposit(&mut ctx, &attacker, 1, 0);
+    assert_eq!(
+        get_token_account_balance(&ctx.svm, &attacker_share).unwrap(),
+        VIRTUAL_SHARES
+    );
+
+    // The attacker sends 1,000 USDC straight to the USDC vault with an ordinary
+    // token transfer. The deposit handler never ran, so the supply is still 1000
+    // share minor units, now against a NAV of 1,000.000001 USDC.
+    let donate_ix = spl_token::instruction::transfer(
+        &spl_token::ID,
+        &derive_ata(&attacker.pubkey(), &ctx.usdc_mint),
+        &ctx.vault_usdc,
+        &attacker.pubkey(),
+        &[],
+        donation,
+    )
+    .unwrap();
+    send_transaction_from_instructions(
+        &mut ctx.svm,
+        vec![donate_ix],
+        &[&attacker],
+        &attacker.pubkey(),
+    )
+    .unwrap();
+    assert_eq!(
+        get_token_account_balance(&ctx.svm, &ctx.vault_usdc).unwrap(),
+        1 + donation
+    );
+
+    // The victim deposits 1,000 USDC with no minimum_shares floor. Without the
+    // offset this would be 1,000,000,000 * 1 / 1,000,000,001 = 0 shares. With it:
+    // 1,000,000,000 * (1000 + 1000) / (1,000,000,001 + 1) = 1999 share minor units.
+    let victim = fund_user(&mut ctx, victim_deposit);
+    let victim_share = do_deposit(&mut ctx, &victim, victim_deposit, 0);
+    let victim_shares = get_token_account_balance(&ctx.svm, &victim_share).unwrap();
+    assert!(victim_shares > 0, "the donation must not zero the deposit");
+    assert_eq!(victim_shares, 1_999);
+
+    // The victim redeems everything in kind: 1999 of the 3999 effective shares
+    // (1000 attacker + 1999 victim + 1000 virtual) of each vault, worth all but
+    // about a quarter of a dollar of the 1,000 USDC they put in.
+    do_withdraw(&mut ctx, &victim, victim_shares, 0);
+    let victim_value = value_in_usdc(
+        get_token_account_balance(&ctx.svm, &derive_ata(&victim.pubkey(), &ctx.usdc_mint)).unwrap(),
+        get_token_account_balance(&ctx.svm, &derive_ata(&victim.pubkey(), &ctx.tsla_mint)).unwrap(),
+        get_token_account_balance(&ctx.svm, &derive_ata(&victim.pubkey(), &ctx.nvda_mint)).unwrap(),
+    );
+    assert!(victim_value <= victim_deposit);
+    let victim_loss = victim_deposit - victim_value;
+    assert!(
+        victim_loss < 1_000_000,
+        "victim lost {victim_loss} minor units, more than a dollar"
+    );
+
+    // The attacker redeems their 1000 share minor units: half of what is left,
+    // the other half belonging to the virtual shares, which is to say to nobody.
+    // They put in 1,000.000001 USDC through the handler and the donation together
+    // and get back about 500 USDC, losing about a thousand times the victim's loss.
+    do_withdraw(&mut ctx, &attacker, VIRTUAL_SHARES, 0);
+    let attacker_value = value_in_usdc(
+        get_token_account_balance(&ctx.svm, &derive_ata(&attacker.pubkey(), &ctx.usdc_mint))
+            .unwrap(),
+        get_token_account_balance(&ctx.svm, &derive_ata(&attacker.pubkey(), &ctx.tsla_mint))
+            .unwrap(),
+        get_token_account_balance(&ctx.svm, &derive_ata(&attacker.pubkey(), &ctx.nvda_mint))
+            .unwrap(),
+    );
+    let attacker_in = 1 + donation;
+    assert!(
+        attacker_value < attacker_in,
+        "the attack must not pay: put in {attacker_in}, got back {attacker_value}"
+    );
+    let attacker_loss = attacker_in - attacker_value;
+    assert!(
+        attacker_loss >= VIRTUAL_SHARES * victim_loss,
+        "attacker lost {attacker_loss}, victim lost {victim_loss}"
+    );
+    assert!(attacker_value <= attacker_in / 2 + 1_000_000);
+    assert_eq!(read_strategy(&ctx).total_shares, 0);
 }

--- a/finance/vault-strategy/anchor/CHANGELOG.md
+++ b/finance/vault-strategy/anchor/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2026-09-08
+
+### Changed
+
+- **Virtual shares and virtual assets.** Every share-price division now adds `VIRTUAL_SHARES` (1,000, `10^SHARE_DECIMALS_OFFSET`) to the real supply and `VIRTUAL_ASSETS` (one USDC minor unit) to the net asset value: `deposit` mints `usdc × (total_shares + 1,000) / (NAV + 1)` and `withdraw` pays `balance × shares / (total_shares + 1,000)` per vault. This is the defense against the first-depositor inflation attack (a dust deposit, a donation straight into a vault, then a deposit that floors to zero shares): a deposit now floors to zero only when the strategy already holds more than a thousand times it, and whoever inflated it that far loses about a thousand times what the depositor loses. The `total_shares == 0` special case in `deposit` is gone; `minimum_shares` and `SlippageTooHigh` stay.
+- **Share mint decimals 6 → 9** (`SHARE_DECIMALS`, USDC's six plus the offset of three), so one whole share still tracks one USDC at launch: a 900 USDC first deposit mints 900,000,000,000 share minor units, which reads as 900 shares. Clients that formatted shares at six decimals must use nine.
+- `collect_fees` is unchanged and dilutes the real supply only; the virtual shares earn the manager nothing.
+
+### Added
+
+- `test_donation_does_not_inflate_share_price` runs the attack against the live program: one minor unit deposited, 1,000 USDC transferred straight to the USDC vault, then a 1,000 USDC deposit with `minimum_shares` = 0. The victim's shares are nonzero and redeem for about 999.75 USDC; the attacker's redeem for about 500 USDC.
+- The Kani proof crate models the offset and adds `proof_first_deposit_is_priced_by_the_offset` and `proof_donation_cannot_zero_a_deposit`.
+
 ## 2026-07-20
 
 - **`WhitelistEntry` renamed `ApprovedAsset`** (and `whitelist_asset` renamed `approve_asset`, PDA seed `"whitelist"` renamed `"approved_asset"`), naming the account after what it is: one curator-approved asset bound to its official price feed. The unused `AssetNotWhitelisted` error is removed; approval is checked by the `ApprovedAsset` account's existence. Doc comments and README now state that the `Registry` account is the curator record at the root of the approved set, not the list itself.

--- a/finance/vault-strategy/anchor/PRODUCT.md
+++ b/finance/vault-strategy/anchor/PRODUCT.md
@@ -41,7 +41,7 @@ Program instructions the frontend can surface:
 Rules the UI must respect and reflect:
 
 - Deposits are accepted only when target weights sum to **exactly 10,000 bps**; a strategy is either still being configured or fully allocated and live (`StrategyNotFullyAllocated` otherwise).
-- Shares: first deposit is 1:1 with USDC minor units; later deposits mint `deposit_usdc × total_shares / NAV`. Share mint is a PDA owned by the strategy PDA.
+- Shares: every deposit, the first included, mints `deposit_usdc × (total_shares + 1,000 virtual shares) / (NAV + 1 virtual minor unit)`, floored. The share mint has 9 decimals (`SHARE_DECIMALS`: USDC's 6 plus a 3-decimal offset), so one whole share tracks one USDC at launch and a 900 USDC first deposit shows as 900 shares. The virtual offset is the first-depositor inflation defense; withdrawals divide by `total_shares` + 1,000 so the virtual shares' slice of each vault stays behind. Share mint is a PDA owned by the strategy PDA.
 - Management fee is charged by minting new shares to the manager (dilution), fixed at creation, capped at `MAX_FEE_BPS` = 1,000 bps (10%), no setter to raise it. `collect_fees` is permissionless.
 - Slippage floors are computed on-chain from the Pyth price and `max_slippage_bps` (capped at 1,000 bps); a manager-supplied minimum is not trusted.
 - `MAX_ASSETS` = 16. `deposit` re-derives the full `0..asset_count` PDA range and refuses to run if any asset account is missing (`IncompleteAssetAccounts`), so NAV can't be understated.

--- a/finance/vault-strategy/anchor/README.md
+++ b/finance/vault-strategy/anchor/README.md
@@ -37,8 +37,10 @@ Prices come from [Pyth Network](https://pyth.network/) `PriceUpdateV2` accounts.
 
 A [share](https://www.investopedia.com/terms/s/shares.asp) represents a fraction of the whole strategy. Hold 1% of shares and you own 1% of every vault.
 
-- **First deposit**: shares are issued 1:1 with USDC minor units (initial price of 1 USDC per share).
-- **Later deposits**: `shares_to_mint = deposit_usdc × total_shares / NAV`.
+- **Every deposit**, the first included: `shares_to_mint = deposit_usdc × (total_shares + VIRTUAL_SHARES) / (NAV + VIRTUAL_ASSETS)`, floored.
+- **The virtual offset** is the defense against the first-depositor inflation attack. `VIRTUAL_SHARES` is 1,000 (`10^SHARE_DECIMALS_OFFSET`) and `VIRTUAL_ASSETS` is one USDC minor unit, so an empty strategy already has a share price and there is no special case for the first deposit. The share mint has `SHARE_DECIMALS` = 9 decimals, USDC's six plus the offset of three, so one whole share still tracks one USDC at launch: a 900 USDC first deposit mints 900,000,000,000 share minor units, which reads as 900 shares.
+- **Why it is safe**: tokens sent straight to a vault count as fund value the moment they arrive, so without the offset a dust first deposit followed by a donation could price one share above the next deposit, which would floor to zero shares. With it, a deposit floors to zero only when the strategy already holds more than a thousand times it, and a donation is split between the real shares and the virtual ones, so an attacker loses about a thousand times what the next depositor loses. Deposit one minor unit, donate 1,000 USDC, and a following 1,000 USDC deposit still mints 1,999 share minor units that redeem for about 999.75 USDC; the attacker's 1,000 share minor units redeem for about 500 USDC. Pinned by `test_donation_does_not_inflate_share_price`.
+- **Withdrawals** pay `vault_balance × shares / (total_shares + VIRTUAL_SHARES)` per vault, floored, so the virtual shares' slice of every vault (at most 1,000 parts in `total_shares` + 1,000) is never paid out.
 - Shares are [SPL tokens](https://solana.com/docs/terminology#token); the share mint's address is a [PDA](https://solana.com/docs/terminology#program-derived-address-pda), so it is deterministic and the strategy PDA is its mint authority.
 
 ### Management Fee
@@ -49,7 +51,7 @@ A [management fee](https://www.investopedia.com/terms/m/managementfee.asp), in [
 fee_shares = total_shares × fee_bps × elapsed_seconds / (10_000 × 31_536_000)
 ```
 
-`collect_fees` is permissionless. The fee is fixed at creation and capped at `MAX_FEE_BPS` (1,000 bps = 10%); there is no setter to raise it later.
+The fee dilutes the real supply only: the virtual shares hold nothing of anyone's and earn the manager nothing. `collect_fees` is permissionless. The fee is fixed at creation and capped at `MAX_FEE_BPS` (1,000 bps = 10%); there is no setter to raise it later.
 
 ### Weights and Rebalancing
 
@@ -92,7 +94,7 @@ An [in-kind distribution](https://www.investopedia.com/terms/i/in-kind.asp) retu
 
 ### Alice deposits, and her money is deployed at once
 
-`deposit(usdc_amount, minimum_shares)`, with each asset's `[asset_config, vault, mint, rate, price_feed]` passed as remaining accounts, plus the router accounts. The handler requires the strategy to be fully allocated, values every asset for NAV (first deposit is 1:1), mints shares to Alice, then deploys her USDC across the basket at its target weights through the router, each leg under an oracle slippage floor. With the weights at 40/60, a 900 USDC deposit lands as 1.44 TSLAx and 3.0 NVDAx with no idle USDC.
+`deposit(usdc_amount, minimum_shares)`, with each asset's `[asset_config, vault, mint, rate, price_feed]` passed as remaining accounts, plus the router accounts. The handler requires the strategy to be fully allocated, values every asset for NAV, prices her shares with the virtual offset (900 USDC into the empty strategy mints 900 whole shares), mints them to Alice, then deploys her USDC across the basket at its target weights through the router, each leg under an oracle slippage floor. With the weights at 40/60, a 900 USDC deposit lands as 1.44 TSLAx and 3.0 NVDAx with no idle USDC.
 
 ### Bob deposits at the current share price
 
@@ -157,7 +159,7 @@ cargo build-sbf --manifest-path programs/vault-strategy/Cargo.toml
 cargo test --manifest-path programs/vault-strategy/Cargo.toml
 ```
 
-Tests live in `programs/vault-strategy/tests/vault_strategy.rs` and use [LiteSVM](https://github.com/LiteSVM/litesvm). Both `.so` files are loaded from `target/deploy/`, so build before testing. The suite covers the full lifecycle end to end (deposit with auto-deployment, a price move, rebalance back to target, a second depositor priced at the new NAV, a year's fee, in-kind withdrawal), retiring an asset with `set_weight` and reallocating to reopen deposits, and the rejection paths: unapproved asset, weight overflow, over-cap fee and slippage, oracle-bounded deposit slippage, an under-allocated strategy, non-manager `set_weight`, unregistered router, and incomplete asset accounts on deposit.
+Tests live in `programs/vault-strategy/tests/vault_strategy.rs` and use [LiteSVM](https://github.com/LiteSVM/litesvm). Both `.so` files are loaded from `target/deploy/`, so build before testing. The suite covers the full lifecycle end to end (deposit with auto-deployment, a price move, rebalance back to target, a second depositor priced at the new NAV, a year's fee, in-kind withdrawal), retiring an asset with `set_weight` and reallocating to reopen deposits, and the rejection paths: unapproved asset, weight overflow, over-cap fee and slippage, oracle-bounded deposit slippage, an under-allocated strategy, non-manager `set_weight`, unregistered router, and incomplete asset accounts on deposit. `test_donation_does_not_inflate_share_price` runs the first-depositor inflation attack (a one-minor-unit deposit, a 1,000 USDC donation straight into the USDC vault, then a 1,000 USDC deposit with no `minimum_shares` floor) and checks that the victim's shares are nonzero and redeem for all but a fraction of a dollar while the attacker loses about a thousand times as much.
 
 ## FAQ
 
@@ -167,7 +169,7 @@ A manager creates a strategy with `initialize_strategy`, registers curator-appro
 
 ### How are share prices calculated?
 
-Shares are priced at the strategy's net asset value: the total value of the vault balances at current prices divided by shares outstanding. A later depositor pays the current share price rather than diluting earlier ones.
+Shares are priced at the strategy's net asset value: the total value of the vault balances at current prices, plus one virtual minor unit, divided by shares outstanding plus 1,000 virtual shares. A later depositor pays the current share price rather than diluting earlier ones, and the virtual offset keeps the price defined and the first depositor honest when the strategy is empty.
 
 ### How does the manager operate the fund?
 

--- a/finance/vault-strategy/anchor/app/src/components/ActionTicket.tsx
+++ b/finance/vault-strategy/anchor/app/src/components/ActionTicket.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { applyToleranceFloor, estimateRedeem, estimateSharesOut, parseAmount } from "../lib/amounts";
 import { describeError } from "../lib/tx";
+import { SHARE_DECIMALS } from "../solana/config";
 import { formatShares, formatUnits, formatUsdc, shortAddress } from "../solana/format";
 import type { Position, StrategyView } from "../solana/strategy";
 import { Button, Segmented, StatusLine, TextField, type TxStatus } from "./atoms";
@@ -61,7 +62,7 @@ export function ActionTicket({ view, connected, walletUsdc, position, onDeposit,
     (walletUsdc === null || usdcMinor <= walletUsdc);
 
   // redeem derivations
-  const sharesMinor = parseAmount(redeemInput, 6);
+  const sharesMinor = parseAmount(redeemInput, SHARE_DECIMALS);
   const redeemInvalid = redeemInput.trim() !== "" && sharesMinor === null;
   const redeemEst = sharesMinor !== null && sharesMinor > 0n ? estimateRedeem(sharesMinor, view) : null;
 
@@ -167,7 +168,7 @@ export function ActionTicket({ view, connected, walletUsdc, position, onDeposit,
               right={
                 <button
                   type="button"
-                  onClick={() => setRedeemInput(rawAmount(shares))}
+                  onClick={() => setRedeemInput(rawAmount(shares, SHARE_DECIMALS))}
                   className="tabular-nums transition-colors hover:text-accent"
                 >
                   Balance {formatShares(shares)} · Max

--- a/finance/vault-strategy/anchor/app/src/lib/amounts.ts
+++ b/finance/vault-strategy/anchor/app/src/lib/amounts.ts
@@ -1,3 +1,4 @@
+import { VIRTUAL_ASSETS, VIRTUAL_SHARES } from "../solana/config";
 import type { StrategyView } from "../solana/strategy";
 
 /** Parse a decimal string into minor units. Returns null if malformed or over-precise. */
@@ -12,17 +13,19 @@ export function parseAmount(input: string, decimals: number): bigint | null {
   return w * 10n ** BigInt(decimals) + f;
 }
 
-/** Shares a deposit would mint, matching the program: first deposit 1:1, else usdc*shares/nav. */
+/**
+ * Shares a deposit would mint, matching the program:
+ * usdc * (shares + VIRTUAL_SHARES) / (nav + VIRTUAL_ASSETS), floored. The virtual
+ * offset prices the empty strategy too, so there is no first-deposit special case.
+ */
 export function estimateSharesOut(usdcMinor: bigint, navMinor: bigint, totalShares: bigint): bigint {
-  if (totalShares === 0n) return usdcMinor;
-  if (navMinor === 0n) return 0n;
-  return (usdcMinor * totalShares) / navMinor;
+  return (usdcMinor * (totalShares + VIRTUAL_SHARES)) / (navMinor + VIRTUAL_ASSETS);
 }
 
 export interface RedeemLeg {
   index: number;
   mint: string;
-  amountMinor: bigint; // 6dp
+  amountMinor: bigint; // the asset's own minor units (6dp for the example assets)
 }
 
 export interface RedeemEstimate {
@@ -30,7 +33,11 @@ export interface RedeemEstimate {
   legs: RedeemLeg[];
 }
 
-/** The in-kind slice a redemption pays out, matching withdraw's proportional math. */
+/**
+ * The in-kind slice a redemption pays out, matching withdraw's proportional math:
+ * balance * shares / (totalShares + VIRTUAL_SHARES) per vault, so the virtual
+ * shares' slice of every vault stays behind.
+ */
 export function estimateRedeem(sharesMinor: bigint, view: StrategyView): RedeemEstimate {
   if (view.totalShares === 0n || sharesMinor <= 0n) {
     return {
@@ -38,11 +45,12 @@ export function estimateRedeem(sharesMinor: bigint, view: StrategyView): RedeemE
       legs: view.assets.map((a) => ({ index: a.index, mint: a.mint.toBase58(), amountMinor: 0n })),
     };
   }
-  const usdcMinor = (view.usdcAmount * sharesMinor) / view.totalShares;
+  const divisor = view.totalShares + VIRTUAL_SHARES;
+  const usdcMinor = (view.usdcAmount * sharesMinor) / divisor;
   const legs = view.assets.map((a) => ({
     index: a.index,
     mint: a.mint.toBase58(),
-    amountMinor: (a.vaultAmount * sharesMinor) / view.totalShares,
+    amountMinor: (a.vaultAmount * sharesMinor) / divisor,
   }));
   return { usdcMinor, legs };
 }

--- a/finance/vault-strategy/anchor/app/src/solana/config.ts
+++ b/finance/vault-strategy/anchor/app/src/solana/config.ts
@@ -34,4 +34,13 @@ export const MAX_SLIPPAGE_BPS = 1_000; // 10%
 export const BPS_DENOMINATOR = 10_000;
 export const PYTH_PRICE_PRECISION = 100_000_000n; // 10^8, Pyth exponent -8
 export const MAX_PRICE_AGE_SECONDS = 60;
-export const SHARE_DECIMALS = 6; // share_mint is created with mint::decimals = 6
+// The share mint has USDC's 6 decimals plus SHARE_DECIMALS_OFFSET, so one whole
+// share tracks one USDC at launch (state/strategy.rs: SHARE_DECIMALS).
+export const SHARE_DECIMALS_OFFSET = 3;
+export const SHARE_DECIMALS = 6 + SHARE_DECIMALS_OFFSET;
+/** One whole share in share-mint minor units. */
+export const SHARE_UNIT = 10n ** BigInt(SHARE_DECIMALS);
+// The virtual offset every share-price division carries (state/strategy.rs):
+// 10^SHARE_DECIMALS_OFFSET virtual shares behind one virtual USDC minor unit.
+export const VIRTUAL_SHARES = 10n ** BigInt(SHARE_DECIMALS_OFFSET);
+export const VIRTUAL_ASSETS = 1n;

--- a/finance/vault-strategy/anchor/app/src/solana/format.ts
+++ b/finance/vault-strategy/anchor/app/src/solana/format.ts
@@ -1,5 +1,5 @@
 import type { PublicKey } from "@solana/web3.js";
-import { CLUSTER, RPC_URL } from "./config";
+import { CLUSTER, RPC_URL, SHARE_DECIMALS } from "./config";
 
 function groupThousands(intDigits: string): string {
   return intDigits.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
@@ -19,9 +19,9 @@ export function formatUnits(minor: bigint, decimals: number, frac = 2): string {
 /** USDC amount (6dp minor units) → "1,363.50". */
 export const formatUsdc = (minor: bigint, frac = 2): string => formatUnits(minor, 6, frac);
 
-/** Share amount (6dp minor units) → "900.000000", trailing zeros trimmed to `minFrac`. */
+/** Share amount (SHARE_DECIMALS minor units) → "900.000000000", trailing zeros trimmed to `minFrac`. */
 export function formatShares(minor: bigint, minFrac = 2): string {
-  const full = formatUnits(minor, 6, 6);
+  const full = formatUnits(minor, SHARE_DECIMALS, SHARE_DECIMALS);
   if (!full.includes(".")) return full;
   const [w, f] = full.split(".");
   const trimmed = f.replace(/0+$/, "");

--- a/finance/vault-strategy/anchor/app/src/solana/strategy.ts
+++ b/finance/vault-strategy/anchor/app/src/solana/strategy.ts
@@ -1,7 +1,14 @@
 import type { BN } from "@coral-xyz/anchor";
 import type { Connection, PublicKey } from "@solana/web3.js";
 import type { AssetConfigAccount, StrategyAccount } from "../idl/vaultStrategy";
-import { MAX_PRICE_AGE_SECONDS, PYTH_PRICE_PRECISION, STRATEGY_INDEX } from "./config";
+import {
+  MAX_PRICE_AGE_SECONDS,
+  PYTH_PRICE_PRECISION,
+  SHARE_UNIT,
+  STRATEGY_INDEX,
+  VIRTUAL_ASSETS,
+  VIRTUAL_SHARES,
+} from "./config";
 import { assetConfigPda, shareMintPda, strategyPda, userAta, vaultAta } from "./pdas";
 import type { VaultProgram } from "./program";
 import { parsePriceUpdateV2, readTokenAmount } from "./pyth";
@@ -176,7 +183,9 @@ export async function loadStrategyView(
   }
 
   const totalShares = toBig(account.totalShares);
-  const navPerShareMinor = totalShares > 0n ? (navMinor * 1_000_000n) / totalShares : 1_000_000n;
+  // USDC minor units per whole share, priced the way the program prices a deposit:
+  // (nav + VIRTUAL_ASSETS) / (shares + VIRTUAL_SHARES), scaled to one whole share.
+  const navPerShareMinor = ((navMinor + VIRTUAL_ASSETS) * SHARE_UNIT) / (totalShares + VIRTUAL_SHARES);
 
   return {
     exists: true,

--- a/finance/vault-strategy/anchor/programs/vault-strategy/src/instructions/collect_fees.rs
+++ b/finance/vault-strategy/anchor/programs/vault-strategy/src/instructions/collect_fees.rs
@@ -61,6 +61,10 @@ pub fn handle_collect_fees(context: &mut Context<CollectFeesAccountConstraints>)
     let strategy_bump = context.accounts.strategy.bump;
 
     // fee_shares = total_shares * fee_bps * elapsed / (10_000 * SECONDS_PER_YEAR)
+    //
+    // The fee is a percentage of what depositors hold, so it dilutes against the
+    // real supply only. The virtual shares that price deposits and withdrawals
+    // hold nothing of anyone's and earn the manager nothing.
     let denominator = (10_000u128)
         .checked_mul(SECONDS_PER_YEAR as u128)
         .ok_or(VaultError::MathOverflow)?;

--- a/finance/vault-strategy/anchor/programs/vault-strategy/src/instructions/deposit.rs
+++ b/finance/vault-strategy/anchor/programs/vault-strategy/src/instructions/deposit.rs
@@ -9,7 +9,7 @@ use mock_swap_router::cpi::accounts::SwapUsdcForAssetAccountConstraints as Route
 
 use crate::error::VaultError;
 use crate::oracle::{asset_value_in_usdc, load_price, read_token_amount, PYTH_PRICE_PRECISION};
-use crate::state::{AssetConfig, Strategy};
+use crate::state::{AssetConfig, Strategy, VIRTUAL_ASSETS, VIRTUAL_SHARES};
 
 #[derive(Accounts)]
 pub struct DepositAccountConstraints {
@@ -152,16 +152,30 @@ pub fn handle_deposit(
             .ok_or(VaultError::MathOverflow)?;
     }
 
-    // shares = usdc_amount * total_shares / nav (floor); first deposit is 1:1.
-    let shares_to_mint: u64 = if total_shares == 0 {
-        usdc_amount
-    } else {
-        (usdc_amount as u128)
-            .checked_mul(total_shares as u128)
-            .ok_or(VaultError::MathOverflow)?
-            .checked_div(nav)
-            .ok_or(VaultError::MathOverflow)? as u64
-    };
+    // shares = usdc_amount * (total_shares + VIRTUAL_SHARES) / (nav + VIRTUAL_ASSETS),
+    // floored in the fund's favour.
+    //
+    // The virtual offset is the defense against the first-depositor inflation
+    // attack. Tokens sent straight to a vault count as fund value the moment they
+    // arrive, so without it a dust-sized first deposit followed by a donation
+    // could price one share at more than the next deposit, which then floors to
+    // zero shares. With `VIRTUAL_SHARES` (10^3) standing behind one virtual minor
+    // unit, an empty fund already has a share price: the first deposit mints a
+    // thousand share minor units per USDC minor unit, which at nine share
+    // decimals is one whole share per USDC, and a donation is split between the
+    // real shares and the virtual ones. A deposit floors to zero only when the
+    // fund already holds more than a thousand times it, and whoever inflated the
+    // fund that far loses about a thousand times what the depositor loses.
+    let shares_to_mint: u64 = (usdc_amount as u128)
+        .checked_mul(total_shares as u128 + VIRTUAL_SHARES as u128)
+        .ok_or(VaultError::MathOverflow)?
+        .checked_div(
+            nav.checked_add(VIRTUAL_ASSETS as u128)
+                .ok_or(VaultError::MathOverflow)?,
+        )
+        .ok_or(VaultError::MathOverflow)?
+        .try_into()
+        .map_err(|_| VaultError::MathOverflow)?;
 
     require!(
         shares_to_mint >= minimum_shares,

--- a/finance/vault-strategy/anchor/programs/vault-strategy/src/instructions/initialize_strategy.rs
+++ b/finance/vault-strategy/anchor/programs/vault-strategy/src/instructions/initialize_strategy.rs
@@ -11,7 +11,7 @@ use anchor_spl::{
 };
 
 use crate::error::VaultError;
-use crate::state::{Registry, Strategy};
+use crate::state::{Registry, Strategy, SHARE_DECIMALS};
 
 /// Highest annual management fee a manager may set, in basis points (10%).
 /// `collect_fees` mints shares to the manager and dilutes every depositor,
@@ -48,7 +48,7 @@ pub struct InitializeStrategyAccountConstraints {
     #[account(
         init,
         payer = manager,
-        mint::decimals = 6,
+        mint::decimals = SHARE_DECIMALS,
         mint::authority = strategy,
         mint::freeze_authority = strategy,
         mint::token_program = token_program,

--- a/finance/vault-strategy/anchor/programs/vault-strategy/src/instructions/withdraw.rs
+++ b/finance/vault-strategy/anchor/programs/vault-strategy/src/instructions/withdraw.rs
@@ -8,7 +8,7 @@ use anchor_spl::{
 
 use crate::error::VaultError;
 use crate::oracle::{read_mint_decimals, read_token_amount, read_token_mint_and_owner};
-use crate::state::{AssetConfig, Strategy};
+use crate::state::{AssetConfig, Strategy, VIRTUAL_SHARES};
 
 #[derive(Accounts)]
 pub struct WithdrawAccountConstraints {
@@ -89,7 +89,11 @@ pub fn handle_withdraw(
     );
 
     let shares_u128 = shares_to_burn as u128;
-    let total_u128 = total_shares as u128;
+    // Every leg pays balance * shares / (total_shares + VIRTUAL_SHARES). The
+    // virtual shares hold their slice of every vault and are never burned, so
+    // even the last real holder leaves that slice behind: at most
+    // VIRTUAL_SHARES parts in (total_shares + VIRTUAL_SHARES) of each balance.
+    let total_u128 = total_shares as u128 + VIRTUAL_SHARES as u128;
 
     // USDC leg, floored in the protocol's favour.
     let amount_usdc: u64 = (vault_usdc_amount as u128)

--- a/finance/vault-strategy/anchor/programs/vault-strategy/src/state/strategy.rs
+++ b/finance/vault-strategy/anchor/programs/vault-strategy/src/state/strategy.rs
@@ -11,6 +11,33 @@ use anchor_lang::prelude::*;
 /// currency, held separately, and does not count against this.
 pub const MAX_ASSETS: u8 = 16;
 
+/// Decimals of the share mint: USDC's six plus `SHARE_DECIMALS_OFFSET`, so one
+/// whole share still tracks one USDC at launch (a 900 USDC first deposit reads
+/// as 900 shares) while the supply carries three more digits than the USDC it
+/// prices.
+pub const SHARE_DECIMALS: u8 = 6 + SHARE_DECIMALS_OFFSET;
+
+/// How many more decimals the share mint has than USDC. This is the vault's
+/// first-depositor defense (virtual shares and virtual assets, the ERC-4626
+/// "decimals offset"): every exchange-rate division adds `VIRTUAL_SHARES` to
+/// the share supply and `VIRTUAL_ASSETS` to the net asset value, so an empty
+/// fund already has a share price (one minor unit of USDC per `10^OFFSET` share
+/// minor units), the `total_shares == 0` case needs no special branch, and a
+/// donation straight into a vault is shared with shares nobody holds. An
+/// attacker inflating the share price loses about `10^OFFSET` times whatever
+/// the next depositor loses to rounding. Three leaves `total_shares: u64` room
+/// for about eighteen billion whole shares.
+pub const SHARE_DECIMALS_OFFSET: u8 = 3;
+
+/// Virtual shares added to the real supply in every share-price division:
+/// `10^SHARE_DECIMALS_OFFSET`. They are never minted, never burned, and their
+/// slice of every vault is never paid out.
+pub const VIRTUAL_SHARES: u64 = 10u64.pow(SHARE_DECIMALS_OFFSET as u32);
+
+/// Virtual assets added to the net asset value in every share-price division:
+/// one USDC minor unit, backing the virtual shares.
+pub const VIRTUAL_ASSETS: u64 = 1;
+
 /// One strategy (basket). Its address is a PDA seeded by a caller-chosen index,
 /// e.g. seeds `"strategy" + 0`, so strategies are addressed by a simple counter
 /// rather than by the manager's key. The index is stored here so every handler

--- a/finance/vault-strategy/anchor/programs/vault-strategy/tests/vault_strategy.rs
+++ b/finance/vault-strategy/anchor/programs/vault-strategy/tests/vault_strategy.rs
@@ -13,6 +13,7 @@ use {
         get_token_account_balance, mint_tokens_to_token_account,
         send_transaction_from_instructions,
     },
+    vault_strategy::state::{SHARE_DECIMALS, VIRTUAL_SHARES},
 };
 
 fn token_program_id() -> Address {
@@ -85,6 +86,11 @@ const TSLA_PRICE: i64 = 25_000_000_000; // $250
 const NVDA_PRICE: i64 = 18_000_000_000; // $180
 const TSLA_RATE: u64 = 250; // router usdc per token
 const NVDA_RATE: u64 = 180;
+
+/// One whole share in share-mint minor units. The share mint has USDC's six
+/// decimals plus the program's three-decimal virtual-share offset, so a 900
+/// USDC first deposit mints 900 whole shares, or 900 * SHARE_UNIT minor units.
+const SHARE_UNIT: u64 = 10u64.pow(SHARE_DECIMALS as u32);
 
 const FEE_BPS: u16 = 100; // 1%
 const SLIPPAGE_BPS: u16 = 100; // 1%
@@ -734,6 +740,15 @@ fn test_initialize_and_add_assets() {
     assert_eq!(strategy.max_slippage_bps, SLIPPAGE_BPS);
     assert_eq!(strategy.registry, ctx.registry_pda);
 
+    // The share mint carries USDC's six decimals plus the virtual-share offset.
+    // Token mint layout: supply is the u64 at bytes 36..44, decimals the byte at 44.
+    let share_mint = ctx.svm.get_account(&ctx.share_mint_pda).unwrap().data;
+    assert_eq!(
+        u64::from_le_bytes(share_mint[36..44].try_into().unwrap()),
+        0
+    );
+    assert_eq!(share_mint[44], SHARE_DECIMALS);
+
     let cfg0 = ctx.svm.get_account(&ctx.asset_config(0)).unwrap();
     let asset0 = vault_strategy::state::AssetConfig::try_deserialize(&mut &cfg0.data[..]).unwrap();
     assert_eq!(asset0.mint, ctx.tsla_mint);
@@ -908,13 +923,19 @@ fn test_deposit_first() {
 
     let amount = 1_000_000u64; // 1 USDC
     let user = fund_user(&mut ctx, amount);
-    let user_share = do_deposit(&mut ctx, &user, amount, amount);
+    let user_share = do_deposit(&mut ctx, &user, amount, SHARE_UNIT);
 
-    // First deposit is 1:1, then deployed at 40/60: 0.4 USDC -> TSLAx, 0.6 -> NVDAx,
-    // leaving no idle USDC.
+    // The first deposit is priced by the virtual offset: 1 USDC minor unit buys
+    // VIRTUAL_SHARES share minor units, so 1 USDC mints exactly one whole share.
+    // It is then deployed at 40/60: 0.4 USDC -> TSLAx, 0.6 -> NVDAx, leaving no
+    // idle USDC.
     assert_eq!(
         get_token_account_balance(&ctx.svm, &user_share).unwrap(),
-        amount
+        amount * VIRTUAL_SHARES
+    );
+    assert_eq!(
+        get_token_account_balance(&ctx.svm, &user_share).unwrap(),
+        SHARE_UNIT
     );
     assert_eq!(
         get_token_account_balance(&ctx.svm, &ctx.vault_usdc).unwrap(),
@@ -1006,34 +1027,37 @@ fn test_deposit_fair_pricing() {
     let mut ctx = setup_full();
     standard_strategy(&mut ctx);
 
-    // Alice deposits 900 USDC (first deposit 1:1 -> 900,000,000 shares), auto-deployed
-    // 40/60: 1.44 TSLAx + 3.0 NVDAx. NAV = 900 USDC.
+    // Alice deposits 900 USDC into the empty fund: 900,000,000 minor units times
+    // (0 + 1000 virtual shares) over (0 + 1 virtual minor unit) = 900 whole shares.
+    // Auto-deployed 40/60: 1.44 TSLAx + 3.0 NVDAx. NAV = 900 USDC.
     let alice = fund_user(&mut ctx, 900_000_000);
     let alice_share = do_deposit(&mut ctx, &alice, 900_000_000, 1);
     assert_eq!(
         get_token_account_balance(&ctx.svm, &alice_share).unwrap(),
-        900_000_000
+        900 * SHARE_UNIT
     );
 
     // NVDAx rises 180 -> 200. NAV rises to 0 + 1.44*250 + 3.0*200 = 960 USDC.
     set_nvda_price(&mut ctx, 20_000_000_000, 200);
 
-    // Bob deposits 480 USDC at the higher NAV: shares = 480 * 900 / 960 = 450,000,000.
-    // He pays today's price, so he does not dilute Alice's gain.
+    // Bob deposits 480 USDC at the higher NAV: shares = 480 * 900 / 960 = 450 whole
+    // shares. He pays today's price, so he does not dilute Alice's gain. The
+    // virtual offset shows up 10 digits down: 480,000,000 * (900 * SHARE_UNIT +
+    // 1000) / (960,000,000 + 1) floors to 450,000,000,031 minor units.
     let bob = fund_user(&mut ctx, 480_000_000);
     let bob_share = do_deposit(&mut ctx, &bob, 480_000_000, 1);
-    assert_eq!(
-        get_token_account_balance(&ctx.svm, &bob_share).unwrap(),
-        450_000_000
-    );
+    let bob_shares = get_token_account_balance(&ctx.svm, &bob_share).unwrap();
+    assert_eq!(bob_shares / SHARE_UNIT, 450);
+    assert_eq!(bob_shares, 450_000_000_031);
 
     // Alice's shares are untouched; supply is the two deposits combined.
     assert_eq!(
         get_token_account_balance(&ctx.svm, &alice_share).unwrap(),
-        900_000_000
+        900 * SHARE_UNIT
     );
     let strategy = read_strategy(&ctx);
-    assert_eq!(strategy.total_shares, 1_350_000_000);
+    assert_eq!(strategy.total_shares, 900 * SHARE_UNIT + bob_shares);
+    assert_eq!(strategy.total_shares / SHARE_UNIT, 1_350);
 }
 
 #[test]
@@ -1078,10 +1102,11 @@ fn test_collect_fees() {
     advance_one_year(&mut ctx);
     let manager_share = do_collect_fees(&mut ctx);
 
-    // 1% of 1,000,000,000 = 10,000,000 fee shares.
+    // 1% of the 1,000 whole shares the deposit minted = 10 whole shares. The fee
+    // dilutes the real supply only; the virtual shares earn the manager nothing.
     assert_eq!(
         get_token_account_balance(&ctx.svm, &manager_share).unwrap(),
-        10_000_000
+        10 * SHARE_UNIT
     );
 }
 
@@ -1141,16 +1166,27 @@ fn test_withdraw() {
     );
     send_transaction_from_instructions(&mut ctx.svm, vec![ix], &[&user], &user.pubkey()).unwrap();
 
-    // Sole holder withdraws everything in kind: all 16000 TSLAx + 33333 NVDAx, no USDC.
+    // The sole holder withdraws everything in kind. Each leg pays balance * shares
+    // / (shares + 1000 virtual shares), so the virtual shares' slice of each vault
+    // stays behind: one minor unit of TSLAx and one of NVDAx, and no USDC.
     assert_eq!(get_token_account_balance(&ctx.svm, &user_usdc).unwrap(), 0);
     assert_eq!(
         get_token_account_balance(&ctx.svm, &derive_ata(&user.pubkey(), &ctx.tsla_mint)).unwrap(),
-        16_000
+        15_999
     );
     assert_eq!(
         get_token_account_balance(&ctx.svm, &derive_ata(&user.pubkey(), &ctx.nvda_mint)).unwrap(),
-        33_333
+        33_332
     );
+    assert_eq!(
+        get_token_account_balance(&ctx.svm, &ctx.vault_tsla).unwrap(),
+        1
+    );
+    assert_eq!(
+        get_token_account_balance(&ctx.svm, &ctx.vault_nvda).unwrap(),
+        1
+    );
+    assert_eq!(read_strategy(&ctx).total_shares, 0);
 }
 
 #[test]
@@ -1331,12 +1367,12 @@ fn test_full_lifecycle() {
     let mut ctx = setup_full();
     standard_strategy(&mut ctx);
 
-    // Alice deposits 900 USDC -> 900,000,000 shares, deployed to 1.44 TSLAx + 3.0 NVDAx.
+    // Alice deposits 900 USDC -> 900 whole shares, deployed to 1.44 TSLAx + 3.0 NVDAx.
     let alice = fund_user(&mut ctx, 900_000_000);
     let alice_share = do_deposit(&mut ctx, &alice, 900_000_000, 1);
     assert_eq!(
         get_token_account_balance(&ctx.svm, &alice_share).unwrap(),
-        900_000_000
+        900 * SHARE_UNIT
     );
     assert_eq!(
         get_token_account_balance(&ctx.svm, &ctx.vault_tsla).unwrap(),
@@ -1359,13 +1395,13 @@ fn test_full_lifecycle() {
         2_880_000
     );
 
-    // Bob deposits 480 USDC at NAV 960 -> 450,000,000 shares, deployed 40/60.
+    // Bob deposits 480 USDC at NAV 960 -> 450 whole shares (450,000,000,031 minor
+    // units, the last two digits being the virtual offset's rounding), deployed 40/60.
     let bob = fund_user(&mut ctx, 480_000_000);
     let bob_share = do_deposit(&mut ctx, &bob, 480_000_000, 1);
-    assert_eq!(
-        get_token_account_balance(&ctx.svm, &bob_share).unwrap(),
-        450_000_000
-    );
+    let bob_shares = get_token_account_balance(&ctx.svm, &bob_share).unwrap();
+    assert_eq!(bob_shares / SHARE_UNIT, 450);
+    assert_eq!(bob_shares, 450_000_000_031);
     assert_eq!(
         get_token_account_balance(&ctx.svm, &ctx.vault_tsla).unwrap(),
         2_304_000
@@ -1375,17 +1411,20 @@ fn test_full_lifecycle() {
         4_320_000
     );
 
-    // A year passes; the manager collects 1% of the 1,350,000,000 supply = 13,500,000.
+    // A year passes; the manager collects 1% of the 1,350 whole-share supply = 13.5
+    // whole shares. The 31 minor units of Bob's rounding earn 0.31, which floors away.
     advance_one_year(&mut ctx);
     let manager_share = do_collect_fees(&mut ctx);
-    assert_eq!(
-        get_token_account_balance(&ctx.svm, &manager_share).unwrap(),
-        13_500_000
-    );
-    assert_eq!(read_strategy(&ctx).total_shares, 1_363_500_000);
+    let fee_shares = get_token_account_balance(&ctx.svm, &manager_share).unwrap();
+    assert_eq!(fee_shares, 13_500_000_000);
+    assert_eq!(fee_shares * 10 / SHARE_UNIT, 135);
+    let supply = 900 * SHARE_UNIT + bob_shares + fee_shares;
+    assert_eq!(read_strategy(&ctx).total_shares, supply);
+    assert_eq!(supply, 1_363_500_000_031);
 
-    // Alice withdraws all 900,000,000 shares in kind: her 900/1363.5 slice of each vault.
-    do_withdraw(&mut ctx, &alice, 900_000_000, 0);
+    // Alice withdraws all 900 whole shares in kind: her 900/1363.5 slice of each
+    // vault, the divisor being the real supply plus the 1000 virtual shares.
+    do_withdraw(&mut ctx, &alice, 900 * SHARE_UNIT, 0);
     assert_eq!(
         get_token_account_balance(&ctx.svm, &derive_ata(&alice.pubkey(), &ctx.tsla_mint)).unwrap(),
         1_520_792
@@ -1398,5 +1437,113 @@ fn test_full_lifecycle() {
         get_token_account_balance(&ctx.svm, &derive_ata(&alice.pubkey(), &ctx.usdc_mint)).unwrap(),
         0
     );
-    assert_eq!(read_strategy(&ctx).total_shares, 463_500_000);
+    assert_eq!(read_strategy(&ctx).total_shares, supply - 900 * SHARE_UNIT);
+}
+
+/// A share-price value in USDC minor units, at the test's oracle prices: USDC
+/// plus TSLAx at $250 plus NVDAx at $180.
+fn value_in_usdc(usdc: u64, tsla: u64, nvda: u64) -> u64 {
+    usdc + tsla * (TSLA_PRICE as u64 / 100_000_000) + nvda * (NVDA_PRICE as u64 / 100_000_000)
+}
+
+/// The first-depositor inflation attack: a dust deposit, then a donation straight
+/// into the strategy's USDC vault, then a 1,000 USDC deposit with no
+/// `minimum_shares` floor. The virtual offset prices the dust deposit at 1000
+/// share minor units, splits the donation between those and the 1000 virtual
+/// shares, and keeps the victim's shares nonzero: they redeem for all but a
+/// fraction of a dollar, while the attacker recovers about half of the donation
+/// and loses the rest to the virtual shares. Modeled on the lending example's
+/// `raw_token_donation_does_not_inflate_exchange_rate`.
+#[test]
+fn test_donation_does_not_inflate_share_price() {
+    let mut ctx = setup_full();
+    standard_strategy(&mut ctx);
+
+    let donation = 1_000_000_000u64; // 1,000 USDC
+    let victim_deposit = 1_000_000_000u64; // 1,000 USDC
+
+    // The attacker deposits one minor unit through the handler. Both deploy legs
+    // floor to zero, so the minor unit stays in the USDC vault, and the offset
+    // prices it at 1 * (0 + 1000) / (0 + 1) = 1000 share minor units.
+    let attacker = fund_user(&mut ctx, 1 + donation);
+    let attacker_share = do_deposit(&mut ctx, &attacker, 1, 0);
+    assert_eq!(
+        get_token_account_balance(&ctx.svm, &attacker_share).unwrap(),
+        VIRTUAL_SHARES
+    );
+
+    // The attacker sends 1,000 USDC straight to the USDC vault with an ordinary
+    // token transfer. The deposit handler never ran, so the supply is still 1000
+    // share minor units, now against a NAV of 1,000.000001 USDC.
+    let donate_ix = spl_token::instruction::transfer(
+        &spl_token::ID,
+        &derive_ata(&attacker.pubkey(), &ctx.usdc_mint),
+        &ctx.vault_usdc,
+        &attacker.pubkey(),
+        &[],
+        donation,
+    )
+    .unwrap();
+    send_transaction_from_instructions(
+        &mut ctx.svm,
+        vec![donate_ix],
+        &[&attacker],
+        &attacker.pubkey(),
+    )
+    .unwrap();
+    assert_eq!(
+        get_token_account_balance(&ctx.svm, &ctx.vault_usdc).unwrap(),
+        1 + donation
+    );
+
+    // The victim deposits 1,000 USDC with no minimum_shares floor. Without the
+    // offset this would be 1,000,000,000 * 1 / 1,000,000,001 = 0 shares. With it:
+    // 1,000,000,000 * (1000 + 1000) / (1,000,000,001 + 1) = 1999 share minor units.
+    let victim = fund_user(&mut ctx, victim_deposit);
+    let victim_share = do_deposit(&mut ctx, &victim, victim_deposit, 0);
+    let victim_shares = get_token_account_balance(&ctx.svm, &victim_share).unwrap();
+    assert!(victim_shares > 0, "the donation must not zero the deposit");
+    assert_eq!(victim_shares, 1_999);
+
+    // The victim redeems everything in kind: 1999 of the 3999 effective shares
+    // (1000 attacker + 1999 victim + 1000 virtual) of each vault, worth all but
+    // about a quarter of a dollar of the 1,000 USDC they put in.
+    do_withdraw(&mut ctx, &victim, victim_shares, 0);
+    let victim_value = value_in_usdc(
+        get_token_account_balance(&ctx.svm, &derive_ata(&victim.pubkey(), &ctx.usdc_mint)).unwrap(),
+        get_token_account_balance(&ctx.svm, &derive_ata(&victim.pubkey(), &ctx.tsla_mint)).unwrap(),
+        get_token_account_balance(&ctx.svm, &derive_ata(&victim.pubkey(), &ctx.nvda_mint)).unwrap(),
+    );
+    assert!(victim_value <= victim_deposit);
+    let victim_loss = victim_deposit - victim_value;
+    assert!(
+        victim_loss < 1_000_000,
+        "victim lost {victim_loss} minor units, more than a dollar"
+    );
+
+    // The attacker redeems their 1000 share minor units: half of what is left,
+    // the other half belonging to the virtual shares, which is to say to nobody.
+    // They put in 1,000.000001 USDC through the handler and the donation together
+    // and get back about 500 USDC, losing about a thousand times the victim's loss.
+    do_withdraw(&mut ctx, &attacker, VIRTUAL_SHARES, 0);
+    let attacker_value = value_in_usdc(
+        get_token_account_balance(&ctx.svm, &derive_ata(&attacker.pubkey(), &ctx.usdc_mint))
+            .unwrap(),
+        get_token_account_balance(&ctx.svm, &derive_ata(&attacker.pubkey(), &ctx.tsla_mint))
+            .unwrap(),
+        get_token_account_balance(&ctx.svm, &derive_ata(&attacker.pubkey(), &ctx.nvda_mint))
+            .unwrap(),
+    );
+    let attacker_in = 1 + donation;
+    assert!(
+        attacker_value < attacker_in,
+        "the attack must not pay: put in {attacker_in}, got back {attacker_value}"
+    );
+    let attacker_loss = attacker_in - attacker_value;
+    assert!(
+        attacker_loss >= VIRTUAL_SHARES * victim_loss,
+        "attacker lost {attacker_loss}, victim lost {victim_loss}"
+    );
+    assert!(attacker_value <= attacker_in / 2 + 1_000_000);
+    assert_eq!(read_strategy(&ctx).total_shares, 0);
 }

--- a/finance/vault-strategy/kani-proofs/README.md
+++ b/finance/vault-strategy/kani-proofs/README.md
@@ -12,19 +12,25 @@ burn shares for a proportional slice of every vault balance; a manager fee mints
 a small slice of shares over time. Token movement is via SPL CPIs Kani cannot
 symbolically execute, but the share math is pure integer arithmetic:
 
-- `proof_withdraw_within_balance`: **Solvency**: a withdrawal never takes more of any vault balance than it holds (`floor(balance·shares/total) <= balance`, since `shares <= total`); burning the whole supply takes exactly the whole balance.
-- `proof_deposit_withdraw_cannot_extract`: A deposit→withdraw round-trip never returns more than was deposited, no rounding attack mints shares worth more than they cost.
-- `proof_fee_shares_bounded_by_supply`: The time-based manager fee can never mint more than 100%/year of dilution (`fee_shares <= total_shares` for `elapsed <= 1yr`, `fee_bps <= 10000`).
+Every share-price division carries the program's virtual offset: `VIRTUAL_SHARES` (1,000, the share mint's three extra decimals over USDC) is added to the real supply and `VIRTUAL_ASSETS` (one USDC minor unit) to the net asset value. That is the first-depositor defense, and the harnesses prove what it buys.
+
+- `proof_withdraw_within_balance`: **Solvency**: a withdrawal never takes more of any vault balance than it holds (`floor(balance·shares/(total + VIRTUAL_SHARES)) < balance` for a positive balance, since `shares <= total`); burning the whole real supply leaves at most the virtual shares' slice behind.
+- `proof_deposit_withdraw_cannot_extract`: A deposit→withdraw round-trip never returns more than was deposited, the empty vault included: no rounding attack mints shares worth more than they cost.
+- `proof_first_deposit_is_priced_by_the_offset`: A deposit into an empty vault mints exactly `VIRTUAL_SHARES` share minor units per USDC minor unit (one whole nine-decimal share per USDC), with no `total_shares == 0` branch.
+- `proof_donation_cannot_zero_a_deposit`: The inflation attack modelled directly (an attacker's first deposit, a donation straight into the vault, the victim's deposit): the victim's deposit mints at least one share whenever the vault holds less than `VIRTUAL_SHARES` times it, whatever the attacker did.
+- `proof_fee_shares_bounded_by_supply`: The time-based manager fee, which dilutes the real supply only, can never mint more than 100%/year of dilution (`fee_shares <= total_shares` for `elapsed <= 1yr`, `fee_bps <= 10000`).
 
 ## Bounded model checking
 
-All three verify nonlinear 128-bit arithmetic with a symbolic divisor (the share
-supply / NAV), so (as percolator does) they bound their symbolic inputs to a
-representative range; the share identities are scale-invariant.
+The nonlinear harnesses verify 128-bit arithmetic with a symbolic divisor (the
+share supply / NAV), so (as percolator does) they bound their symbolic inputs to
+a representative range; the share identities are scale-invariant.
 
-- `proof_withdraw_within_balance`: balances/supply `<= 255`, runs in ~12s
-- `proof_deposit_withdraw_cannot_extract`: `<= 31`, runs in ~3s
-- `proof_fee_shares_bounded_by_supply`: `<= 255`, runs in ~4s
+- `proof_withdraw_within_balance`: balances/supply `<= 255`
+- `proof_deposit_withdraw_cannot_extract`: `<= 31`
+- `proof_first_deposit_is_priced_by_the_offset`: unbounded (linear)
+- `proof_donation_cannot_zero_a_deposit`: deposits `<= 15`, donation `<= 15,000`
+- `proof_fee_shares_bounded_by_supply`: `<= 255`
 
 Run weekly in CI (the `kani.yml` `verify` job), not on every push/PR, because
 the bounded nonlinear proofs are slow. A fast unit-test job runs per push/PR.

--- a/finance/vault-strategy/kani-proofs/src/lib.rs
+++ b/finance/vault-strategy/kani-proofs/src/lib.rs
@@ -11,10 +11,26 @@
 //! integer arithmetic. This crate reproduces it faithfully and proves the
 //! invariants the vault's solvency rests on.
 //!
+//! Every share-price division carries the program's virtual offset: `VIRTUAL_SHARES`
+//! (10^3, the share mint's three extra decimals over USDC) is added to the real
+//! supply and `VIRTUAL_ASSETS` (one USDC minor unit) to the net asset value. That is
+//! the first-depositor defense, and the harnesses prove what it buys: a deposit
+//! into an empty vault mints `VIRTUAL_SHARES` share minor units per USDC minor unit,
+//! and a donation into the vault cannot floor a deposit to zero shares unless the
+//! vault already holds more than `VIRTUAL_SHARES` times that deposit.
+//!
 //! Nonlinear 128-bit harnesses use bounded model checking (small symbolic
 //! inputs), as percolator does; the share identities are scale-invariant.
 
 #![cfg_attr(kani, allow(dead_code))]
+
+/// Virtual shares added to the real supply in every share-price division
+/// (`state::VIRTUAL_SHARES` in the program): `10^SHARE_DECIMALS_OFFSET`.
+pub const VIRTUAL_SHARES: u64 = 1_000;
+
+/// Virtual assets added to the net asset value in every share-price division
+/// (`state::VIRTUAL_ASSETS` in the program): one USDC minor unit.
+pub const VIRTUAL_ASSETS: u64 = 1;
 
 /// `floor((a*b)/d)`, `None` on overflow / zero divisor.
 pub fn mul_div_floor(a: u128, b: u128, d: u128) -> Option<u128> {
@@ -24,24 +40,33 @@ pub fn mul_div_floor(a: u128, b: u128, d: u128) -> Option<u128> {
     a.checked_mul(b)?.checked_div(d)
 }
 
-/// Proportional withdrawal of one vault balance: `floor(balance * shares / total)`
-/// — the formula `handle_withdraw` applies to the USDC leg and to every basket
-/// asset.
+/// Proportional withdrawal of one vault balance:
+/// `floor(balance * shares / (total_shares + VIRTUAL_SHARES))` — the formula
+/// `handle_withdraw` applies to the USDC leg and to every basket asset. The
+/// virtual shares' slice of the balance is never paid out.
 pub fn withdraw_amount(balance: u64, shares_burned: u64, total_shares: u64) -> Option<u64> {
-    mul_div_floor(balance as u128, shares_burned as u128, total_shares as u128)?
-        .try_into()
-        .ok()
+    mul_div_floor(
+        balance as u128,
+        shares_burned as u128,
+        total_shares as u128 + VIRTUAL_SHARES as u128,
+    )?
+    .try_into()
+    .ok()
 }
 
-/// Shares minted for a deposit: `floor(usdc_amount * total_shares / nav)`
-/// (`handle_deposit`; the first deposit, `total_shares == 0`, mints 1:1).
+/// Shares minted for a deposit:
+/// `floor(usdc_amount * (total_shares + VIRTUAL_SHARES) / (nav + VIRTUAL_ASSETS))`
+/// (`handle_deposit`). There is no special case for an empty vault: with
+/// `total_shares == 0` and `nav == 0` the offset alone prices the deposit at
+/// `VIRTUAL_SHARES` share minor units per USDC minor unit.
 pub fn deposit_shares(usdc_amount: u64, total_shares: u64, nav: u64) -> Option<u64> {
-    if total_shares == 0 {
-        return Some(usdc_amount);
-    }
-    mul_div_floor(usdc_amount as u128, total_shares as u128, nav as u128)?
-        .try_into()
-        .ok()
+    mul_div_floor(
+        usdc_amount as u128,
+        total_shares as u128 + VIRTUAL_SHARES as u128,
+        nav as u128 + VIRTUAL_ASSETS as u128,
+    )?
+    .try_into()
+    .ok()
 }
 
 // ===========================================================================
@@ -49,10 +74,13 @@ pub fn deposit_shares(usdc_amount: u64, total_shares: u64, nav: u64) -> Option<u
 // ===========================================================================
 
 /// A withdrawal can never take more of any vault balance than it holds. Because
-/// the burned shares are at most the total supply, the proportional slice
-/// `floor(balance * shares / total)` is `<= balance`. This holds for the USDC
-/// leg and for every in-kind asset leg, so a withdrawal can never overdraw a
-/// vault — the core solvency property.
+/// the burned shares are at most the real supply, and the divisor is the real
+/// supply plus the virtual shares, the proportional slice
+/// `floor(balance * shares / (total + VIRTUAL_SHARES))` is `< balance` whenever
+/// the balance is positive. This holds for the USDC leg and for every in-kind
+/// asset leg, so a withdrawal can never overdraw a vault — the core solvency
+/// property — and burning the entire real supply leaves the virtual shares'
+/// slice, at most `VIRTUAL_SHARES` parts in `total + VIRTUAL_SHARES`, behind.
 #[cfg(kani)]
 #[kani::proof]
 #[kani::solver(cadical)]
@@ -62,16 +90,24 @@ fn proof_withdraw_within_balance() {
     let total_shares: u64 = kani::any();
 
     // Bounded model checking (nonlinear `balance * shares`, symbolic divisor
-    // `total_shares`).
+    // `total_shares + VIRTUAL_SHARES`).
     kani::assume(balance as u128 <= 255);
     kani::assume(total_shares >= 1 && total_shares <= 255);
     kani::assume(shares_burned <= total_shares); // can't burn more than supply
 
     let out = withdraw_amount(balance, shares_burned, total_shares).expect("computes");
     assert!(out <= balance);
-    // And withdrawing the entire supply takes exactly the whole balance.
+    if balance > 0 {
+        // The virtual shares keep their slice: nobody can take a whole balance.
+        assert!(out < balance);
+    }
+    // Withdrawing the entire real supply leaves at most the virtual shares' slice
+    // (rounded up) behind.
     if shares_burned == total_shares {
-        assert_eq!(out, balance);
+        let kept = balance - out;
+        let virtual_slice = (balance as u128 * VIRTUAL_SHARES as u128)
+            / (total_shares as u128 + VIRTUAL_SHARES as u128);
+        assert!(kept as u128 <= virtual_slice + 1);
     }
 }
 
@@ -81,9 +117,11 @@ fn proof_withdraw_within_balance() {
 
 /// In a USDC-only vault (NAV == vault USDC, no basket assets), depositing and
 /// immediately withdrawing the minted shares never returns more USDC than was
-/// deposited. Both legs floor in the protocol's favour, so a deposit/withdraw
-/// round-trip is never profitable — there is no rounding attack that mints
-/// shares worth more than they cost.
+/// deposited. Both legs floor in the protocol's favour, and the offset prices the
+/// deposit against `nav + VIRTUAL_ASSETS` while the withdrawal pays from the real
+/// balance, so a deposit/withdraw round-trip is never profitable — there is no
+/// rounding attack that mints shares worth more than they cost. The bound covers
+/// the empty vault too: `total_shares == 0`, `nav == 0`.
 #[cfg(kani)]
 #[kani::proof]
 #[kani::solver(cadical)]
@@ -92,32 +130,92 @@ fn proof_deposit_withdraw_cannot_extract() {
     let total_shares: u64 = kani::any();
     let nav: u64 = kani::any(); // == vault USDC balance for a USDC-only vault
 
-    // Bounded model checking; an established vault has positive supply and NAV.
+    // Bounded model checking.
     kani::assume(amount <= 31);
-    kani::assume(total_shares >= 1 && total_shares <= 31);
-    kani::assume(nav >= 1 && nav <= 31);
+    kani::assume(total_shares <= 31);
+    kani::assume(nav <= 31);
 
     let minted = deposit_shares(amount, total_shares, nav).expect("computes");
 
     // State after the deposit.
-    let new_total = (total_shares as u128) + (minted as u128);
-    let new_vault = (nav as u128) + (amount as u128);
+    let new_total = total_shares + minted;
+    let new_vault = nav + amount;
 
     // Withdraw exactly the freshly minted shares.
-    let back = mul_div_floor(new_vault, minted as u128, new_total).expect("computes");
-    assert!(back <= amount as u128); // round-trip never profitable
+    let back = withdraw_amount(new_vault, minted, new_total).expect("computes");
+    assert!(back <= amount); // round-trip never profitable
 }
 
 // ===========================================================================
-// 3. Manager fee dilution is bounded
+// 3. The empty vault and the first deposit
+// ===========================================================================
+
+/// A deposit into an empty vault (`total_shares == 0`, `nav == 0`) mints exactly
+/// `VIRTUAL_SHARES` share minor units per USDC minor unit: the offset alone
+/// prices it, with no `total_shares == 0` branch. At the share mint's nine
+/// decimals that is one whole share per USDC, so a 900 USDC first deposit reads
+/// as 900 shares.
+#[cfg(kani)]
+#[kani::proof]
+fn proof_first_deposit_is_priced_by_the_offset() {
+    let amount: u64 = kani::any();
+    kani::assume(amount as u128 * VIRTUAL_SHARES as u128 <= u64::MAX as u128);
+
+    let minted = deposit_shares(amount, 0, 0).expect("computes");
+    assert_eq!(minted, amount * VIRTUAL_SHARES);
+}
+
+// ===========================================================================
+// 4. A donation cannot floor a deposit to zero
+// ===========================================================================
+
+/// The inflation attack: a dust first deposit, then a donation straight into the
+/// vault (which counts toward NAV without minting shares), so that the next
+/// deposit floors to zero shares. With the offset, a nonzero deposit mints at
+/// least one share whenever `VIRTUAL_SHARES * amount > nav`, whatever the real
+/// supply is, because `amount * (total + VIRTUAL_SHARES) >= amount * VIRTUAL_SHARES
+/// > nav + VIRTUAL_ASSETS - 1`. Flooring a deposit to nothing therefore takes a
+/// vault already holding more than `VIRTUAL_SHARES` times that deposit, and an
+/// attacker who inflates the vault that far shares the inflation with the virtual
+/// shares. The harness models the attack directly: an attacker's first deposit,
+/// a donation, then the victim's deposit.
+#[cfg(kani)]
+#[kani::proof]
+#[kani::solver(cadical)]
+fn proof_donation_cannot_zero_a_deposit() {
+    let attacker_deposit: u64 = kani::any();
+    let donation: u64 = kani::any();
+    let victim_deposit: u64 = kani::any();
+
+    // Bounded model checking (nonlinear products with a symbolic divisor).
+    kani::assume(attacker_deposit >= 1 && attacker_deposit <= 15);
+    kani::assume(donation <= 15_000);
+    kani::assume(victim_deposit >= 1 && victim_deposit <= 15);
+
+    // The attacker's deposit into the empty vault.
+    let attacker_shares = deposit_shares(attacker_deposit, 0, 0).expect("computes");
+    // The donation lands in the vault without going through the handler.
+    let nav = attacker_deposit + donation;
+    // The victim's deposit.
+    let victim_shares = deposit_shares(victim_deposit, attacker_shares, nav).expect("computes");
+
+    if (nav as u128) < VIRTUAL_SHARES as u128 * victim_deposit as u128 {
+        assert!(victim_shares >= 1);
+    }
+}
+
+// ===========================================================================
+// 5. Manager fee dilution is bounded
 // ===========================================================================
 
 /// The time-based manager fee mints
-/// `fee_shares = floor(total_shares * fee_bps * elapsed / (10_000 * SECONDS_PER_YEAR))`.
-/// Over at most one year (`elapsed <= SECONDS_PER_YEAR`) with a valid fee rate
-/// (`fee_bps <= 10_000`), the combined numerator factor `fee_bps * elapsed` is
-/// `<= 10_000 * SECONDS_PER_YEAR`, so `fee_shares <= total_shares`: the manager
-/// can never mint more than a 100%-per-year dilution. Modelled with the combined
+/// `fee_shares = floor(total_shares * fee_bps * elapsed / (10_000 * SECONDS_PER_YEAR))`
+/// against the real supply only; the virtual shares hold nothing of anyone's and
+/// earn the manager nothing. Over at most one year (`elapsed <= SECONDS_PER_YEAR`)
+/// with a valid fee rate (`fee_bps <= 10_000`), the combined numerator factor
+/// `fee_bps * elapsed` is `<= 10_000 * SECONDS_PER_YEAR`, so
+/// `fee_shares <= total_shares`: the manager can never mint more than a
+/// 100%-per-year dilution. Modelled with the combined
 /// `numerator_factor <= denominator` (the constraint the two bounds imply).
 #[cfg(kani)]
 #[kani::proof]
@@ -147,22 +245,57 @@ mod tests {
 
     #[test]
     fn withdraw_proportional() {
-        // Burn half the supply -> get half the balance.
-        assert_eq!(withdraw_amount(1000, 50, 100).unwrap(), 500);
-        // Burn all -> get all.
-        assert_eq!(withdraw_amount(1000, 100, 100).unwrap(), 1000);
+        // Burn half the supply -> just under half the balance: the 1000 virtual
+        // shares keep their slice.
+        assert_eq!(withdraw_amount(1_000_000, 500, 1000).unwrap(), 250_000);
+        // Burn all -> all but the virtual shares' slice.
+        assert_eq!(withdraw_amount(1_000_000, 1000, 1000).unwrap(), 500_000);
+        // At a real supply that dwarfs the offset the slice is rounding noise.
+        assert_eq!(
+            withdraw_amount(1_000_000, 1_000_000_000, 1_000_000_000).unwrap(),
+            999_999
+        );
     }
 
     #[test]
-    fn deposit_first_is_one_to_one() {
-        assert_eq!(deposit_shares(500, 0, 0).unwrap(), 500);
+    fn first_deposit_reads_as_whole_shares() {
+        // 900 USDC (900,000,000 minor units) into an empty vault mints
+        // 900,000,000,000 share minor units: 900 whole shares at nine decimals.
+        assert_eq!(deposit_shares(900_000_000, 0, 0).unwrap(), 900_000_000_000);
+    }
+
+    #[test]
+    fn later_deposit_pays_the_share_price() {
+        // 480 USDC at a 960 USDC NAV against 900 whole shares buys 450 whole
+        // shares, the offset showing up ten digits down.
+        let bob = deposit_shares(480_000_000, 900_000_000_000, 960_000_000).unwrap();
+        assert_eq!(bob / 1_000_000_000, 450);
+        assert_eq!(bob, 450_000_000_031);
+    }
+
+    #[test]
+    fn donation_does_not_zero_a_deposit() {
+        // The attack from the book: one minor unit deposited, 1,000 USDC donated,
+        // then a 1,000 USDC deposit.
+        let attacker = deposit_shares(1, 0, 0).unwrap();
+        assert_eq!(attacker, VIRTUAL_SHARES);
+        let nav = 1 + 1_000_000_000;
+        let victim = deposit_shares(1_000_000_000, attacker, nav).unwrap();
+        assert_eq!(victim, 1_999);
+        // The victim redeems all but a fraction of a dollar of the 2,000.000001
+        // USDC vault; the attacker's 1000 share minor units are worth half of the
+        // rest, the virtual shares' half being nobody's.
+        let vault = nav + 1_000_000_000;
+        let victim_out = withdraw_amount(vault, victim, attacker + victim).unwrap();
+        assert!(victim_out > 999_000_000 && victim_out <= 1_000_000_000);
+        let attacker_out = withdraw_amount(vault - victim_out, attacker, attacker).unwrap();
+        assert!(attacker_out < 501_000_000);
     }
 
     #[test]
     fn round_trip_not_profitable() {
         let minted = deposit_shares(100, 200, 150).unwrap();
-        let back =
-            mul_div_floor((150 + 100) as u128, minted as u128, (200 + minted) as u128).unwrap();
+        let back = withdraw_amount(150 + 100, minted, 200 + minted).unwrap();
         assert!(back <= 100);
     }
 }

--- a/finance/vault-strategy/quasar/CHANGELOG.md
+++ b/finance/vault-strategy/quasar/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [2026-09-08]
+
+### Changed
+
+- **Virtual shares and virtual assets.** Every share-price division adds
+  `VIRTUAL_SHARES` (1,000) to the real supply and `VIRTUAL_ASSETS` (one USDC
+  minor unit) to the net asset value, matching the Anchor build: `deposit`
+  mints `usdc × (total_shares + 1,000) / (NAV + 1)` with no first-deposit
+  special case, and `withdraw` pays `balance × shares / (total_shares + 1,000)`
+  per vault. This is the defense against the first-depositor inflation attack.
+- **Share mint decimals 6 → 9** (`SHARE_DECIMALS`), so a 900 USDC first deposit
+  still reads as 900 shares.
+
+### Added
+
+- `donation_does_not_inflate_share_price`: the attack run against the program,
+  with the victim's shares nonzero and redeeming for about 999.75 USDC and the
+  attacker losing about half of the donation to the virtual shares.
+
 ## [2026-07-22]
 
 ### Changed

--- a/finance/vault-strategy/quasar/README.md
+++ b/finance/vault-strategy/quasar/README.md
@@ -39,15 +39,25 @@ themselves or pair a real mint with a feed they control.
 - `deposit` prices the incoming USDC against the vault's net asset value (the
   USDC vault plus every asset vault valued at its oracle price), mints shares for
   that fraction of the vault, and deploys the deposit across the basket by
-  swapping a weight-sized slice into each asset through the router. The first
-  deposit into an empty vault mints shares one-to-one.
+  swapping a weight-sized slice into each asset through the router. Every
+  share-price division adds 1,000 virtual shares (`VIRTUAL_SHARES`) to the
+  supply and one virtual USDC minor unit (`VIRTUAL_ASSETS`) to the net asset
+  value, the defense against the first-depositor inflation attack: an empty
+  vault already has a share price, so a first deposit of 900 USDC mints 900
+  whole shares (the share mint has `SHARE_DECIMALS` = 9 decimals, USDC's six
+  plus the offset of three) and a donation straight into a vault is shared with
+  shares nobody holds. A deposit floors to zero only when the vault already
+  holds a thousand times it, and whoever inflated it that far loses about a
+  thousand times what the depositor loses.
 - `withdraw` burns shares and pays out a proportional slice of the USDC vault and
-  every asset vault, in kind.
+  every asset vault, in kind, dividing by the real supply plus the virtual
+  shares so the virtual shares' slice of each vault stays behind.
 - `rebalance` lets the manager sell one asset for USDC and buy another with it,
   keeping holdings near their targets as prices drift. Both legs are floored to
   the oracle price so a bad swap route reverts.
 - `collect_fees` accrues the time-based management fee by minting fresh shares to
-  the manager, diluting holders at the configured annual rate.
+  the manager, diluting holders at the configured annual rate. It dilutes the
+  real supply only; the virtual shares earn the manager nothing.
 
 Every swap and rebalance leg is bounded by the registered price feed: the
 program computes the oracle-implied output and rejects any swap that falls short
@@ -117,6 +127,13 @@ cargo install --git https://github.com/blueshift-gg/quasar quasar-cli --locked
 (cd mock-swap-router && cargo test)
 (cd vault-strategy && cargo test)
 ```
+
+The vault's tests cover the manager-side setup, a first deposit priced by the
+virtual offset and deployed through the router, and
+`donation_does_not_inflate_share_price`: a one-minor-unit deposit, a 1,000 USDC
+transfer straight into the USDC vault, then a 1,000 USDC deposit with no
+`minimum_shares` floor, whose shares are nonzero and redeem for all but a
+fraction of a dollar while the attacker loses about a thousand times as much.
 
 The router suite (`mock-swap-router/src/tests.rs`) exercises initialize, set-rate,
 and a USDC-for-asset swap. The vault suite (`vault-strategy/src/tests.rs`) drives

--- a/finance/vault-strategy/quasar/vault-strategy/src/instructions/collect_fees.rs
+++ b/finance/vault-strategy/quasar/vault-strategy/src/instructions/collect_fees.rs
@@ -51,6 +51,10 @@ pub fn handle_collect_fees(
     let strategy_bump = accounts.strategy.bump;
 
     // fee_shares = total_shares * fee_bps * elapsed / (10_000 * SECONDS_PER_YEAR)
+    //
+    // The fee is a percentage of what depositors hold, so it dilutes against the
+    // real supply only. The virtual shares that price deposits and withdrawals
+    // hold nothing of anyone's and earn the manager nothing.
     let denominator = (10_000u128)
         .checked_mul(SECONDS_PER_YEAR as u128)
         .ok_or(VaultError::MathOverflow)?;

--- a/finance/vault-strategy/quasar/vault-strategy/src/instructions/deposit.rs
+++ b/finance/vault-strategy/quasar/vault-strategy/src/instructions/deposit.rs
@@ -8,6 +8,7 @@ use crate::errors::VaultError;
 use crate::oracle::{asset_value_in_usdc, load_price, read_token_amount, PYTH_PRICE_PRECISION};
 use crate::state::{
     load_asset_config, snapshot_strategy, ShareMintPda, Strategy, UsdcVaultPda, STRATEGY_SEED,
+    VIRTUAL_ASSETS, VIRTUAL_SHARES,
 };
 
 /// Discriminator of the router's `swap_usdc_for_asset` instruction.
@@ -140,18 +141,30 @@ pub fn handle_deposit(
             .ok_or(VaultError::MathOverflow)?;
     }
 
-    // shares = usdc_amount * total_shares / nav (floor); first deposit is 1:1.
-    let shares_to_mint: u64 = if total_shares == 0 {
-        usdc_amount
-    } else {
-        (usdc_amount as u128)
-            .checked_mul(total_shares as u128)
-            .ok_or(VaultError::MathOverflow)?
-            .checked_div(nav)
-            .ok_or(VaultError::MathOverflow)?
-            .try_into()
-            .map_err(|_| VaultError::MathOverflow)?
-    };
+    // shares = usdc_amount * (total_shares + VIRTUAL_SHARES) / (nav + VIRTUAL_ASSETS),
+    // floored in the fund's favour.
+    //
+    // The virtual offset is the defense against the first-depositor inflation
+    // attack. Tokens sent straight to a vault count as fund value the moment they
+    // arrive, so without it a dust-sized first deposit followed by a donation
+    // could price one share at more than the next deposit, which then floors to
+    // zero shares. With `VIRTUAL_SHARES` (10^3) standing behind one virtual minor
+    // unit, an empty fund already has a share price: the first deposit mints a
+    // thousand share minor units per USDC minor unit, which at nine share
+    // decimals is one whole share per USDC, and a donation is split between the
+    // real shares and the virtual ones. A deposit floors to zero only when the
+    // fund already holds more than a thousand times it, and whoever inflated the
+    // fund that far loses about a thousand times what the depositor loses.
+    let shares_to_mint: u64 = (usdc_amount as u128)
+        .checked_mul(total_shares as u128 + VIRTUAL_SHARES as u128)
+        .ok_or(VaultError::MathOverflow)?
+        .checked_div(
+            nav.checked_add(VIRTUAL_ASSETS as u128)
+                .ok_or(VaultError::MathOverflow)?,
+        )
+        .ok_or(VaultError::MathOverflow)?
+        .try_into()
+        .map_err(|_| VaultError::MathOverflow)?;
     require!(
         shares_to_mint >= minimum_shares,
         VaultError::SlippageTooHigh

--- a/finance/vault-strategy/quasar/vault-strategy/src/instructions/initialize_strategy.rs
+++ b/finance/vault-strategy/quasar/vault-strategy/src/instructions/initialize_strategy.rs
@@ -3,7 +3,7 @@ use quasar_lang::sysvars::Sysvar as _;
 use quasar_spl::prelude::*;
 
 use crate::errors::VaultError;
-use crate::state::{Registry, ShareMintPda, Strategy, StrategyInner, UsdcVaultPda};
+use crate::state::{Registry, ShareMintPda, Strategy, StrategyInner, UsdcVaultPda, SHARE_DECIMALS};
 
 /// Highest annual management fee a manager may set (10%). `collect_fees` mints
 /// shares to the manager and dilutes every depositor, so an uncapped fee would
@@ -30,7 +30,7 @@ pub struct InitializeStrategyAccountConstraints {
     #[account(
         init,
         payer = manager,
-        mint(decimals = 6, authority = strategy, freeze_authority = None, token_program = token_program),
+        mint(decimals = SHARE_DECIMALS, authority = strategy, freeze_authority = None, token_program = token_program),
         address = ShareMintPda::seeds(strategy.address()),
     )]
     pub share_mint: Account<Mint>,

--- a/finance/vault-strategy/quasar/vault-strategy/src/instructions/withdraw.rs
+++ b/finance/vault-strategy/quasar/vault-strategy/src/instructions/withdraw.rs
@@ -7,6 +7,7 @@ use crate::errors::VaultError;
 use crate::oracle::{read_mint_decimals, read_token_amount, read_token_mint_and_owner};
 use crate::state::{
     load_asset_config, snapshot_strategy, ShareMintPda, Strategy, UsdcVaultPda, STRATEGY_SEED,
+    VIRTUAL_SHARES,
 };
 
 /// remaining_accounts arrive as, per asset index 0..asset_count:
@@ -77,7 +78,11 @@ pub fn handle_withdraw(
     let user_key = *accounts.user.address();
 
     let shares_u128 = shares_to_burn as u128;
-    let total_u128 = total_shares as u128;
+    // Every leg pays balance * shares / (total_shares + VIRTUAL_SHARES). The
+    // virtual shares hold their slice of every vault and are never burned, so
+    // even the last real holder leaves that slice behind: at most
+    // VIRTUAL_SHARES parts in (total_shares + VIRTUAL_SHARES) of each balance.
+    let total_u128 = total_shares as u128 + VIRTUAL_SHARES as u128;
 
     // USDC leg, floored in the protocol's favour.
     let amount_usdc: u64 = (vault_usdc_amount as u128)

--- a/finance/vault-strategy/quasar/vault-strategy/src/state/strategy.rs
+++ b/finance/vault-strategy/quasar/vault-strategy/src/state/strategy.rs
@@ -11,6 +11,33 @@ pub const ASSET_CONFIG_SEED: &[u8] = b"asset";
 /// single transaction.
 pub const MAX_ASSETS: u8 = 16;
 
+/// Decimals of the share mint: USDC's six plus `SHARE_DECIMALS_OFFSET`, so one
+/// whole share still tracks one USDC at launch (a 900 USDC first deposit reads
+/// as 900 shares) while the supply carries three more digits than the USDC it
+/// prices.
+pub const SHARE_DECIMALS: u8 = 6 + SHARE_DECIMALS_OFFSET;
+
+/// How many more decimals the share mint has than USDC. This is the vault's
+/// first-depositor defense (virtual shares and virtual assets, the ERC-4626
+/// "decimals offset"): every exchange-rate division adds `VIRTUAL_SHARES` to
+/// the share supply and `VIRTUAL_ASSETS` to the net asset value, so an empty
+/// fund already has a share price (one minor unit of USDC per `10^OFFSET` share
+/// minor units), the `total_shares == 0` case needs no special branch, and a
+/// donation straight into a vault is shared with shares nobody holds. An
+/// attacker inflating the share price loses about `10^OFFSET` times whatever
+/// the next depositor loses to rounding. Three leaves `total_shares: u64` room
+/// for about eighteen billion whole shares.
+pub const SHARE_DECIMALS_OFFSET: u8 = 3;
+
+/// Virtual shares added to the real supply in every share-price division:
+/// `10^SHARE_DECIMALS_OFFSET`. They are never minted, never burned, and their
+/// slice of every vault is never paid out.
+pub const VIRTUAL_SHARES: u64 = 10u64.pow(SHARE_DECIMALS_OFFSET as u32);
+
+/// Virtual assets added to the net asset value in every share-price division:
+/// one USDC minor unit, backing the virtual shares.
+pub const VIRTUAL_ASSETS: u64 = 1;
+
 /// One strategy (basket). PDA `["strategy", index]`, addressed by a
 /// caller-chosen counter rather than the manager's key. The index is stored so
 /// every handler can re-derive the PDA to sign for the vaults and share mint.

--- a/finance/vault-strategy/quasar/vault-strategy/src/tests.rs
+++ b/finance/vault-strategy/quasar/vault-strategy/src/tests.rs
@@ -1,17 +1,22 @@
 //! quasar-test integration tests. `strategy_setup` drives the manager-side
 //! setup (registry, approve asset, strategy, add asset) and asserts state.
-//! `deposit` is a two-program test: it loads the mock swap router too, wires
-//! up rates and a Pyth-shaped price feed, and deposits, checking that the
-//! deposit is priced 1:1 on the first deposit and deployed into the basket
-//! through the router CPI.
+//! The deposit tests are two-program tests: they load the mock swap router
+//! too, wire up rates and a Pyth-shaped price feed, and deposit, checking that
+//! the first deposit is priced by the virtual-share offset (one whole share per
+//! USDC) and deployed into the basket through the router CPI, and that a
+//! donation straight into the USDC vault cannot floor the next deposit to zero
+//! shares.
 
 use {
     crate::{
         cpi::{
             AddAssetInstruction, ApproveAssetInstruction, DepositInstruction,
-            InitializeRegistryInstruction, InitializeStrategyInstruction,
+            InitializeRegistryInstruction, InitializeStrategyInstruction, WithdrawInstruction,
         },
-        state::{AssetConfig, AssetVaultPda, Registry, ShareMintPda, Strategy, UsdcVaultPda},
+        state::{
+            AssetConfig, AssetVaultPda, Registry, ShareMintPda, Strategy, UsdcVaultPda,
+            SHARE_DECIMALS, VIRTUAL_SHARES,
+        },
     },
     quasar_test::prelude::*,
 };
@@ -20,10 +25,10 @@ const DECIMALS: u8 = 6;
 const FEE_BPS: u16 = 100;
 const MAX_SLIPPAGE_BPS: u16 = 100;
 
-// Router program (loaded for the deposit test).
+// Router program (loaded for the deposit tests).
 const ROUTER_ID_STR: &str = "SWPR8Rk3aq3DrDGLdaANq7xCMnXoUFUJWJJmCWxc8Jm";
 const RATE: u64 = 250; // USDC base units per asset base unit
-const NOW: i64 = 1_000; // fixed clock for the deposit test
+const NOW: i64 = 1_000; // fixed clock for the deposit tests
 const STRATEGY_INDEX: u64 = 0;
 
 // Deterministic addresses.
@@ -36,6 +41,11 @@ const PRICE_FEED: Pubkey = Pubkey::new_from_array([6; 32]);
 const DEPOSITOR_USDC: Pubkey = Pubkey::new_from_array([7; 32]);
 const DEPOSITOR_SHARE: Pubkey = Pubkey::new_from_array([8; 32]);
 const FEED_OWNER: Pubkey = Pubkey::new_from_array([9; 32]);
+const DEPOSITOR_ASSET: Pubkey = Pubkey::new_from_array([10; 32]);
+const ATTACKER: Pubkey = Pubkey::new_from_array([11; 32]);
+const ATTACKER_USDC: Pubkey = Pubkey::new_from_array([12; 32]);
+const ATTACKER_SHARE: Pubkey = Pubkey::new_from_array([13; 32]);
+const ATTACKER_ASSET: Pubkey = Pubkey::new_from_array([14; 32]);
 
 fn router_id() -> Pubkey {
     ROUTER_ID_STR.parse().unwrap()
@@ -150,11 +160,10 @@ fn strategy_setup_records_the_basket(test: &mut Test) {
     );
 }
 
-/// Two-program deposit: set up the router + a single-asset strategy, then
-/// deposit USDC. The first deposit mints shares 1:1 and deploys the whole
-/// amount into the asset through the router CPI.
-#[quasar_test]
-fn deposit_mints_shares_and_deploys_into_the_basket(test: &mut Test) {
+/// Load the router program, set the clock, and build a single-asset strategy
+/// whose asset the router mints, priced at 250 USDC per token on both the Pyth
+/// feed and the router. Returns the strategy PDAs.
+fn setup_router_and_strategy(test: &mut Test) -> Pdas {
     // Runtime read (NOT include_bytes!): quasar-test auto-loads only this
     // program's .so; the sibling router program is added explicitly.
     let router_elf =
@@ -167,23 +176,10 @@ fn deposit_mints_shares_and_deploys_into_the_basket(test: &mut Test) {
     setup_strategy(test, r_authority);
     let w = pdas(test);
 
-    test.add(Wallet::new().at(DEPOSITOR));
-
     // Asset priced 250 USDC/token: Pyth price = 250 * 10^8 so
     // asset_value = amount * price / 10^8 gives 250 USDC per token base unit.
     let pyth_price: i64 = 250 * 100_000_000;
     add_pyth_feed(test, pyth_price, NOW);
-
-    const DEPOSIT: u64 = 1_000;
-    const ASSET_OUT: u64 = DEPOSIT / RATE; // 4
-
-    // Depositor token accounts (share account created up front).
-    test.add(
-        TokenAccount::new(USDC_MINT, DEPOSITOR)
-            .at(DEPOSITOR_USDC)
-            .amount(DEPOSIT),
-    );
-    test.add(TokenAccount::new(w.share_mint, DEPOSITOR).at(DEPOSITOR_SHARE));
 
     // Initialize the router and set the asset's rate (hand-built: the router's
     // builders live in the sibling crate).
@@ -222,21 +218,46 @@ fn deposit_mints_shares_and_deploys_into_the_basket(test: &mut Test) {
         data: set_rate_data,
     })
     .succeeds();
+    w
+}
 
-    // Deposit: declared accounts, then remaining accounts per basket asset
-    // (asset_config, vault_asset, asset_mint, asset_rate, price_feed).
-    test.send(DepositInstruction {
-        depositor: DEPOSITOR,
+/// A depositor's wallet plus their USDC, share, and asset token accounts (the
+/// share account must exist before a deposit; the asset account before an
+/// in-kind withdrawal).
+fn add_depositor(test: &mut Test, w: &Pdas, owner: Pubkey, accounts: [Pubkey; 3], usdc: u64) {
+    let [usdc_account, share_account, asset_account] = accounts;
+    test.add(Wallet::new().at(owner));
+    test.add(
+        TokenAccount::new(USDC_MINT, owner)
+            .at(usdc_account)
+            .amount(usdc),
+    );
+    test.add(TokenAccount::new(w.share_mint, owner).at(share_account));
+    test.add(TokenAccount::new(ASSET_MINT, owner).at(asset_account));
+}
+
+/// Deposit: declared accounts, then remaining accounts per basket asset
+/// (asset_config, vault_asset, asset_mint, asset_rate, price_feed).
+fn deposit(
+    w: &Pdas,
+    depositor: Pubkey,
+    usdc_account: Pubkey,
+    share_account: Pubkey,
+    usdc_amount: u64,
+    minimum_shares: u64,
+) -> DepositInstruction {
+    DepositInstruction {
+        depositor,
         strategy_index_seed: STRATEGY_INDEX,
         usdc_mint: USDC_MINT,
-        depositor_usdc_account: DEPOSITOR_USDC,
-        depositor_share_account: DEPOSITOR_SHARE,
+        depositor_usdc_account: usdc_account,
+        depositor_share_account: share_account,
         router_config: router_config_pda(),
         router_usdc_treasury: router_treasury_pda(),
-        router_authority: r_authority,
+        router_authority: router_authority_pda(),
         swap_router_program: router_id(),
-        usdc_amount: DEPOSIT,
-        minimum_shares: DEPOSIT,
+        usdc_amount,
+        minimum_shares,
         remaining_accounts: vec![
             AccountMeta::new_readonly(w.asset_config, false),
             AccountMeta::new(w.vault_asset, false),
@@ -244,14 +265,186 @@ fn deposit_mints_shares_and_deploys_into_the_basket(test: &mut Test) {
             AccountMeta::new_readonly(router_rate_pda(&ASSET_MINT), false),
             AccountMeta::new_readonly(PRICE_FEED, false),
         ],
-    })
+    }
+}
+
+/// Withdraw in kind: declared accounts, then remaining accounts per basket
+/// asset (asset_config, vault_asset, asset_mint, user_asset_account).
+fn withdraw(
+    w: &Pdas,
+    user: Pubkey,
+    accounts: [Pubkey; 3],
+    shares_to_burn: u64,
+) -> WithdrawInstruction {
+    let [usdc_account, share_account, asset_account] = accounts;
+    WithdrawInstruction {
+        user,
+        strategy_index_seed: STRATEGY_INDEX,
+        usdc_mint: USDC_MINT,
+        user_share_account: share_account,
+        user_usdc_account: usdc_account,
+        shares_to_burn,
+        min_usdc_out: 0,
+        remaining_accounts: vec![
+            AccountMeta::new_readonly(w.asset_config, false),
+            AccountMeta::new(w.vault_asset, false),
+            AccountMeta::new_readonly(ASSET_MINT, false),
+            AccountMeta::new(asset_account, false),
+        ],
+    }
+}
+
+/// A holder's position valued in USDC minor units at the test's price: USDC
+/// plus the asset at 250 USDC per token.
+fn value_in_usdc(test: &Test, usdc_account: Pubkey, asset_account: Pubkey) -> u64 {
+    test.tokens(usdc_account) + test.tokens(asset_account) * RATE
+}
+
+/// Two-program deposit: set up the router + a single-asset strategy, then
+/// deposit USDC. The first deposit is priced by the virtual-share offset (1000
+/// share minor units per USDC minor unit, one whole share per USDC) and deploys
+/// the whole amount into the asset through the router CPI.
+#[quasar_test]
+fn deposit_mints_shares_and_deploys_into_the_basket(test: &mut Test) {
+    let w = setup_router_and_strategy(test);
+
+    const DEPOSIT: u64 = 1_000;
+    const ASSET_OUT: u64 = DEPOSIT / RATE; // 4
+
+    add_depositor(
+        test,
+        &w,
+        DEPOSITOR,
+        [DEPOSITOR_USDC, DEPOSITOR_SHARE, DEPOSITOR_ASSET],
+        DEPOSIT,
+    );
+
+    test.send(deposit(
+        &w,
+        DEPOSITOR,
+        DEPOSITOR_USDC,
+        DEPOSITOR_SHARE,
+        DEPOSIT,
+        DEPOSIT * VIRTUAL_SHARES,
+    ))
     .succeeds()
-    // First deposit mints shares 1:1 with USDC.
-    .has_tokens(DEPOSITOR_SHARE, DEPOSIT)
+    // The first deposit mints VIRTUAL_SHARES share minor units per USDC minor
+    // unit: 1000 USDC minor units become 1,000,000, a thousandth of a whole share.
+    .has_tokens(DEPOSITOR_SHARE, DEPOSIT * VIRTUAL_SHARES)
     // The deposit was deployed into the asset via the router.
     .has_tokens(w.vault_asset, ASSET_OUT)
     .has_tokens(DEPOSITOR_USDC, 0)
     .has_tokens(router_treasury_pda(), DEPOSIT)
     // All USDC was swapped out of the vault into the asset.
     .has_tokens(w.vault_usdc, 0);
+
+    // The share mint carries USDC's six decimals plus the virtual-share offset,
+    // so those 1,000,000 minor units are a thousandth of a whole share. Token
+    // mint layout: decimals is the byte at offset 44.
+    let share_mint = test.account(w.share_mint).unwrap();
+    assert_eq!(share_mint.data[44], SHARE_DECIMALS, "share mint decimals");
+}
+
+/// The first-depositor inflation attack: a dust deposit, then a donation straight
+/// into the strategy's USDC vault, then a 1,000 USDC deposit with no
+/// `minimum_shares` floor. The virtual offset prices the dust deposit at 1000
+/// share minor units, splits the donation between those and the 1000 virtual
+/// shares, and keeps the victim's shares nonzero: they redeem for all but a
+/// fraction of a dollar, while the attacker recovers about half of the donation
+/// and loses the rest to the virtual shares. Modeled on the lending example's
+/// `raw_token_donation_does_not_inflate_exchange_rate`.
+#[quasar_test]
+fn donation_does_not_inflate_share_price(test: &mut Test) {
+    let w = setup_router_and_strategy(test);
+
+    const DONATION: u64 = 1_000_000_000; // 1,000 USDC
+    const VICTIM_DEPOSIT: u64 = 1_000_000_000; // 1,000 USDC
+
+    let attacker_accounts = [ATTACKER_USDC, ATTACKER_SHARE, ATTACKER_ASSET];
+    let victim_accounts = [DEPOSITOR_USDC, DEPOSITOR_SHARE, DEPOSITOR_ASSET];
+    add_depositor(test, &w, ATTACKER, attacker_accounts, 1 + DONATION);
+    add_depositor(test, &w, DEPOSITOR, victim_accounts, VICTIM_DEPOSIT);
+
+    // The attacker deposits one minor unit through the handler. The offset prices
+    // it at 1 * (0 + 1000) / (0 + 1) = 1000 share minor units. The basket is one
+    // asset at 100%, so the deploy leg swaps the minor unit through the router,
+    // which at 250 USDC per token returns nothing for it: the vaults stay empty.
+    test.send(deposit(&w, ATTACKER, ATTACKER_USDC, ATTACKER_SHARE, 1, 0))
+        .succeeds()
+        .has_tokens(ATTACKER_SHARE, VIRTUAL_SHARES)
+        .has_tokens(w.vault_usdc, 0)
+        .has_tokens(w.vault_asset, 0);
+
+    // The attacker sends 1,000 USDC straight to the USDC vault with an ordinary
+    // token transfer (SPL Token `Transfer`, instruction 3). The deposit handler
+    // never ran, so the supply is still 1000 share minor units, now against a
+    // NAV of 1,000 USDC.
+    let mut transfer_data = vec![3u8];
+    transfer_data.extend_from_slice(&DONATION.to_le_bytes());
+    test.send(Instruction {
+        program_id: SPL_TOKEN_PROGRAM_ID,
+        accounts: vec![
+            AccountMeta::new(ATTACKER_USDC, false),
+            AccountMeta::new(w.vault_usdc, false),
+            AccountMeta::new_readonly(ATTACKER, true),
+        ],
+        data: transfer_data,
+    })
+    .succeeds()
+    .has_tokens(w.vault_usdc, DONATION);
+
+    // The victim deposits 1,000 USDC with no minimum_shares floor. Without the
+    // offset this would be 1,000,000,000 * 1 / 1,000,000,000 = 1 share minor unit,
+    // a millionth of what they paid for. With it:
+    // 1,000,000,000 * (1000 + 1000) / (1,000,000,000 + 1) = 1999 share minor units.
+    const VICTIM_SHARES: u64 = 1_999;
+    test.send(deposit(
+        &w,
+        DEPOSITOR,
+        DEPOSITOR_USDC,
+        DEPOSITOR_SHARE,
+        VICTIM_DEPOSIT,
+        0,
+    ))
+    .succeeds()
+    .has_tokens(DEPOSITOR_SHARE, VICTIM_SHARES)
+    // The victim's USDC was deployed into the asset: 1,000 USDC at 250 per token.
+    .has_tokens(w.vault_asset, VICTIM_DEPOSIT / RATE);
+
+    // The victim redeems everything in kind: 1999 of the 3999 effective shares
+    // (1000 attacker + 1999 victim + 1000 virtual) of each vault, worth all but
+    // about a quarter of a dollar of the 1,000 USDC they put in.
+    test.send(withdraw(&w, DEPOSITOR, victim_accounts, VICTIM_SHARES))
+        .succeeds()
+        .has_tokens(DEPOSITOR_SHARE, 0);
+    let victim_value = value_in_usdc(test, DEPOSITOR_USDC, DEPOSITOR_ASSET);
+    assert!(victim_value <= VICTIM_DEPOSIT);
+    let victim_loss = VICTIM_DEPOSIT - victim_value;
+    assert!(
+        victim_loss < 1_000_000,
+        "victim lost {victim_loss} minor units, more than a dollar"
+    );
+
+    // The attacker redeems their 1000 share minor units: half of what is left,
+    // the other half belonging to the virtual shares, which is to say to nobody.
+    // They put in 1,000.000001 USDC through the handler and the donation together
+    // and get back about 500 USDC, losing about a thousand times the victim's loss.
+    test.send(withdraw(&w, ATTACKER, attacker_accounts, VIRTUAL_SHARES))
+        .succeeds()
+        .has_tokens(ATTACKER_SHARE, 0);
+    let attacker_value = value_in_usdc(test, ATTACKER_USDC, ATTACKER_ASSET);
+    let attacker_in = 1 + DONATION;
+    assert!(
+        attacker_value < attacker_in,
+        "the attack must not pay: put in {attacker_in}, got back {attacker_value}"
+    );
+    let attacker_loss = attacker_in - attacker_value;
+    assert!(
+        attacker_loss >= VIRTUAL_SHARES * victim_loss,
+        "attacker lost {attacker_loss}, victim lost {victim_loss}"
+    );
+    assert!(attacker_value <= attacker_in / 2 + 1_000_000);
+
+    let strategy = test.read::<Strategy>(w.strategy);
+    assert_eq!(u64::from(strategy.total_shares), 0, "total_shares");
 }


### PR DESCRIPTION
The vault strategy priced shares as NAV divided by share supply with no defense against the first-depositor inflation attack: deposit one minor unit, transfer 1,000 USDC straight to the USDC vault (tokens in a vault count as fund value the moment they arrive), and the next 1,000 USDC deposit floors to zero shares. The only floor was the caller's `minimum_shares`, which protects the transaction that set it and not the pool. This change gives the program a named defense, virtual shares and virtual assets, in every implementation of the example, and the book follows in a companion PR that must merge after this one.

## What changed

- **Every share-price division carries a virtual offset.** `VIRTUAL_SHARES` (1,000, `10^SHARE_DECIMALS_OFFSET`) is added to the real supply and `VIRTUAL_ASSETS` (one USDC minor unit) to the net asset value. `deposit` mints `usdc × (total_shares + 1,000) / (nav + 1)`, floored, and the `total_shares == 0` special case is gone. `withdraw` pays `balance × shares / (total_shares + 1,000)` per vault, so the virtual shares' slice of every vault (at most 1,000 parts in `total_shares + 1,000`) is never paid out. `collect_fees` dilutes the real supply only: fees are a percentage of what depositors hold, and the virtual shares hold nothing of anyone's. `minimum_shares` and `SlippageTooHigh` stay; they still protect a depositor against a share price that moved between signing and landing.
- **Share mint decimals 6 → 9** (`SHARE_DECIMALS = 6 + SHARE_DECIMALS_OFFSET`), so one whole share still tracks one USDC at launch: Alice's 900 USDC first deposit mints 900,000,000,000 share minor units, which reads as 900 shares, and Bob's 480 USDC at a 960 USDC NAV reads as 450 shares (450,000,000,031 minor units, the offset's rounding ten digits down).
- **Done in every implementation**: `anchor/`, `anchor-v1/`, `quasar/vault-strategy/`, and `kani-proofs/`. The Anchor app client (`amounts.ts`, `config.ts`, `format.ts`, `strategy.ts`, `ActionTicket.tsx`, both copies) mirrors the new formula and the nine-decimal share mint. READMEs, `PRODUCT.md`, changelogs, the Kani README, and `VIDEO_SCRIPT.md` describe the new behavior; no doc still says the first deposit is one-to-one.

## Design decisions, in order

1. **Offsets: the decimals offset, `OFFSET = 3`.** Two designs were checked against the *Adversary* chapter's numbers (attacker deposits one minor unit, donates 1,000 USDC, victim deposits 1,000 USDC with no floor):
   - *Decimals offset (chosen)*: virtual assets 1 minor unit, virtual shares `10^3`, share decimals raised to 9. The attacker's minor unit buys 1,000 share minor units, the donation is split between those and the virtual 1,000, and the victim's 1,000 USDC buys 1,999 share minor units that redeem for about 999.75 USDC (a loss of about 0.25 USDC). The attacker's 1,000 share minor units redeem for about 500 USDC against 1,000.000001 put in: they lose about 2,000 times what the victim loses. In general the attacker loses about `10^OFFSET` times the victim's loss, and flooring a deposit to nothing takes a fund already holding `10^OFFSET` times it. `u64` headroom: at nine decimals `total_shares` holds about 18.4 billion whole shares, ample for a USDC-denominated fund; `OFFSET = 6` would leave about eighteen million.
   - *Equal constants (rejected)*: one USDC in minor units on both sides keeps the mint at six decimals and the first deposit at exactly 1:1, but its effective decimals offset is zero. Working the attack through: an attacker who deposits 1 USDC and donates twice the victim's deposit zeroes the victim's shares while recovering about 1.5× the victim's deposit plus half their own, losing only about half of what the victim loses. It also gives the virtual shares a fixed one-USDC slice of every gain. Weaker protection and a permanent dilution, so rejected.
2. **Applied everywhere shares are priced**: the deposit mint, both withdrawal legs (USDC and each asset vault), and the fee, which deliberately uses the real supply only (see above).
3. **Every implementation agrees**: the same constants, formulas, and doc comments in the two Anchor copies and the Quasar port; the Kani model reproduces them.
4. **Pinning tests**, modeled on the lending example's `raw_token_donation_does_not_inflate_exchange_rate`:
   - `test_donation_does_not_inflate_share_price` (Anchor v2 and v1) and `donation_does_not_inflate_share_price` (Quasar): attacker deposits one minor unit, transfers 1,000 USDC to the strategy's USDC vault with an ordinary token transfer, victim deposits 1,000 USDC with `minimum_shares = 0`. Asserts the victim's shares are nonzero (1,999 minor units), redeem in kind for all but a fraction of a dollar, and that the attacker's shares redeem for less than they put in through the handler and the donation together, with the attacker's loss at least `VIRTUAL_SHARES` times the victim's. One note on the brief's wording: "the attacker's shares redeem for no more than they deposited through the handler" cannot hold literally under any virtual-share design, because a donation is always shared pro rata with existing holders (here the attacker recovers about half of it). The test asserts the bound the defense actually gives: the attack is unprofitable, by about a thousand to one.
   - The whole-share expectations in `test_deposit_first`, `test_deposit_fair_pricing`, `test_withdraw`, `test_full_lifecycle`, and `test_collect_fees` are asserted in whole shares (`SHARE_UNIT`) and as exact minor-unit values. `test_withdraw` now expects 15,999 TSLAx and 33,332 NVDAx minor units back, the one minor unit of each being the virtual shares' slice that stays in the vault. `test_initialize_and_add_assets` checks the share mint's decimals.
   - Kani: `proof_first_deposit_is_priced_by_the_offset` (a deposit into an empty vault mints exactly `VIRTUAL_SHARES` share minor units per USDC minor unit) and `proof_donation_cannot_zero_a_deposit` (attacker deposit, donation, victim deposit: the victim mints at least one share whenever the vault holds less than `VIRTUAL_SHARES` times their deposit). The existing three proofs were updated to the offset formulas; `proof_withdraw_within_balance` now also proves the virtual shares' slice is never paid out.

## Verification

- `anchor/`: `cargo build-sbf` for both programs and `cargo test --manifest-path programs/vault-strategy/Cargo.toml`: 21 tests pass. Root `cargo clippy -p vault-strategy -p mock-swap-router --all-targets -- -D warnings -A clippy::diverging_sub_expression` and `cargo fmt --check` clean.
- `anchor-v1/`: same build and test commands: 21 tests pass, `cargo fmt --check` clean.
- `quasar/`: `cargo generate-lockfile && quasar build` for both programs, then `cargo test` in each, as `quasar.yml` does: router 2 tests, vault 4 tests pass. `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.
- `kani-proofs/`: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (5 unit tests), and `cargo kani`: 5 harnesses verified, 0 failures.
- `anchor/app`: `pnpm run typecheck` and `pnpm run verify` pass (the IDL is unchanged: no instruction or argument changed).

The book PR in `quicknode/solana-book` describes this formula and must merge after this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jbHknFnC6NKkeWvgvziB1

---
_Generated by [Claude Code](https://claude.ai/code/session_012jbHknFnC6NKkeWvgvziB1)_