### PR TITLE
finance: let each market's state account own its vaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this repository are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2026-09-10] - Market and pool accounts own their vaults
+
+Five finance examples kept a dataless "authority" PDA beside their state
+account, existing only to own the vaults and mints and to sign for them: the
+token swap, the prop AMM, the perpetual futures pool, the options venue, and the
+vault strategy's mock swap router. A program-owned data account signs with its
+own seeds just as well, as the escrow's offer account already does, and its
+seeds never change however its data does, so the extra account bought nothing
+but one more account per instruction and one more stored bump.
+
+- The pool config, market, pool, and router config now own their vaults and
+  mints directly and sign with their own seeds, in every port: Anchor v2,
+  Anchor v1, and Quasar. The token swap's reserves are now associated token
+  accounts of the pool config, so their addresses changed; the vault strategy's
+  web app derives the router treasury from the router config.
+- Each affected port's tests assert the new ownership, and its README and
+  changelog follow.
+- Pre-existing formatting drift and clippy findings in the prop AMM and token
+  swap v1 and Quasar ports were fixed so the gates pass.
+
 ## [2026-09-08] - Anchor v1 examples on Anchor 1.2.0
 
 Anchor 1.2.0 is the current release of the v1 line. Every `anchor-v1/` example now

--- a/finance/options/anchor-v1/CHANGELOG.md
+++ b/finance/options/anchor-v1/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-09-10
+
+The `Market` account is now the token authority of both vaults and signs
+every transfer out of them with its own seeds. The separate dataless signer
+PDA, the second bump `Market` stored for it, and the extra account
+`initialize_market`, `cancel_option`, `exercise_option`, `collect_proceeds`,
+`reclaim_collateral` and `collect_fees` took for it are gone.
+
 ## 2026-09-04
 
 Initial version: a fully collateralized, physically settled options venue.

--- a/finance/options/anchor-v1/README.md
+++ b/finance/options/anchor-v1/README.md
@@ -103,8 +103,10 @@ NVDAx the story hands them. NVDAx is trading around $165 offchain.
 ### Step 1: Maria opens the venue
 
 `initialize_market(fee_bps = 100)` creates the `Market` account (a PDA of the
-two mints), a dataless vault-authority PDA, and the two vaults. Maria's key is
-recorded as `admin`: it can sweep fees and do nothing else.
+two mints) and the two vaults. The market account is the token authority of
+both vaults: it owns them and signs every transfer out of them with its own
+seeds. Maria's key is recorded as `admin`: it can sweep fees and do nothing
+else.
 
 ### Step 2: Alice writes 5 covered calls
 

--- a/finance/options/anchor-v1/programs/options/src/constants.rs
+++ b/finance/options/anchor-v1/programs/options/src/constants.rs
@@ -9,9 +9,6 @@ pub const BASIS_POINTS_DENOMINATOR: u64 = 10_000;
 pub const MARKET_SEED: &[u8] = b"market";
 
 #[constant]
-pub const AUTHORITY_SEED: &[u8] = b"authority";
-
-#[constant]
 pub const UNDERLYING_VAULT_SEED: &[u8] = b"underlying_vault";
 
 #[constant]

--- a/finance/options/anchor-v1/programs/options/src/instructions/cancel_option.rs
+++ b/finance/options/anchor-v1/programs/options/src/instructions/cancel_option.rs
@@ -1,9 +1,7 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
 
-use crate::constants::{
-    AUTHORITY_SEED, MARKET_SEED, OPTION_SEED, QUOTE_VAULT_SEED, UNDERLYING_VAULT_SEED,
-};
+use crate::constants::{MARKET_SEED, OPTION_SEED, QUOTE_VAULT_SEED, UNDERLYING_VAULT_SEED};
 use crate::contract_math;
 use crate::errors::OptionsError;
 use crate::instructions::shared::{check_custody, transfer_from_vault};
@@ -59,7 +57,6 @@ pub fn handle_cancel_option(context: Context<CancelOptionAccountConstraints>) ->
             &mut context.accounts.underlying_vault,
             &context.accounts.underlying_mint,
             &mut context.accounts.writer_underlying,
-            &context.accounts.market_authority,
             market,
             collateral,
         ),
@@ -68,7 +65,6 @@ pub fn handle_cancel_option(context: Context<CancelOptionAccountConstraints>) ->
             &mut context.accounts.quote_vault,
             &context.accounts.quote_mint,
             &mut context.accounts.writer_quote,
-            &context.accounts.market_authority,
             market,
             collateral,
         ),
@@ -96,13 +92,6 @@ pub struct CancelOptionAccountConstraints<'info> {
         bump = option.bump,
     )]
     pub option: Box<Account<'info, OptionContract>>,
-
-    /// CHECK: PDA authority over both vaults; holds no data, only signs.
-    #[account(
-        seeds = [AUTHORITY_SEED, market.key().as_ref()],
-        bump = market.authority_bump,
-    )]
-    pub market_authority: UncheckedAccount<'info>,
 
     #[account(address = market.underlying_mint)]
     pub underlying_mint: Box<InterfaceAccount<'info, Mint>>,

--- a/finance/options/anchor-v1/programs/options/src/instructions/collect_fees.rs
+++ b/finance/options/anchor-v1/programs/options/src/instructions/collect_fees.rs
@@ -4,7 +4,7 @@ use anchor_spl::{
     token_interface::{Mint, TokenAccount, TokenInterface},
 };
 
-use crate::constants::{AUTHORITY_SEED, MARKET_SEED, QUOTE_VAULT_SEED};
+use crate::constants::{MARKET_SEED, QUOTE_VAULT_SEED};
 use crate::errors::OptionsError;
 use crate::instructions::shared::{check_custody, transfer_from_vault};
 use crate::state::Market;
@@ -36,7 +36,6 @@ pub fn handle_collect_fees(context: Context<CollectFeesAccountConstraints>) -> R
         &mut context.accounts.quote_vault,
         &context.accounts.quote_mint,
         &mut context.accounts.admin_quote,
-        &context.accounts.market_authority,
         market,
         amount,
     )
@@ -53,13 +52,6 @@ pub struct CollectFeesAccountConstraints<'info> {
         bump = market.bump,
     )]
     pub market: Box<Account<'info, Market>>,
-
-    /// CHECK: PDA authority over both vaults; holds no data, only signs.
-    #[account(
-        seeds = [AUTHORITY_SEED, market.key().as_ref()],
-        bump = market.authority_bump,
-    )]
-    pub market_authority: UncheckedAccount<'info>,
 
     #[account(address = market.quote_mint)]
     pub quote_mint: Box<InterfaceAccount<'info, Mint>>,

--- a/finance/options/anchor-v1/programs/options/src/instructions/collect_proceeds.rs
+++ b/finance/options/anchor-v1/programs/options/src/instructions/collect_proceeds.rs
@@ -4,9 +4,7 @@ use anchor_spl::{
     token_interface::{Mint, TokenAccount, TokenInterface},
 };
 
-use crate::constants::{
-    AUTHORITY_SEED, MARKET_SEED, OPTION_SEED, QUOTE_VAULT_SEED, UNDERLYING_VAULT_SEED,
-};
+use crate::constants::{MARKET_SEED, OPTION_SEED, QUOTE_VAULT_SEED, UNDERLYING_VAULT_SEED};
 use crate::contract_math;
 use crate::errors::OptionsError;
 use crate::instructions::shared::{check_custody, transfer_from_vault};
@@ -64,7 +62,6 @@ pub fn handle_collect_proceeds(context: Context<CollectProceedsAccountConstraint
             &mut context.accounts.quote_vault,
             &context.accounts.quote_mint,
             &mut context.accounts.writer_quote,
-            &context.accounts.market_authority,
             market,
             proceeds,
         ),
@@ -73,7 +70,6 @@ pub fn handle_collect_proceeds(context: Context<CollectProceedsAccountConstraint
             &mut context.accounts.underlying_vault,
             &context.accounts.underlying_mint,
             &mut context.accounts.writer_underlying,
-            &context.accounts.market_authority,
             market,
             proceeds,
         ),
@@ -101,13 +97,6 @@ pub struct CollectProceedsAccountConstraints<'info> {
         bump = option.bump,
     )]
     pub option: Box<Account<'info, OptionContract>>,
-
-    /// CHECK: PDA authority over both vaults; holds no data, only signs.
-    #[account(
-        seeds = [AUTHORITY_SEED, market.key().as_ref()],
-        bump = market.authority_bump,
-    )]
-    pub market_authority: UncheckedAccount<'info>,
 
     #[account(address = market.underlying_mint)]
     pub underlying_mint: Box<InterfaceAccount<'info, Mint>>,

--- a/finance/options/anchor-v1/programs/options/src/instructions/exercise_option.rs
+++ b/finance/options/anchor-v1/programs/options/src/instructions/exercise_option.rs
@@ -4,9 +4,7 @@ use anchor_spl::{
     token_interface::{Mint, TokenAccount, TokenInterface},
 };
 
-use crate::constants::{
-    AUTHORITY_SEED, MARKET_SEED, OPTION_SEED, QUOTE_VAULT_SEED, UNDERLYING_VAULT_SEED,
-};
+use crate::constants::{MARKET_SEED, OPTION_SEED, QUOTE_VAULT_SEED, UNDERLYING_VAULT_SEED};
 use crate::contract_math;
 use crate::errors::OptionsError;
 use crate::instructions::shared::{check_custody, transfer_from_signer, transfer_from_vault};
@@ -104,7 +102,6 @@ pub fn handle_exercise_option(context: Context<ExerciseOptionAccountConstraints>
                 &mut context.accounts.underlying_vault,
                 &context.accounts.underlying_mint,
                 &mut context.accounts.holder_underlying,
-                &context.accounts.market_authority,
                 market,
                 underlying_total,
             )
@@ -123,7 +120,6 @@ pub fn handle_exercise_option(context: Context<ExerciseOptionAccountConstraints>
                 &mut context.accounts.quote_vault,
                 &context.accounts.quote_mint,
                 &mut context.accounts.holder_quote,
-                &context.accounts.market_authority,
                 market,
                 strike_total,
             )
@@ -155,13 +151,6 @@ pub struct ExerciseOptionAccountConstraints<'info> {
         bump = option.bump,
     )]
     pub option: Box<Account<'info, OptionContract>>,
-
-    /// CHECK: PDA authority over both vaults; holds no data, only signs.
-    #[account(
-        seeds = [AUTHORITY_SEED, market.key().as_ref()],
-        bump = market.authority_bump,
-    )]
-    pub market_authority: UncheckedAccount<'info>,
 
     #[account(address = market.underlying_mint)]
     pub underlying_mint: Box<InterfaceAccount<'info, Mint>>,

--- a/finance/options/anchor-v1/programs/options/src/instructions/initialize_market.rs
+++ b/finance/options/anchor-v1/programs/options/src/instructions/initialize_market.rs
@@ -2,7 +2,7 @@ use anchor_lang::prelude::*;
 use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
 
 use crate::constants::{
-    AUTHORITY_SEED, BASIS_POINTS_DENOMINATOR, MARKET_SEED, QUOTE_VAULT_SEED, UNDERLYING_VAULT_SEED,
+    BASIS_POINTS_DENOMINATOR, MARKET_SEED, QUOTE_VAULT_SEED, UNDERLYING_VAULT_SEED,
 };
 use crate::errors::OptionsError;
 use crate::state::Market;
@@ -35,7 +35,6 @@ pub fn handle_initialize_market(
     market.fees_owed = 0;
     market.fee_bps = fee_bps;
     market.bump = context.bumps.market;
-    market.authority_bump = context.bumps.market_authority;
 
     Ok(())
 }
@@ -60,21 +59,15 @@ pub struct InitializeMarketAccountConstraints<'info> {
 
     pub quote_mint: Box<InterfaceAccount<'info, Mint>>,
 
-    /// CHECK: PDA that owns both vaults. Holds no data; used only to sign
-    /// vault CPIs.
-    #[account(
-        seeds = [AUTHORITY_SEED, market.key().as_ref()],
-        bump,
-    )]
-    pub market_authority: UncheckedAccount<'info>,
-
+    // The market account is the token authority of both vaults: it signs
+    // every transfer out of them with its own PDA seeds.
     #[account(
         init,
         payer = admin,
         seeds = [UNDERLYING_VAULT_SEED, market.key().as_ref()],
         bump,
         token::mint = underlying_mint,
-        token::authority = market_authority,
+        token::authority = market,
         token::token_program = token_program,
     )]
     pub underlying_vault: Box<InterfaceAccount<'info, TokenAccount>>,
@@ -85,7 +78,7 @@ pub struct InitializeMarketAccountConstraints<'info> {
         seeds = [QUOTE_VAULT_SEED, market.key().as_ref()],
         bump,
         token::mint = quote_mint,
-        token::authority = market_authority,
+        token::authority = market,
         token::token_program = token_program,
     )]
     pub quote_vault: Box<InterfaceAccount<'info, TokenAccount>>,

--- a/finance/options/anchor-v1/programs/options/src/instructions/reclaim_collateral.rs
+++ b/finance/options/anchor-v1/programs/options/src/instructions/reclaim_collateral.rs
@@ -1,9 +1,7 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
 
-use crate::constants::{
-    AUTHORITY_SEED, MARKET_SEED, OPTION_SEED, QUOTE_VAULT_SEED, UNDERLYING_VAULT_SEED,
-};
+use crate::constants::{MARKET_SEED, OPTION_SEED, QUOTE_VAULT_SEED, UNDERLYING_VAULT_SEED};
 use crate::contract_math;
 use crate::errors::OptionsError;
 use crate::instructions::shared::{check_custody, transfer_from_vault};
@@ -68,7 +66,6 @@ pub fn handle_reclaim_collateral(
             &mut context.accounts.underlying_vault,
             &context.accounts.underlying_mint,
             &mut context.accounts.writer_underlying,
-            &context.accounts.market_authority,
             market,
             collateral,
         ),
@@ -77,7 +74,6 @@ pub fn handle_reclaim_collateral(
             &mut context.accounts.quote_vault,
             &context.accounts.quote_mint,
             &mut context.accounts.writer_quote,
-            &context.accounts.market_authority,
             market,
             collateral,
         ),
@@ -105,13 +101,6 @@ pub struct ReclaimCollateralAccountConstraints<'info> {
         bump = option.bump,
     )]
     pub option: Box<Account<'info, OptionContract>>,
-
-    /// CHECK: PDA authority over both vaults; holds no data, only signs.
-    #[account(
-        seeds = [AUTHORITY_SEED, market.key().as_ref()],
-        bump = market.authority_bump,
-    )]
-    pub market_authority: UncheckedAccount<'info>,
 
     #[account(address = market.underlying_mint)]
     pub underlying_mint: Box<InterfaceAccount<'info, Mint>>,

--- a/finance/options/anchor-v1/programs/options/src/instructions/shared.rs
+++ b/finance/options/anchor-v1/programs/options/src/instructions/shared.rs
@@ -3,7 +3,7 @@ use anchor_spl::token_interface::{
     transfer_checked, Mint, TokenAccount, TokenInterface, TransferChecked,
 };
 
-use crate::constants::AUTHORITY_SEED;
+use crate::constants::MARKET_SEED;
 use crate::errors::OptionsError;
 use crate::state::Market;
 
@@ -52,21 +52,25 @@ pub fn transfer_from_signer<'info>(
     )
 }
 
-/// A transfer out of a vault, signed by the market's vault authority PDA.
-/// Takes the market by reference for its address and authority bump, so the
-/// caller must have finished mutating it (it has: effects come before CPIs).
+/// A transfer out of a vault, signed by the market account, which is the
+/// token authority of both vaults. Takes the market by reference for its
+/// seeds and bump, so the caller must have finished mutating it (it has:
+/// effects come before CPIs).
 pub fn transfer_from_vault<'info>(
     token_program: &Interface<'info, TokenInterface>,
     vault: &mut InterfaceAccount<'info, TokenAccount>,
     mint: &InterfaceAccount<'info, Mint>,
     to: &mut InterfaceAccount<'info, TokenAccount>,
-    market_authority: &UncheckedAccount<'info>,
     market: &Account<'info, Market>,
     amount: u64,
 ) -> Result<()> {
-    let market_key = market.key();
-    let bump = [market.authority_bump];
-    let authority_seeds: &[&[u8]] = &[AUTHORITY_SEED, market_key.as_ref(), &bump];
+    let bump = [market.bump];
+    let market_seeds: &[&[u8]] = &[
+        MARKET_SEED,
+        market.underlying_mint.as_ref(),
+        market.quote_mint.as_ref(),
+        &bump,
+    ];
     transfer_checked(
         CpiContext::new_with_signer(
             token_program.key(),
@@ -74,9 +78,9 @@ pub fn transfer_from_vault<'info>(
                 from: vault.to_account_info(),
                 mint: mint.to_account_info(),
                 to: to.to_account_info(),
-                authority: market_authority.to_account_info(),
+                authority: market.to_account_info(),
             },
-            &[authority_seeds],
+            &[market_seeds],
         ),
         amount,
         mint.decimals,

--- a/finance/options/anchor-v1/programs/options/src/state/market.rs
+++ b/finance/options/anchor-v1/programs/options/src/state/market.rs
@@ -41,9 +41,8 @@ pub struct Market {
     /// Fee charged on each premium, in basis points. The venue's revenue.
     pub fee_bps: u16,
 
+    /// Bump of this account's own PDA. The market is the token authority of
+    /// both vaults and signs every transfer out of them with its seeds, so the
+    /// bump is stored to save re-deriving it on each CPI.
     pub bump: u8,
-
-    /// Bump for the vault authority PDA, stored so CPIs can sign without
-    /// re-deriving it.
-    pub authority_bump: u8,
 }

--- a/finance/options/anchor-v1/programs/options/tests/test_options.rs
+++ b/finance/options/anchor-v1/programs/options/tests/test_options.rs
@@ -84,7 +84,6 @@ struct Venue {
     underlying_mint: Pubkey,
     quote_mint: Pubkey,
     market: Pubkey,
-    market_authority: Pubkey,
     underlying_vault: Pubkey,
     quote_vault: Pubkey,
 }
@@ -132,8 +131,6 @@ impl Venue {
             &options::id(),
         )
         .0;
-        let market_authority =
-            Pubkey::find_program_address(&[b"authority", market.as_ref()], &options::id()).0;
         let underlying_vault =
             Pubkey::find_program_address(&[b"underlying_vault", market.as_ref()], &options::id()).0;
         let quote_vault =
@@ -147,7 +144,6 @@ impl Venue {
                 market,
                 underlying_mint,
                 quote_mint,
-                market_authority,
                 underlying_vault,
                 quote_vault,
                 token_program: token_program_id(),
@@ -170,7 +166,6 @@ impl Venue {
             underlying_mint,
             quote_mint,
             market,
-            market_authority,
             underlying_vault,
             quote_vault,
         })
@@ -269,6 +264,13 @@ impl Venue {
         get_token_account_balance(&self.svm, token_account).unwrap()
     }
 
+    /// The token authority of a token account: bytes 32..64 of the SPL Token
+    /// account layout.
+    fn token_authority(&self, token_account: &Pubkey) -> Pubkey {
+        let account = self.svm.get_account(token_account).unwrap();
+        Pubkey::try_from(&account.data[32..64]).unwrap()
+    }
+
     fn send(&mut self, instruction: Instruction, signer: &Keypair) -> Result<(), ()> {
         send_transaction_from_instructions(
             &mut self.svm,
@@ -357,7 +359,6 @@ impl Venue {
                 writer: writer.pubkey(),
                 market: self.market,
                 option: *option,
-                market_authority: self.market_authority,
                 underlying_mint: self.underlying_mint,
                 quote_mint: self.quote_mint,
                 underlying_vault: self.underlying_vault,
@@ -385,7 +386,6 @@ impl Venue {
                 writer: *writer,
                 market: self.market,
                 option: *option,
-                market_authority: self.market_authority,
                 underlying_mint: self.underlying_mint,
                 quote_mint: self.quote_mint,
                 underlying_vault: self.underlying_vault,
@@ -409,7 +409,6 @@ impl Venue {
                 writer: writer.pubkey(),
                 market: self.market,
                 option: *option,
-                market_authority: self.market_authority,
                 underlying_mint: self.underlying_mint,
                 quote_mint: self.quote_mint,
                 underlying_vault: self.underlying_vault,
@@ -433,7 +432,6 @@ impl Venue {
                 writer: writer.pubkey(),
                 market: self.market,
                 option: *option,
-                market_authority: self.market_authority,
                 underlying_mint: self.underlying_mint,
                 quote_mint: self.quote_mint,
                 underlying_vault: self.underlying_vault,
@@ -454,7 +452,6 @@ impl Venue {
             options::accounts::CollectFeesAccountConstraints {
                 admin: signer.pubkey(),
                 market: self.market,
-                market_authority: self.market_authority,
                 quote_mint: self.quote_mint,
                 underlying_vault: self.underlying_vault,
                 quote_vault: self.quote_vault,
@@ -494,6 +491,16 @@ impl Venue {
 // ===========================================================================
 // The call: write, buy, exercise, collect
 // ===========================================================================
+
+/// The market account itself is the token authority of both vaults: there is
+/// no separate signer, so every transfer out of a vault is signed with the
+/// market's own seeds.
+#[test]
+fn test_market_owns_both_vaults() {
+    let venue = Venue::new();
+    assert_eq!(venue.token_authority(&venue.underlying_vault), venue.market);
+    assert_eq!(venue.token_authority(&venue.quote_vault), venue.market);
+}
 
 /// Alice writes 5 covered calls on her 5 NVDAx. The whole 5 NVDAx moves into
 /// the vault at once; the option is listed for a 25 USDC premium.

--- a/finance/options/anchor/CHANGELOG.md
+++ b/finance/options/anchor/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-09-10
+
+The `Market` account is now the token authority of both vaults and signs
+every transfer out of them with its own seeds. The separate dataless signer
+PDA, the second bump `Market` stored for it, and the extra account
+`initialize_market`, `cancel_option`, `exercise_option`, `collect_proceeds`,
+`reclaim_collateral` and `collect_fees` took for it are gone.
+
 ## 2026-09-04
 
 Initial version: a fully collateralized, physically settled options venue.

--- a/finance/options/anchor/README.md
+++ b/finance/options/anchor/README.md
@@ -103,8 +103,10 @@ NVDAx the story hands them. NVDAx is trading around $165 offchain.
 ### Step 1: Maria opens the venue
 
 `initialize_market(fee_bps = 100)` creates the `Market` account (a PDA of the
-two mints), a dataless vault-authority PDA, and the two vaults. Maria's key is
-recorded as `admin`: it can sweep fees and do nothing else.
+two mints) and the two vaults. The market account is the token authority of
+both vaults: it owns them and signs every transfer out of them with its own
+seeds. Maria's key is recorded as `admin`: it can sweep fees and do nothing
+else.
 
 ### Step 2: Alice writes 5 covered calls
 

--- a/finance/options/anchor/programs/options/src/constants.rs
+++ b/finance/options/anchor/programs/options/src/constants.rs
@@ -9,9 +9,6 @@ pub const BASIS_POINTS_DENOMINATOR: u64 = 10_000;
 pub const MARKET_SEED: &[u8] = b"market";
 
 #[constant]
-pub const AUTHORITY_SEED: &[u8] = b"authority";
-
-#[constant]
 pub const UNDERLYING_VAULT_SEED: &[u8] = b"underlying_vault";
 
 #[constant]

--- a/finance/options/anchor/programs/options/src/instructions/cancel_option.rs
+++ b/finance/options/anchor/programs/options/src/instructions/cancel_option.rs
@@ -1,9 +1,7 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
 
-use crate::constants::{
-    AUTHORITY_SEED, MARKET_SEED, OPTION_SEED, QUOTE_VAULT_SEED, UNDERLYING_VAULT_SEED,
-};
+use crate::constants::{MARKET_SEED, OPTION_SEED, QUOTE_VAULT_SEED, UNDERLYING_VAULT_SEED};
 use crate::contract_math;
 use crate::errors::OptionsError;
 use crate::instructions::shared::{check_custody, transfer_from_vault};
@@ -59,7 +57,6 @@ pub fn handle_cancel_option(context: &mut Context<CancelOptionAccountConstraints
             &mut context.accounts.underlying_vault,
             &context.accounts.underlying_mint,
             &mut context.accounts.writer_underlying,
-            &context.accounts.market_authority,
             market,
             collateral,
         ),
@@ -68,7 +65,6 @@ pub fn handle_cancel_option(context: &mut Context<CancelOptionAccountConstraints
             &mut context.accounts.quote_vault,
             &context.accounts.quote_mint,
             &mut context.accounts.writer_quote,
-            &context.accounts.market_authority,
             market,
             collateral,
         ),
@@ -96,13 +92,6 @@ pub struct CancelOptionAccountConstraints {
         bump = option.bump,
     )]
     pub option: Box<BorshAccount<OptionContract>>,
-
-    /// CHECK: PDA authority over both vaults; holds no data, only signs.
-    #[account(
-        seeds = [AUTHORITY_SEED, market.address().as_ref()],
-        bump = market.authority_bump,
-    )]
-    pub market_authority: UncheckedAccount,
 
     #[account(address = market.underlying_mint)]
     pub underlying_mint: Box<InterfaceAccount<Mint>>,

--- a/finance/options/anchor/programs/options/src/instructions/collect_fees.rs
+++ b/finance/options/anchor/programs/options/src/instructions/collect_fees.rs
@@ -4,7 +4,7 @@ use anchor_spl::{
     token_interface::{Mint, TokenAccount, TokenInterface},
 };
 
-use crate::constants::{AUTHORITY_SEED, MARKET_SEED, QUOTE_VAULT_SEED};
+use crate::constants::{MARKET_SEED, QUOTE_VAULT_SEED};
 use crate::errors::OptionsError;
 use crate::instructions::shared::{check_custody, transfer_from_vault};
 use crate::state::Market;
@@ -36,7 +36,6 @@ pub fn handle_collect_fees(context: &mut Context<CollectFeesAccountConstraints>)
         &mut context.accounts.quote_vault,
         &context.accounts.quote_mint,
         &mut context.accounts.admin_quote,
-        &context.accounts.market_authority,
         market,
         amount,
     )
@@ -53,13 +52,6 @@ pub struct CollectFeesAccountConstraints {
         bump = market.bump,
     )]
     pub market: Box<BorshAccount<Market>>,
-
-    /// CHECK: PDA authority over both vaults; holds no data, only signs.
-    #[account(
-        seeds = [AUTHORITY_SEED, market.address().as_ref()],
-        bump = market.authority_bump,
-    )]
-    pub market_authority: UncheckedAccount,
 
     #[account(address = market.quote_mint)]
     pub quote_mint: Box<InterfaceAccount<Mint>>,

--- a/finance/options/anchor/programs/options/src/instructions/collect_proceeds.rs
+++ b/finance/options/anchor/programs/options/src/instructions/collect_proceeds.rs
@@ -4,9 +4,7 @@ use anchor_spl::{
     token_interface::{Mint, TokenAccount, TokenInterface},
 };
 
-use crate::constants::{
-    AUTHORITY_SEED, MARKET_SEED, OPTION_SEED, QUOTE_VAULT_SEED, UNDERLYING_VAULT_SEED,
-};
+use crate::constants::{MARKET_SEED, OPTION_SEED, QUOTE_VAULT_SEED, UNDERLYING_VAULT_SEED};
 use crate::contract_math;
 use crate::errors::OptionsError;
 use crate::instructions::shared::{check_custody, transfer_from_vault};
@@ -66,7 +64,6 @@ pub fn handle_collect_proceeds(
             &mut context.accounts.quote_vault,
             &context.accounts.quote_mint,
             &mut context.accounts.writer_quote,
-            &context.accounts.market_authority,
             market,
             proceeds,
         ),
@@ -75,7 +72,6 @@ pub fn handle_collect_proceeds(
             &mut context.accounts.underlying_vault,
             &context.accounts.underlying_mint,
             &mut context.accounts.writer_underlying,
-            &context.accounts.market_authority,
             market,
             proceeds,
         ),
@@ -103,13 +99,6 @@ pub struct CollectProceedsAccountConstraints {
         bump = option.bump,
     )]
     pub option: Box<BorshAccount<OptionContract>>,
-
-    /// CHECK: PDA authority over both vaults; holds no data, only signs.
-    #[account(
-        seeds = [AUTHORITY_SEED, market.address().as_ref()],
-        bump = market.authority_bump,
-    )]
-    pub market_authority: UncheckedAccount,
 
     #[account(address = market.underlying_mint)]
     pub underlying_mint: Box<InterfaceAccount<Mint>>,

--- a/finance/options/anchor/programs/options/src/instructions/exercise_option.rs
+++ b/finance/options/anchor/programs/options/src/instructions/exercise_option.rs
@@ -4,9 +4,7 @@ use anchor_spl::{
     token_interface::{Mint, TokenAccount, TokenInterface},
 };
 
-use crate::constants::{
-    AUTHORITY_SEED, MARKET_SEED, OPTION_SEED, QUOTE_VAULT_SEED, UNDERLYING_VAULT_SEED,
-};
+use crate::constants::{MARKET_SEED, OPTION_SEED, QUOTE_VAULT_SEED, UNDERLYING_VAULT_SEED};
 use crate::contract_math;
 use crate::errors::OptionsError;
 use crate::instructions::shared::{check_custody, transfer_from_signer, transfer_from_vault};
@@ -106,7 +104,6 @@ pub fn handle_exercise_option(
                 &mut context.accounts.underlying_vault,
                 &context.accounts.underlying_mint,
                 &mut context.accounts.holder_underlying,
-                &context.accounts.market_authority,
                 market,
                 underlying_total,
             )
@@ -125,7 +122,6 @@ pub fn handle_exercise_option(
                 &mut context.accounts.quote_vault,
                 &context.accounts.quote_mint,
                 &mut context.accounts.holder_quote,
-                &context.accounts.market_authority,
                 market,
                 strike_total,
             )
@@ -157,13 +153,6 @@ pub struct ExerciseOptionAccountConstraints {
         bump = option.bump,
     )]
     pub option: Box<BorshAccount<OptionContract>>,
-
-    /// CHECK: PDA authority over both vaults; holds no data, only signs.
-    #[account(
-        seeds = [AUTHORITY_SEED, market.address().as_ref()],
-        bump = market.authority_bump,
-    )]
-    pub market_authority: UncheckedAccount,
 
     #[account(address = market.underlying_mint)]
     pub underlying_mint: Box<InterfaceAccount<Mint>>,

--- a/finance/options/anchor/programs/options/src/instructions/initialize_market.rs
+++ b/finance/options/anchor/programs/options/src/instructions/initialize_market.rs
@@ -3,7 +3,7 @@ use anchor_spl::token;
 use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
 
 use crate::constants::{
-    AUTHORITY_SEED, BASIS_POINTS_DENOMINATOR, MARKET_SEED, QUOTE_VAULT_SEED, UNDERLYING_VAULT_SEED,
+    BASIS_POINTS_DENOMINATOR, MARKET_SEED, QUOTE_VAULT_SEED, UNDERLYING_VAULT_SEED,
 };
 use crate::errors::OptionsError;
 use crate::state::Market;
@@ -36,7 +36,6 @@ pub fn handle_initialize_market(
     market.fees_owed = 0;
     market.fee_bps = fee_bps;
     market.bump = context.bumps.market;
-    market.authority_bump = context.bumps.market_authority;
 
     Ok(())
 }
@@ -61,21 +60,15 @@ pub struct InitializeMarketAccountConstraints {
 
     pub quote_mint: Box<InterfaceAccount<Mint>>,
 
-    /// CHECK: PDA that owns both vaults. Holds no data; used only to sign
-    /// vault CPIs.
-    #[account(
-        seeds = [AUTHORITY_SEED, market.address().as_ref()],
-        bump,
-    )]
-    pub market_authority: UncheckedAccount,
-
+    // The market account is the token authority of both vaults: it signs
+    // every transfer out of them with its own PDA seeds.
     #[account(
         init,
         payer = admin,
         seeds = [UNDERLYING_VAULT_SEED, market.address().as_ref()],
         bump,
         token::mint = underlying_mint,
-        token::authority = market_authority,
+        token::authority = market,
         token::token_program = token_program,
     )]
     pub underlying_vault: Box<InterfaceAccount<TokenAccount>>,
@@ -86,7 +79,7 @@ pub struct InitializeMarketAccountConstraints {
         seeds = [QUOTE_VAULT_SEED, market.address().as_ref()],
         bump,
         token::mint = quote_mint,
-        token::authority = market_authority,
+        token::authority = market,
         token::token_program = token_program,
     )]
     pub quote_vault: Box<InterfaceAccount<TokenAccount>>,

--- a/finance/options/anchor/programs/options/src/instructions/reclaim_collateral.rs
+++ b/finance/options/anchor/programs/options/src/instructions/reclaim_collateral.rs
@@ -1,9 +1,7 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
 
-use crate::constants::{
-    AUTHORITY_SEED, MARKET_SEED, OPTION_SEED, QUOTE_VAULT_SEED, UNDERLYING_VAULT_SEED,
-};
+use crate::constants::{MARKET_SEED, OPTION_SEED, QUOTE_VAULT_SEED, UNDERLYING_VAULT_SEED};
 use crate::contract_math;
 use crate::errors::OptionsError;
 use crate::instructions::shared::{check_custody, transfer_from_vault};
@@ -68,7 +66,6 @@ pub fn handle_reclaim_collateral(
             &mut context.accounts.underlying_vault,
             &context.accounts.underlying_mint,
             &mut context.accounts.writer_underlying,
-            &context.accounts.market_authority,
             market,
             collateral,
         ),
@@ -77,7 +74,6 @@ pub fn handle_reclaim_collateral(
             &mut context.accounts.quote_vault,
             &context.accounts.quote_mint,
             &mut context.accounts.writer_quote,
-            &context.accounts.market_authority,
             market,
             collateral,
         ),
@@ -105,13 +101,6 @@ pub struct ReclaimCollateralAccountConstraints {
         bump = option.bump,
     )]
     pub option: Box<BorshAccount<OptionContract>>,
-
-    /// CHECK: PDA authority over both vaults; holds no data, only signs.
-    #[account(
-        seeds = [AUTHORITY_SEED, market.address().as_ref()],
-        bump = market.authority_bump,
-    )]
-    pub market_authority: UncheckedAccount,
 
     #[account(address = market.underlying_mint)]
     pub underlying_mint: Box<InterfaceAccount<Mint>>,

--- a/finance/options/anchor/programs/options/src/instructions/shared.rs
+++ b/finance/options/anchor/programs/options/src/instructions/shared.rs
@@ -3,7 +3,7 @@ use anchor_spl::token_interface::{
     transfer_checked, Mint, TokenAccount, TokenInterface, TransferChecked,
 };
 
-use crate::constants::AUTHORITY_SEED;
+use crate::constants::MARKET_SEED;
 use crate::errors::OptionsError;
 use crate::state::Market;
 
@@ -52,21 +52,33 @@ pub fn transfer_from_signer(
     )
 }
 
-/// A transfer out of a vault, signed by the market's vault authority PDA.
-/// Takes the market by reference for its address and authority bump, so the
-/// caller must have finished mutating it (it has: effects come before CPIs).
+/// A transfer out of a vault, signed by the market account, which is the
+/// token authority of both vaults. Takes the market mutably: it is a data
+/// account, so it holds a live borrow on its buffer, and the runtime rejects
+/// a CPI that borrows it again. The borrow is released around the CPI and
+/// taken back afterwards so the derive's exit path can still serialize it.
+/// The caller must have finished mutating the market (it has: effects come
+/// before CPIs).
 pub fn transfer_from_vault(
     token_program: &Interface<'static, TokenInterface>,
     vault: &mut InterfaceAccount<TokenAccount>,
     mint: &InterfaceAccount<Mint>,
     to: &mut InterfaceAccount<TokenAccount>,
-    market_authority: &UncheckedAccount,
-    market: &BorshAccount<Market>,
+    market: &mut BorshAccount<Market>,
     amount: u64,
 ) -> Result<()> {
-    let market_key = market.address();
-    let bump = [market.authority_bump];
-    let authority_seeds: &[&[u8]] = &[AUTHORITY_SEED, market_key.as_ref(), &bump];
+    let underlying_mint = market.underlying_mint;
+    let quote_mint = market.quote_mint;
+    let bump = [market.bump];
+    let market_seeds: &[&[u8]] = &[
+        MARKET_SEED,
+        underlying_mint.as_ref(),
+        quote_mint.as_ref(),
+        &bump,
+    ];
+
+    market.release_borrow()?;
+    let market_view = *market.account();
     transfer_checked(
         CpiContext::new_with_signer(
             token_program.address(),
@@ -74,11 +86,12 @@ pub fn transfer_from_vault(
                 from: vault.to_cpi_handle_mut(),
                 mint: mint.to_cpi_handle(),
                 to: to.to_cpi_handle_mut(),
-                authority: market_authority.cpi_handle(),
+                authority: CpiHandle::readonly(&market_view),
             },
-            &[authority_seeds],
+            &[market_seeds],
         ),
         amount,
         mint.decimals(),
-    )
+    )?;
+    market.reacquire_borrow_mut()
 }

--- a/finance/options/anchor/programs/options/src/state/market.rs
+++ b/finance/options/anchor/programs/options/src/state/market.rs
@@ -41,9 +41,8 @@ pub struct Market {
     /// Fee charged on each premium, in basis points. The venue's revenue.
     pub fee_bps: u16,
 
+    /// Bump of this account's own PDA. The market is the token authority of
+    /// both vaults and signs every transfer out of them with its seeds, so the
+    /// bump is stored to save re-deriving it on each CPI.
     pub bump: u8,
-
-    /// Bump for the vault authority PDA, stored so CPIs can sign without
-    /// re-deriving it.
-    pub authority_bump: u8,
 }

--- a/finance/options/anchor/programs/options/tests/test_options.rs
+++ b/finance/options/anchor/programs/options/tests/test_options.rs
@@ -85,7 +85,6 @@ struct Venue {
     underlying_mint: Address,
     quote_mint: Address,
     market: Address,
-    market_authority: Address,
     underlying_vault: Address,
     quote_vault: Address,
 }
@@ -133,8 +132,6 @@ impl Venue {
             &options::id(),
         )
         .0;
-        let market_authority =
-            Address::find_program_address(&[b"authority", market.as_ref()], &options::id()).0;
         let underlying_vault =
             Address::find_program_address(&[b"underlying_vault", market.as_ref()], &options::id())
                 .0;
@@ -149,7 +146,6 @@ impl Venue {
                 market,
                 underlying_mint,
                 quote_mint,
-                market_authority,
                 underlying_vault,
                 quote_vault,
                 token_program: token_program_id(),
@@ -172,7 +168,6 @@ impl Venue {
             underlying_mint,
             quote_mint,
             market,
-            market_authority,
             underlying_vault,
             quote_vault,
         })
@@ -271,6 +266,13 @@ impl Venue {
         get_token_account_balance(&self.svm, token_account).unwrap()
     }
 
+    /// The token authority of a token account: bytes 32..64 of the SPL Token
+    /// account layout.
+    fn token_authority(&self, token_account: &Address) -> Address {
+        let account = self.svm.get_account(token_account).unwrap();
+        Address::try_from(&account.data[32..64]).unwrap()
+    }
+
     fn send(&mut self, instruction: Instruction, signer: &Keypair) -> Result<(), ()> {
         send_transaction_from_instructions(
             &mut self.svm,
@@ -364,7 +366,6 @@ impl Venue {
                 writer: writer.pubkey(),
                 market: self.market,
                 option: *option,
-                market_authority: self.market_authority,
                 underlying_mint: self.underlying_mint,
                 quote_mint: self.quote_mint,
                 underlying_vault: self.underlying_vault,
@@ -392,7 +393,6 @@ impl Venue {
                 writer: *writer,
                 market: self.market,
                 option: *option,
-                market_authority: self.market_authority,
                 underlying_mint: self.underlying_mint,
                 quote_mint: self.quote_mint,
                 underlying_vault: self.underlying_vault,
@@ -416,7 +416,6 @@ impl Venue {
                 writer: writer.pubkey(),
                 market: self.market,
                 option: *option,
-                market_authority: self.market_authority,
                 underlying_mint: self.underlying_mint,
                 quote_mint: self.quote_mint,
                 underlying_vault: self.underlying_vault,
@@ -440,7 +439,6 @@ impl Venue {
                 writer: writer.pubkey(),
                 market: self.market,
                 option: *option,
-                market_authority: self.market_authority,
                 underlying_mint: self.underlying_mint,
                 quote_mint: self.quote_mint,
                 underlying_vault: self.underlying_vault,
@@ -461,7 +459,6 @@ impl Venue {
             options::accounts::CollectFeesAccountConstraints {
                 admin: signer.pubkey(),
                 market: self.market,
-                market_authority: self.market_authority,
                 quote_mint: self.quote_mint,
                 underlying_vault: self.underlying_vault,
                 quote_vault: self.quote_vault,
@@ -501,6 +498,16 @@ impl Venue {
 // ===========================================================================
 // The call: write, buy, exercise, collect
 // ===========================================================================
+
+/// The market account itself is the token authority of both vaults: there is
+/// no separate signer, so every transfer out of a vault is signed with the
+/// market's own seeds.
+#[test]
+fn test_market_owns_both_vaults() {
+    let venue = Venue::new();
+    assert_eq!(venue.token_authority(&venue.underlying_vault), venue.market);
+    assert_eq!(venue.token_authority(&venue.quote_vault), venue.market);
+}
 
 /// Alice writes 5 covered calls on her 5 NVDAx. The whole 5 NVDAx moves into
 /// the vault at once; the option is listed for a 25 USDC premium.

--- a/finance/options/quasar/CHANGELOG.md
+++ b/finance/options/quasar/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-09-10
+
+The `Market` account is now the token authority of both vaults and signs
+every transfer out of them with its own seeds. The separate dataless signer
+PDA, the second bump `Market` stored for it, and the extra account
+`initialize_market`, `cancel_option`, `exercise_option`, `collect_proceeds`,
+`reclaim_collateral` and `collect_fees` took for it are gone.
+
 ## 2026-09-04
 
 Initial version: Quasar port of the options example, matching the Anchor

--- a/finance/options/quasar/src/instructions/cancel_option.rs
+++ b/finance/options/quasar/src/instructions/cancel_option.rs
@@ -3,7 +3,7 @@ use {
         constants::STATUS_LISTED,
         errors::OptionsError,
         instructions::shared::{check_custody, sub_locked, transfer_from_vault, Terms},
-        state::{Market, MarketAuthorityPda, OptionContract},
+        state::{Market, OptionContract},
     },
     quasar_lang::prelude::*,
     quasar_spl::prelude::*,
@@ -28,9 +28,6 @@ pub struct CancelOptionAccountConstraints {
         address = OptionContract::seeds(market.address(), writer.address(), option.id.into()),
     )]
     pub option: Account<OptionContract>,
-    /// Authority PDA over both vaults; holds no data, only signs.
-    #[account(address = MarketAuthorityPda::seeds(market.address()))]
-    pub market_authority: UncheckedAccount,
     pub underlying_mint: Account<Mint>,
     pub quote_mint: Account<Mint>,
     #[account(mut)]
@@ -85,7 +82,6 @@ pub fn handle_cancel_option(
             &accounts.underlying_vault,
             &accounts.underlying_mint,
             &accounts.writer_underlying,
-            &accounts.market_authority,
             &accounts.market,
             collateral,
         )
@@ -95,7 +91,6 @@ pub fn handle_cancel_option(
             &accounts.quote_vault,
             &accounts.quote_mint,
             &accounts.writer_quote,
-            &accounts.market_authority,
             &accounts.market,
             collateral,
         )

--- a/finance/options/quasar/src/instructions/collect_fees.rs
+++ b/finance/options/quasar/src/instructions/collect_fees.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         errors::OptionsError,
         instructions::shared::{check_custody, transfer_from_vault},
-        state::{Market, MarketAuthorityPda},
+        state::Market,
     },
     quasar_lang::prelude::*,
     quasar_spl::prelude::*,
@@ -20,9 +20,6 @@ pub struct CollectFeesAccountConstraints {
         has_one(quote_vault),
     )]
     pub market: Account<Market>,
-    /// Authority PDA over both vaults; holds no data, only signs.
-    #[account(address = MarketAuthorityPda::seeds(market.address()))]
-    pub market_authority: UncheckedAccount,
     /// CHECK: seed input for the market PDA.
     pub underlying_mint: UncheckedAccount,
     pub quote_mint: Account<Mint>,
@@ -63,7 +60,6 @@ pub fn handle_collect_fees(
         &accounts.quote_vault,
         &accounts.quote_mint,
         &accounts.admin_quote,
-        &accounts.market_authority,
         &accounts.market,
         amount,
     )

--- a/finance/options/quasar/src/instructions/collect_proceeds.rs
+++ b/finance/options/quasar/src/instructions/collect_proceeds.rs
@@ -3,7 +3,7 @@ use {
         constants::STATUS_EXERCISED,
         errors::OptionsError,
         instructions::shared::{check_custody, sub_locked, transfer_from_vault, Terms},
-        state::{Market, MarketAuthorityPda, OptionContract},
+        state::{Market, OptionContract},
     },
     quasar_lang::prelude::*,
     quasar_spl::prelude::*,
@@ -28,9 +28,6 @@ pub struct CollectProceedsAccountConstraints {
         address = OptionContract::seeds(market.address(), writer.address(), option.id.into()),
     )]
     pub option: Account<OptionContract>,
-    /// Authority PDA over both vaults; holds no data, only signs.
-    #[account(address = MarketAuthorityPda::seeds(market.address()))]
-    pub market_authority: UncheckedAccount,
     pub underlying_mint: Account<Mint>,
     pub quote_mint: Account<Mint>,
     #[account(mut)]
@@ -88,7 +85,6 @@ pub fn handle_collect_proceeds(
             &accounts.quote_vault,
             &accounts.quote_mint,
             &accounts.writer_quote,
-            &accounts.market_authority,
             &accounts.market,
             proceeds,
         )
@@ -98,7 +94,6 @@ pub fn handle_collect_proceeds(
             &accounts.underlying_vault,
             &accounts.underlying_mint,
             &accounts.writer_underlying,
-            &accounts.market_authority,
             &accounts.market,
             proceeds,
         )

--- a/finance/options/quasar/src/instructions/exercise_option.rs
+++ b/finance/options/quasar/src/instructions/exercise_option.rs
@@ -5,7 +5,7 @@ use {
         instructions::shared::{
             add_locked, check_custody, may_exercise, sub_locked, transfer_from_vault, Terms,
         },
-        state::{Market, MarketAuthorityPda, OptionContract},
+        state::{Market, OptionContract},
     },
     quasar_lang::{prelude::*, sysvars::Sysvar as _},
     quasar_spl::prelude::*,
@@ -33,9 +33,6 @@ pub struct ExerciseOptionAccountConstraints {
         address = OptionContract::seeds(market.address(), writer.address(), option.id.into()),
     )]
     pub option: Account<OptionContract>,
-    /// Authority PDA over both vaults; holds no data, only signs.
-    #[account(address = MarketAuthorityPda::seeds(market.address()))]
-    pub market_authority: UncheckedAccount,
     pub underlying_mint: Account<Mint>,
     pub quote_mint: Account<Mint>,
     #[account(mut)]
@@ -127,7 +124,6 @@ pub fn handle_exercise_option(
             &accounts.underlying_vault,
             &accounts.underlying_mint,
             &accounts.holder_underlying,
-            &accounts.market_authority,
             &accounts.market,
             underlying_total,
         )
@@ -148,7 +144,6 @@ pub fn handle_exercise_option(
             &accounts.quote_vault,
             &accounts.quote_mint,
             &accounts.holder_quote,
-            &accounts.market_authority,
             &accounts.market,
             strike_total,
         )

--- a/finance/options/quasar/src/instructions/initialize_market.rs
+++ b/finance/options/quasar/src/instructions/initialize_market.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         constants::BASIS_POINTS_DENOMINATOR,
         errors::OptionsError,
-        state::{Market, MarketAuthorityPda, MarketInner, QuoteVaultPda, UnderlyingVaultPda},
+        state::{Market, MarketInner, QuoteVaultPda, UnderlyingVaultPda},
     },
     quasar_lang::prelude::*,
     quasar_spl::prelude::*,
@@ -23,15 +23,14 @@ pub struct InitializeMarketAccountConstraints {
     pub market: Account<Market>,
     pub underlying_mint: Account<Mint>,
     pub quote_mint: Account<Mint>,
-    /// Authority PDA over both vaults. Holds no data; only signs.
-    #[account(address = MarketAuthorityPda::seeds(market.address()))]
-    pub market_authority: UncheckedAccount,
+    // The market account is the token authority of both vaults: it signs
+    // every transfer out of them with its own PDA seeds.
     #[account(
         mut,
         init(idempotent),
         payer = admin,
         address = UnderlyingVaultPda::seeds(market.address()),
-        token(mint = underlying_mint, authority = market_authority, token_program = token_program),
+        token(mint = underlying_mint, authority = market, token_program = token_program),
     )]
     pub underlying_vault: Account<Token>,
     #[account(
@@ -39,7 +38,7 @@ pub struct InitializeMarketAccountConstraints {
         init(idempotent),
         payer = admin,
         address = QuoteVaultPda::seeds(market.address()),
-        token(mint = quote_mint, authority = market_authority, token_program = token_program),
+        token(mint = quote_mint, authority = market, token_program = token_program),
     )]
     pub quote_vault: Account<Token>,
     pub token_program: Program<TokenProgram>,
@@ -76,7 +75,6 @@ pub fn handle_initialize_market(
         fees_owed: 0,
         fee_bps,
         bump: bumps.market,
-        authority_bump: bumps.market_authority,
     });
     Ok(())
 }

--- a/finance/options/quasar/src/instructions/reclaim_collateral.rs
+++ b/finance/options/quasar/src/instructions/reclaim_collateral.rs
@@ -5,7 +5,7 @@ use {
         instructions::shared::{
             check_custody, may_reclaim, sub_locked, transfer_from_vault, Terms,
         },
-        state::{Market, MarketAuthorityPda, OptionContract},
+        state::{Market, OptionContract},
     },
     quasar_lang::{prelude::*, sysvars::Sysvar as _},
     quasar_spl::prelude::*,
@@ -30,9 +30,6 @@ pub struct ReclaimCollateralAccountConstraints {
         address = OptionContract::seeds(market.address(), writer.address(), option.id.into()),
     )]
     pub option: Account<OptionContract>,
-    /// Authority PDA over both vaults; holds no data, only signs.
-    #[account(address = MarketAuthorityPda::seeds(market.address()))]
-    pub market_authority: UncheckedAccount,
     pub underlying_mint: Account<Mint>,
     pub quote_mint: Account<Mint>,
     #[account(mut)]
@@ -96,7 +93,6 @@ pub fn handle_reclaim_collateral(
             &accounts.underlying_vault,
             &accounts.underlying_mint,
             &accounts.writer_underlying,
-            &accounts.market_authority,
             &accounts.market,
             collateral,
         )
@@ -106,7 +102,6 @@ pub fn handle_reclaim_collateral(
             &accounts.quote_vault,
             &accounts.quote_mint,
             &accounts.writer_quote,
-            &accounts.market_authority,
             &accounts.market,
             collateral,
         )

--- a/finance/options/quasar/src/instructions/shared.rs
+++ b/finance/options/quasar/src/instructions/shared.rs
@@ -155,24 +155,24 @@ pub fn sub_locked(
     Ok(())
 }
 
-/// A transfer out of a vault, signed by the market's vault authority PDA.
+/// A transfer out of a vault, signed by the market account, which is the
+/// token authority of both vaults.
 pub fn transfer_from_vault(
     token_program: &Program<TokenProgram>,
     vault: &Account<Token>,
     mint: &Account<Mint>,
     to: &Account<Token>,
-    market_authority: &UncheckedAccount,
     market: &Account<Market>,
     amount: u64,
 ) -> Result<(), ProgramError> {
-    let bump = [market.authority_bump];
-    let market_address = *market.address();
+    let bump = [market.bump];
     let seeds: &[Seed] = &[
-        Seed::from(b"authority".as_ref()),
-        Seed::from(market_address.as_ref()),
+        Seed::from(b"market".as_ref()),
+        Seed::from(market.underlying_mint.as_ref()),
+        Seed::from(market.quote_mint.as_ref()),
         Seed::from(&bump as &[u8]),
     ];
     token_program
-        .transfer_checked(vault, mint, to, market_authority, amount, mint.decimals())
+        .transfer_checked(vault, mint, to, market, amount, mint.decimals())
         .invoke_signed(seeds)
 }

--- a/finance/options/quasar/src/state.rs
+++ b/finance/options/quasar/src/state.rs
@@ -22,8 +22,9 @@ pub struct Market {
     pub fees_owed: u64,
     /// Fee charged on each premium, in basis points.
     pub fee_bps: u16,
+    /// Bump of this account's own PDA. The market is the token authority of
+    /// both vaults and signs every transfer out of them with its seeds.
     pub bump: u8,
-    pub authority_bump: u8,
 }
 
 /// One option. Mirrors the Anchor `OptionContract`; `kind` and `status`
@@ -53,12 +54,6 @@ pub struct OptionContract {
     pub status: u8,
     pub bump: u8,
 }
-
-/// Authority PDA at seeds = [b"authority", market]. Holds no data; signs
-/// every transfer out of either vault.
-#[derive(Seeds)]
-#[seeds(b"authority", market: Address)]
-pub struct MarketAuthorityPda;
 
 /// Underlying-token vault PDA at seeds = [b"underlying_vault", market].
 #[derive(Seeds)]

--- a/finance/options/quasar/src/tests.rs
+++ b/finance/options/quasar/src/tests.rs
@@ -298,6 +298,13 @@ fn collect_fees(test: &mut Test, env: &Env, admin: Pubkey, admin_quote: Pubkey) 
     })
 }
 
+/// The token authority of a token account: bytes 32..64 of the SPL Token
+/// account layout.
+fn token_authority(test: &Test, token_account: Pubkey) -> Pubkey {
+    let account = test.account(token_account).unwrap();
+    Pubkey::try_from(&account.data[32..64]).unwrap()
+}
+
 /// The custody invariant: each vault holds exactly what the market owes.
 fn assert_vaults_match_ledger(test: &Test, env: &Env) {
     let market = test.read::<Market>(env.market);
@@ -316,6 +323,16 @@ fn assert_vaults_match_ledger(test: &Test, env: &Env) {
 // ===========================================================================
 // The call: write, buy, exercise, collect
 // ===========================================================================
+
+/// The market account itself is the token authority of both vaults: there is
+/// no separate signer, so every transfer out of a vault is signed with the
+/// market's own seeds.
+#[quasar_test]
+fn market_owns_both_vaults(test: &mut Test) {
+    let env = setup(test);
+    assert_eq!(token_authority(test, env.underlying_vault), env.market);
+    assert_eq!(token_authority(test, env.quote_vault), env.market);
+}
 
 /// Alice writes 5 covered calls on her 5 NVDAx. The whole 5 NVDAx moves into
 /// the vault at once; the option is listed for a 25 USDC premium.

--- a/finance/perpetual-futures/anchor-v1/CHANGELOG.md
+++ b/finance/perpetual-futures/anchor-v1/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2026-09-10
+
+Remove the separate dataless signing PDA (seeds `["authority", pool]`) that
+owned the vault and the LP mint, and the bump field on `Pool` that recorded it.
+The pool account is already a PDA, so it is now the custody vault's owner and
+the LP mint's authority itself, and signs vault transfers and mint/burn CPIs
+with its own seeds, `["pool", collateral_mint, oracle_feed, bump]`: the pattern
+the escrow example uses for its vault and the vault-strategy example uses for
+its share mint. `initialize_pool`, `add_liquidity`, `remove_liquidity`,
+`close_position`, `liquidate_position` and `collect_fees` each take one account
+fewer. The admin signer stored on `Pool` as `authority` (the pool operator) is
+unchanged. `test_initialize_pool` now also checks that the vault's owner and the
+mint's authority are the pool.
+
 ## 2026-09-08
 
 Move to Anchor 1.2.0, LiteSVM 0.16.0 and solana-kite 0.5.0. No program source
@@ -11,7 +25,7 @@ warp relative to the current slot, as the other tests already did.
 
 ## 2026-08-14
 
-Add `set_funding_rate`, so the pool authority can retune `funding_rate_per_slot`
+Add `set_funding_rate`, so the pool operator can retune `funding_rate_per_slot`
 after the pool is created. The rate is quoted per slot, so what a position costs
 per hour depends on the cluster's slot time as well as on the rate; Solana lowers
 the slot time over time, and a pool created before a reduction charges the

--- a/finance/perpetual-futures/anchor-v1/README.md
+++ b/finance/perpetual-futures/anchor-v1/README.md
@@ -48,7 +48,7 @@ So a winning trader can always be paid, the pool **reserves** liquidity to back 
 
 [Funding](https://www.investopedia.com/terms/f/futurescontract.asp) anchors the pool's risk: the heavier side of [open interest](https://www.investopedia.com/terms/o/openinterest.asp) pays the pool over time. A cumulative funding index rises while longs are the larger side and falls while shorts are, advancing by `funding_rate_per_slot` each [slot](https://solana.com/docs/terminology#slot); a position records the index at open and settles the change when it closes. In a pool-based perp this is the equivalent of the borrow fee Jupiter Perpetuals charges.
 
-Because the rate is quoted per slot, what a position costs per hour depends on the cluster's slot time as well as on the rate. Solana lowers the slot time over time, so a pool that outlives a reduction charges the heavier side more per hour than it was set up to. `set_funding_rate(funding_rate_per_slot)` lets the pool authority bring it back in line; it advances the index at the old rate first, so slots already elapsed are charged at the rate that was in force for them.
+Because the rate is quoted per slot, what a position costs per hour depends on the cluster's slot time as well as on the rate. Solana lowers the slot time over time, so a pool that outlives a reduction charges the heavier side more per hour than it was set up to. `set_funding_rate(funding_rate_per_slot)` lets the pool operator bring it back in line; it advances the index at the old rate first, so slots already elapsed are charged at the rate that was in force for them.
 
 ### Maintenance margin and liquidation
 
@@ -68,7 +68,7 @@ Open and close fees are charged in [basis points](https://www.investopedia.com/t
 
 ### Participants
 
-- **Admin** (Pool authority): Operate the market and collect the protocol's slice of trading fees.
+- **Admin** (Pool operator): Operate the market and collect the protocol's slice of trading fees.
 - **Carol** (Liquidity provider): Earn fees by funding the pool and being the counterparty to traders.
 - **Alice** (Long trader): She has a thesis that NVDA will rise and wants leveraged upside without buying the stock.
 - **Bob** (Short trader): He thinks NVDA will fall and wants to profit from the downside.
@@ -84,10 +84,9 @@ Amounts below are shown in whole USDC; onchain they are base units (× 10⁶). T
 
 **Accounts created:**
 
-- `Pool` [PDA](https://solana.com/docs/terminology#program-derived-address-pda), seeds `["pool", collateral_mint, oracle_feed]`: parameters, liquidity, reserved liquidity, collateral total, per-side open-interest accumulators, funding index, protocol fees
-- `pool_authority` PDA, seeds `["authority", pool]`: nothing; signs vault and mint CPIs
-- `custody_vault` [token account](https://solana.com/docs/terminology#token-account) PDA, seeds `["vault", pool]`: all USDC, both provider liquidity and trader collateral
-- `lp_mint` PDA, seeds `["lp_mint", pool]`: the share [mint](https://solana.com/docs/terminology#mint-account); `pool_authority` is the mint authority
+- `Pool` [PDA](https://solana.com/docs/terminology#program-derived-address-pda), seeds `["pool", collateral_mint, oracle_feed]`: parameters, liquidity, reserved liquidity, collateral total, per-side open-interest accumulators, funding index, protocol fees. The pool owns the vault and is the LP mint's authority, and signs vault transfers and mint/burn CPIs with its own seeds; there is no separate signing PDA
+- `custody_vault` [token account](https://solana.com/docs/terminology#token-account) PDA, seeds `["vault", pool]`: all USDC, both provider liquidity and trader collateral; `pool` is its owner
+- `lp_mint` PDA, seeds `["lp_mint", pool]`: the share [mint](https://solana.com/docs/terminology#mint-account); `pool` is the mint authority
 
 ---
 

--- a/finance/perpetual-futures/anchor-v1/programs/perpetual-futures/src/constants.rs
+++ b/finance/perpetual-futures/anchor-v1/programs/perpetual-futures/src/constants.rs
@@ -39,9 +39,6 @@ pub const MAX_LEVERAGE_CEILING: u16 = 100;
 pub const POOL_SEED: &[u8] = b"pool";
 
 #[constant]
-pub const AUTHORITY_SEED: &[u8] = b"authority";
-
-#[constant]
 pub const LP_MINT_SEED: &[u8] = b"lp_mint";
 
 #[constant]

--- a/finance/perpetual-futures/anchor-v1/programs/perpetual-futures/src/instructions/add_liquidity.rs
+++ b/finance/perpetual-futures/anchor-v1/programs/perpetual-futures/src/instructions/add_liquidity.rs
@@ -6,7 +6,7 @@ use anchor_spl::{
     },
 };
 
-use crate::constants::{AUTHORITY_SEED, MINIMUM_LIQUIDITY, POOL_SEED, VAULT_SEED};
+use crate::constants::{MINIMUM_LIQUIDITY, POOL_SEED, VAULT_SEED};
 use crate::errors::PerpError;
 use crate::instructions::shared::{liquidity_provider_aum, refresh_price_and_funding};
 use crate::state::Pool;
@@ -65,17 +65,22 @@ pub fn handle_add_liquidity(
         context.accounts.collateral_mint.decimals,
     )?;
 
-    let pool_key = pool.key();
-    let authority_seeds: &[&[u8]] = &[AUTHORITY_SEED, pool_key.as_ref(), &[pool.authority_bump]];
+    // The pool signs the CPI below with its own seeds.
+    let pool_seeds: &[&[u8]] = &[
+        POOL_SEED,
+        pool.collateral_mint.as_ref(),
+        pool.oracle_feed.as_ref(),
+        &[pool.bump],
+    ];
     mint_to(
         CpiContext::new_with_signer(
             context.accounts.token_program.key(),
             MintTo {
                 mint: context.accounts.lp_mint.to_account_info(),
                 to: context.accounts.provider_lp.to_account_info(),
-                authority: context.accounts.pool_authority.to_account_info(),
+                authority: pool.to_account_info(),
             },
-            &[authority_seeds],
+            &[pool_seeds],
         ),
         shares,
     )?;
@@ -98,13 +103,6 @@ pub struct AddLiquidityAccountConstraints<'info> {
         has_one = oracle_feed,
     )]
     pub pool: Box<Account<'info, Pool>>,
-
-    /// CHECK: PDA authority over the vault and liquidity-provider mint.
-    #[account(
-        seeds = [AUTHORITY_SEED, pool.key().as_ref()],
-        bump = pool.authority_bump,
-    )]
-    pub pool_authority: UncheckedAccount<'info>,
 
     /// CHECK: validated by the `has_one = oracle_feed` constraint on the pool.
     pub oracle_feed: UncheckedAccount<'info>,

--- a/finance/perpetual-futures/anchor-v1/programs/perpetual-futures/src/instructions/close_position.rs
+++ b/finance/perpetual-futures/anchor-v1/programs/perpetual-futures/src/instructions/close_position.rs
@@ -4,7 +4,7 @@ use anchor_spl::{
     token_interface::{transfer_checked, Mint, TokenAccount, TokenInterface, TransferChecked},
 };
 
-use crate::constants::{AUTHORITY_SEED, POOL_SEED, POSITION_SEED, VAULT_SEED};
+use crate::constants::{POOL_SEED, POSITION_SEED, VAULT_SEED};
 use crate::errors::PerpError;
 use crate::instructions::shared::{basis_points_of, refresh_price_and_funding, settle_position};
 use crate::state::{Pool, Position};
@@ -66,8 +66,13 @@ pub fn handle_close_position(
         .checked_add(close_fee)
         .ok_or(PerpError::MathOverflow)?;
 
-    let pool_key = pool.key();
-    let authority_seeds: &[&[u8]] = &[AUTHORITY_SEED, pool_key.as_ref(), &[pool.authority_bump]];
+    // The pool signs the CPI below with its own seeds.
+    let pool_seeds: &[&[u8]] = &[
+        POOL_SEED,
+        pool.collateral_mint.as_ref(),
+        pool.oracle_feed.as_ref(),
+        &[pool.bump],
+    ];
     transfer_checked(
         CpiContext::new_with_signer(
             context.accounts.token_program.key(),
@@ -75,9 +80,9 @@ pub fn handle_close_position(
                 from: context.accounts.custody_vault.to_account_info(),
                 mint: context.accounts.collateral_mint.to_account_info(),
                 to: context.accounts.trader_collateral.to_account_info(),
-                authority: context.accounts.pool_authority.to_account_info(),
+                authority: pool.to_account_info(),
             },
-            &[authority_seeds],
+            &[pool_seeds],
         ),
         payout,
         context.accounts.collateral_mint.decimals,
@@ -110,13 +115,6 @@ pub struct ClosePositionAccountConstraints<'info> {
         has_one = pool,
     )]
     pub position: Box<Account<'info, Position>>,
-
-    /// CHECK: PDA authority over the vault.
-    #[account(
-        seeds = [AUTHORITY_SEED, pool.key().as_ref()],
-        bump = pool.authority_bump,
-    )]
-    pub pool_authority: UncheckedAccount<'info>,
 
     /// CHECK: validated by the `has_one = oracle_feed` constraint on the pool.
     pub oracle_feed: UncheckedAccount<'info>,

--- a/finance/perpetual-futures/anchor-v1/programs/perpetual-futures/src/instructions/collect_fees.rs
+++ b/finance/perpetual-futures/anchor-v1/programs/perpetual-futures/src/instructions/collect_fees.rs
@@ -4,7 +4,7 @@ use anchor_spl::{
     token_interface::{transfer_checked, Mint, TokenAccount, TokenInterface, TransferChecked},
 };
 
-use crate::constants::{AUTHORITY_SEED, POOL_SEED, VAULT_SEED};
+use crate::constants::{POOL_SEED, VAULT_SEED};
 use crate::errors::PerpError;
 use crate::state::Pool;
 
@@ -16,8 +16,13 @@ pub fn handle_collect_fees(context: Context<CollectFeesAccountConstraints>) -> R
     // Effects before interaction: zero the balance, then transfer.
     pool.protocol_fees = 0;
 
-    let pool_key = pool.key();
-    let authority_seeds: &[&[u8]] = &[AUTHORITY_SEED, pool_key.as_ref(), &[pool.authority_bump]];
+    // The pool signs the CPI below with its own seeds.
+    let pool_seeds: &[&[u8]] = &[
+        POOL_SEED,
+        pool.collateral_mint.as_ref(),
+        pool.oracle_feed.as_ref(),
+        &[pool.bump],
+    ];
     transfer_checked(
         CpiContext::new_with_signer(
             context.accounts.token_program.key(),
@@ -25,9 +30,9 @@ pub fn handle_collect_fees(context: Context<CollectFeesAccountConstraints>) -> R
                 from: context.accounts.custody_vault.to_account_info(),
                 mint: context.accounts.collateral_mint.to_account_info(),
                 to: context.accounts.authority_collateral.to_account_info(),
-                authority: context.accounts.pool_authority.to_account_info(),
+                authority: pool.to_account_info(),
             },
-            &[authority_seeds],
+            &[pool_seeds],
         ),
         amount,
         context.accounts.collateral_mint.decimals,
@@ -50,13 +55,6 @@ pub struct CollectFeesAccountConstraints<'info> {
         has_one = custody_vault,
     )]
     pub pool: Box<Account<'info, Pool>>,
-
-    /// CHECK: PDA authority over the vault.
-    #[account(
-        seeds = [AUTHORITY_SEED, pool.key().as_ref()],
-        bump = pool.authority_bump,
-    )]
-    pub pool_authority: UncheckedAccount<'info>,
 
     pub collateral_mint: Box<InterfaceAccount<'info, Mint>>,
 

--- a/finance/perpetual-futures/anchor-v1/programs/perpetual-futures/src/instructions/initialize_pool.rs
+++ b/finance/perpetual-futures/anchor-v1/programs/perpetual-futures/src/instructions/initialize_pool.rs
@@ -5,8 +5,7 @@ use anchor_spl::{
 };
 
 use crate::constants::{
-    AUTHORITY_SEED, BASIS_POINTS_DENOMINATOR, LP_MINT_SEED, MAX_LEVERAGE_CEILING, POOL_SEED,
-    VAULT_SEED,
+    BASIS_POINTS_DENOMINATOR, LP_MINT_SEED, MAX_LEVERAGE_CEILING, POOL_SEED, VAULT_SEED,
 };
 use crate::errors::PerpError;
 use crate::state::Pool;
@@ -100,7 +99,6 @@ pub fn handle_initialize_pool(
     pool.liquidation_fee_bps = parameters.liquidation_fee_bps;
     pool.max_confidence_bps = parameters.max_confidence_bps;
     pool.bump = context.bumps.pool;
-    pool.authority_bump = context.bumps.pool_authority;
 
     Ok(())
 }
@@ -126,32 +124,28 @@ pub struct InitializePoolAccountConstraints<'info> {
     /// type. Swap for a real Switchboard feed in production.
     pub oracle_feed: UncheckedAccount<'info>,
 
-    /// CHECK: PDA that owns the vault and the liquidity-provider mint. Holds no
-    /// data; used only to sign vault and mint CPIs.
-    #[account(
-        seeds = [AUTHORITY_SEED, pool.key().as_ref()],
-        bump,
-    )]
-    pub pool_authority: UncheckedAccount<'info>,
-
+    /// Liquidity-provider share mint. The pool account is its mint authority
+    /// and signs every mint and burn with its own seeds.
     #[account(
         init,
         payer = authority,
         seeds = [LP_MINT_SEED, pool.key().as_ref()],
         bump,
         mint::decimals = collateral_mint.decimals,
-        mint::authority = pool_authority,
+        mint::authority = pool,
         mint::token_program = token_program,
     )]
     pub lp_mint: Box<InterfaceAccount<'info, Mint>>,
 
+    /// Custody vault for all collateral. The pool account owns it and signs
+    /// every transfer out with its own seeds.
     #[account(
         init,
         payer = authority,
         seeds = [VAULT_SEED, pool.key().as_ref()],
         bump,
         token::mint = collateral_mint,
-        token::authority = pool_authority,
+        token::authority = pool,
         token::token_program = token_program,
     )]
     pub custody_vault: Box<InterfaceAccount<'info, TokenAccount>>,

--- a/finance/perpetual-futures/anchor-v1/programs/perpetual-futures/src/instructions/liquidate_position.rs
+++ b/finance/perpetual-futures/anchor-v1/programs/perpetual-futures/src/instructions/liquidate_position.rs
@@ -4,7 +4,7 @@ use anchor_spl::{
     token_interface::{transfer_checked, Mint, TokenAccount, TokenInterface, TransferChecked},
 };
 
-use crate::constants::{AUTHORITY_SEED, POOL_SEED, POSITION_SEED, VAULT_SEED};
+use crate::constants::{POOL_SEED, POSITION_SEED, VAULT_SEED};
 use crate::errors::PerpError;
 use crate::instructions::shared::{basis_points_of, refresh_price_and_funding, settle_position};
 use crate::state::{Pool, Position};
@@ -60,8 +60,13 @@ pub fn handle_liquidate_position(
         .try_into()
         .map_err(|_| PerpError::MathOverflow)?;
 
-    let pool_key = pool.key();
-    let authority_seeds: &[&[u8]] = &[AUTHORITY_SEED, pool_key.as_ref(), &[pool.authority_bump]];
+    // The pool signs the CPI below with its own seeds.
+    let pool_seeds: &[&[u8]] = &[
+        POOL_SEED,
+        pool.collateral_mint.as_ref(),
+        pool.oracle_feed.as_ref(),
+        &[pool.bump],
+    ];
 
     if liquidator_payout > 0 {
         transfer_checked(
@@ -71,9 +76,9 @@ pub fn handle_liquidate_position(
                     from: context.accounts.custody_vault.to_account_info(),
                     mint: context.accounts.collateral_mint.to_account_info(),
                     to: context.accounts.liquidator_collateral.to_account_info(),
-                    authority: context.accounts.pool_authority.to_account_info(),
+                    authority: pool.to_account_info(),
                 },
-                &[authority_seeds],
+                &[pool_seeds],
             ),
             liquidator_payout,
             context.accounts.collateral_mint.decimals,
@@ -88,9 +93,9 @@ pub fn handle_liquidate_position(
                     from: context.accounts.custody_vault.to_account_info(),
                     mint: context.accounts.collateral_mint.to_account_info(),
                     to: context.accounts.trader_collateral.to_account_info(),
-                    authority: context.accounts.pool_authority.to_account_info(),
+                    authority: pool.to_account_info(),
                 },
-                &[authority_seeds],
+                &[pool_seeds],
             ),
             trader_refund,
             context.accounts.collateral_mint.decimals,
@@ -129,13 +134,6 @@ pub struct LiquidatePositionAccountConstraints<'info> {
         has_one = pool,
     )]
     pub position: Box<Account<'info, Position>>,
-
-    /// CHECK: PDA authority over the vault.
-    #[account(
-        seeds = [AUTHORITY_SEED, pool.key().as_ref()],
-        bump = pool.authority_bump,
-    )]
-    pub pool_authority: UncheckedAccount<'info>,
 
     /// CHECK: validated by the `has_one = oracle_feed` constraint on the pool.
     pub oracle_feed: UncheckedAccount<'info>,

--- a/finance/perpetual-futures/anchor-v1/programs/perpetual-futures/src/instructions/remove_liquidity.rs
+++ b/finance/perpetual-futures/anchor-v1/programs/perpetual-futures/src/instructions/remove_liquidity.rs
@@ -6,7 +6,7 @@ use anchor_spl::{
     },
 };
 
-use crate::constants::{AUTHORITY_SEED, POOL_SEED, VAULT_SEED};
+use crate::constants::{POOL_SEED, VAULT_SEED};
 use crate::errors::PerpError;
 use crate::instructions::shared::{liquidity_provider_aum, refresh_price_and_funding};
 use crate::state::Pool;
@@ -68,8 +68,13 @@ pub fn handle_remove_liquidity(
         shares,
     )?;
 
-    let pool_key = pool.key();
-    let authority_seeds: &[&[u8]] = &[AUTHORITY_SEED, pool_key.as_ref(), &[pool.authority_bump]];
+    // The pool signs the CPI below with its own seeds.
+    let pool_seeds: &[&[u8]] = &[
+        POOL_SEED,
+        pool.collateral_mint.as_ref(),
+        pool.oracle_feed.as_ref(),
+        &[pool.bump],
+    ];
     transfer_checked(
         CpiContext::new_with_signer(
             context.accounts.token_program.key(),
@@ -77,9 +82,9 @@ pub fn handle_remove_liquidity(
                 from: context.accounts.custody_vault.to_account_info(),
                 mint: context.accounts.collateral_mint.to_account_info(),
                 to: context.accounts.provider_collateral.to_account_info(),
-                authority: context.accounts.pool_authority.to_account_info(),
+                authority: pool.to_account_info(),
             },
-            &[authority_seeds],
+            &[pool_seeds],
         ),
         amount_out,
         context.accounts.collateral_mint.decimals,
@@ -103,13 +108,6 @@ pub struct RemoveLiquidityAccountConstraints<'info> {
         has_one = oracle_feed,
     )]
     pub pool: Box<Account<'info, Pool>>,
-
-    /// CHECK: PDA authority over the vault and liquidity-provider mint.
-    #[account(
-        seeds = [AUTHORITY_SEED, pool.key().as_ref()],
-        bump = pool.authority_bump,
-    )]
-    pub pool_authority: UncheckedAccount<'info>,
 
     /// CHECK: validated by the `has_one = oracle_feed` constraint on the pool.
     pub oracle_feed: UncheckedAccount<'info>,

--- a/finance/perpetual-futures/anchor-v1/programs/perpetual-futures/src/lib.rs
+++ b/finance/perpetual-futures/anchor-v1/programs/perpetual-futures/src/lib.rs
@@ -75,13 +75,13 @@ pub mod perpetual_futures {
         instructions::handle_liquidate_position(context)
     }
 
-    /// Pool authority sweeps the accumulated protocol fees from the vault.
+    /// The pool operator sweeps the accumulated protocol fees from the vault.
     pub fn collect_fees(context: Context<CollectFeesAccountConstraints>) -> Result<()> {
         instructions::handle_collect_fees(context)
     }
 
-    /// Pool authority retunes the per-slot funding rate, accruing at the old
-    /// rate first.
+    /// The pool operator retunes the per-slot funding rate, accruing at the
+    /// old rate first.
     pub fn set_funding_rate(
         context: Context<SetFundingRateAccountConstraints>,
         funding_rate_per_slot: u64,

--- a/finance/perpetual-futures/anchor-v1/programs/perpetual-futures/src/state/pool.rs
+++ b/finance/perpetual-futures/anchor-v1/programs/perpetual-futures/src/state/pool.rs
@@ -91,9 +91,9 @@ pub struct Pool {
     /// pool will trade against. A wider band is rejected as untrustworthy.
     pub max_confidence_bps: u16,
 
+    /// Bump of this account's own address. The pool owns the custody vault
+    /// and is the LP mint's authority, so it signs vault transfers and
+    /// mint/burn CPIs with `[POOL_SEED, collateral_mint, oracle_feed, bump]`;
+    /// there is no separate signing PDA.
     pub bump: u8,
-
-    /// Bump for the vault/LP-mint authority PDA, stored so CPIs can sign without
-    /// re-deriving it.
-    pub authority_bump: u8,
 }

--- a/finance/perpetual-futures/anchor-v1/programs/perpetual-futures/tests/test_perpetual_futures.rs
+++ b/finance/perpetual-futures/anchor-v1/programs/perpetual-futures/tests/test_perpetual_futures.rs
@@ -55,14 +55,13 @@ struct Market {
     collateral_mint: Pubkey,
     feed: Pubkey,
     pool: Pubkey,
-    pool_authority: Pubkey,
     lp_mint: Pubkey,
     custody_vault: Pubkey,
 }
 
 impl Market {
     /// Stand up a market with the given starting oracle price and per-slot
-    /// funding rate. The admin is both the pool authority and the oracle feed
+    /// funding rate. The admin is both the pool operator and the oracle feed
     /// authority.
     fn new(initial_price: i128, funding_rate_per_slot: u64) -> Market {
         let parameters = PoolParameters {
@@ -97,7 +96,8 @@ impl Market {
             "/../../target/deploy/mock_switchboard.so"
         ))
         .expect("mock_switchboard.so not found - run `anchor build` first");
-        svm.add_program(mock_switchboard::id(), &switchboard_bytes).unwrap();
+        svm.add_program(mock_switchboard::id(), &switchboard_bytes)
+            .unwrap();
 
         let payer = create_wallet(&mut svm, 100_000_000_000).unwrap();
         let admin = create_wallet(&mut svm, 100_000_000_000).unwrap();
@@ -135,9 +135,6 @@ impl Market {
             &perpetual_futures::id(),
         )
         .0;
-        let pool_authority =
-            Pubkey::find_program_address(&[b"authority", pool.as_ref()], &perpetual_futures::id())
-                .0;
         let lp_mint =
             Pubkey::find_program_address(&[b"lp_mint", pool.as_ref()], &perpetual_futures::id()).0;
         let custody_vault =
@@ -151,7 +148,6 @@ impl Market {
                 pool,
                 collateral_mint,
                 oracle_feed: feed,
-                pool_authority,
                 lp_mint,
                 custody_vault,
                 token_program: token_program_id(),
@@ -175,7 +171,6 @@ impl Market {
             collateral_mint,
             feed,
             pool,
-            pool_authority,
             lp_mint,
             custody_vault,
         })
@@ -226,9 +221,10 @@ impl Market {
     /// Simulate a cluster restart at `slot`: prices stamped at or before it
     /// must be rejected until the publisher posts again.
     fn set_last_restart_slot(&mut self, slot: u64) {
-        self.svm.set_sysvar(&solana_sysvar::last_restart_slot::LastRestartSlot {
-            last_restart_slot: slot,
-        });
+        self.svm
+            .set_sysvar(&solana_sysvar::last_restart_slot::LastRestartSlot {
+                last_restart_slot: slot,
+            });
     }
 
     /// Create a wallet holding `amount` collateral tokens in its associated
@@ -271,7 +267,6 @@ impl Market {
             perpetual_futures::accounts::AddLiquidityAccountConstraints {
                 provider: provider.pubkey(),
                 pool: self.pool,
-                pool_authority: self.pool_authority,
                 oracle_feed: self.feed,
                 collateral_mint: self.collateral_mint,
                 lp_mint: self.lp_mint,
@@ -312,7 +307,6 @@ impl Market {
             perpetual_futures::accounts::RemoveLiquidityAccountConstraints {
                 provider: provider.pubkey(),
                 pool: self.pool,
-                pool_authority: self.pool_authority,
                 oracle_feed: self.feed,
                 collateral_mint: self.collateral_mint,
                 lp_mint: self.lp_mint,
@@ -405,7 +399,6 @@ impl Market {
                 owner: trader.pubkey(),
                 pool: self.pool,
                 position,
-                pool_authority: self.pool_authority,
                 oracle_feed: self.feed,
                 collateral_mint: self.collateral_mint,
                 custody_vault: self.custody_vault,
@@ -443,7 +436,6 @@ impl Market {
                 owner: *owner,
                 pool: self.pool,
                 position,
-                pool_authority: self.pool_authority,
                 oracle_feed: self.feed,
                 collateral_mint: self.collateral_mint,
                 custody_vault: self.custody_vault,
@@ -473,7 +465,6 @@ impl Market {
             perpetual_futures::accounts::CollectFeesAccountConstraints {
                 authority: authority.pubkey(),
                 pool: self.pool,
-                pool_authority: self.pool_authority,
                 collateral_mint: self.collateral_mint,
                 custody_vault: self.custody_vault,
                 authority_collateral,
@@ -538,6 +529,17 @@ fn test_initialize_pool() {
     assert_eq!(pool.max_leverage, 10);
     assert_eq!(pool.liquidity, 0);
     assert_eq!(pool.total_collateral, 0);
+
+    // The pool account itself owns the custody vault and is the LP mint's
+    // authority; there is no separate signing PDA. A token account keeps its
+    // owner at bytes 32..64, and a mint keeps its authority at bytes 4..36
+    // behind a four-byte `COption` tag.
+    let vault = market.svm.get_account(&market.custody_vault).unwrap();
+    let vault_owner = Pubkey::new_from_array(vault.data[32..64].try_into().unwrap());
+    assert_eq!(vault_owner, market.pool);
+    let lp_mint = market.svm.get_account(&market.lp_mint).unwrap();
+    let mint_authority = Pubkey::new_from_array(lp_mint.data[4..36].try_into().unwrap());
+    assert_eq!(mint_authority, market.pool);
 }
 
 #[test]
@@ -850,7 +852,7 @@ fn test_open_rejects_price_from_before_a_restart() {
             Side::Long,
             collateral,
             5_000 * ONE_USDC,
-            u64::MAX
+            u64::MAX,
         )
         .expect("a freshly published price must be accepted after a restart");
 }
@@ -920,7 +922,7 @@ fn test_funding_charged_to_long() {
 
 /// The funding rate is quoted per slot, so what a position costs per hour also
 /// depends on the cluster's slot time. When the protocol shortens the slot, the
-/// pool authority retunes the rate, and the retune must settle the slots already
+/// pool operator retunes the rate, and the retune must settle the slots already
 /// elapsed at the old rate rather than repricing them at the new one.
 #[test]
 fn test_set_funding_rate_settles_at_the_old_rate_first() {
@@ -960,7 +962,10 @@ fn test_set_funding_rate_settles_at_the_old_rate_first() {
 
     let flat = funding_for(false);
     let retuned = funding_for(true);
-    assert!(flat > 0, "the flat run must pay some funding to compare against");
+    assert!(
+        flat > 0,
+        "the flat run must pay some funding to compare against"
+    );
 
     // Half the elapsed slots at 1x and half at 2x is 1.5x the flat run. Had the
     // handler skipped its accrual, the new rate would have applied to every

--- a/finance/perpetual-futures/anchor/CHANGELOG.md
+++ b/finance/perpetual-futures/anchor/CHANGELOG.md
@@ -1,8 +1,22 @@
 # Changelog
 
+## 2026-09-10
+
+Remove the separate dataless signing PDA (seeds `["authority", pool]`) that
+owned the vault and the LP mint, and the bump field on `Pool` that recorded it.
+The pool account is already a PDA, so it is now the custody vault's owner and
+the LP mint's authority itself, and signs vault transfers and mint/burn CPIs
+with its own seeds, `["pool", collateral_mint, oracle_feed, bump]`: the pattern
+the escrow example uses for its vault and the vault-strategy example uses for
+its share mint. `initialize_pool`, `add_liquidity`, `remove_liquidity`,
+`close_position`, `liquidate_position` and `collect_fees` each take one account
+fewer. The admin signer stored on `Pool` as `authority` (the pool operator) is
+unchanged. `test_initialize_pool` now also checks that the vault's owner and the
+mint's authority are the pool.
+
 ## 2026-08-14
 
-Add `set_funding_rate`, so the pool authority can retune `funding_rate_per_slot`
+Add `set_funding_rate`, so the pool operator can retune `funding_rate_per_slot`
 after the pool is created. The rate is quoted per slot, so what a position costs
 per hour depends on the cluster's slot time as well as on the rate; Solana lowers
 the slot time over time, and a pool created before a reduction charges the

--- a/finance/perpetual-futures/anchor/README.md
+++ b/finance/perpetual-futures/anchor/README.md
@@ -48,7 +48,7 @@ So a winning trader can always be paid, the pool **reserves** liquidity to back 
 
 [Funding](https://www.investopedia.com/terms/f/futurescontract.asp) anchors the pool's risk: the heavier side of [open interest](https://www.investopedia.com/terms/o/openinterest.asp) pays the pool over time. A cumulative funding index rises while longs are the larger side and falls while shorts are, advancing by `funding_rate_per_slot` each [slot](https://solana.com/docs/terminology#slot); a position records the index at open and settles the change when it closes. In a pool-based perp this is the equivalent of the borrow fee Jupiter Perpetuals charges.
 
-Because the rate is quoted per slot, what a position costs per hour depends on the cluster's slot time as well as on the rate. Solana lowers the slot time over time, so a pool that outlives a reduction charges the heavier side more per hour than it was set up to. `set_funding_rate(funding_rate_per_slot)` lets the pool authority bring it back in line; it advances the index at the old rate first, so slots already elapsed are charged at the rate that was in force for them.
+Because the rate is quoted per slot, what a position costs per hour depends on the cluster's slot time as well as on the rate. Solana lowers the slot time over time, so a pool that outlives a reduction charges the heavier side more per hour than it was set up to. `set_funding_rate(funding_rate_per_slot)` lets the pool operator bring it back in line; it advances the index at the old rate first, so slots already elapsed are charged at the rate that was in force for them.
 
 ### Maintenance margin and liquidation
 
@@ -68,7 +68,7 @@ Open and close fees are charged in [basis points](https://www.investopedia.com/t
 
 ### Participants
 
-- **Admin** (Pool authority): Operate the market and collect the protocol's slice of trading fees.
+- **Admin** (Pool operator): Operate the market and collect the protocol's slice of trading fees.
 - **Carol** (Liquidity provider): Earn fees by funding the pool and being the counterparty to traders.
 - **Alice** (Long trader): She has a thesis that NVDA will rise and wants leveraged upside without buying the stock.
 - **Bob** (Short trader): He thinks NVDA will fall and wants to profit from the downside.
@@ -84,10 +84,9 @@ Amounts below are shown in whole USDC; onchain they are base units (× 10⁶). T
 
 **Accounts created:**
 
-- `Pool` [PDA](https://solana.com/docs/terminology#program-derived-address-pda), seeds `["pool", collateral_mint, oracle_feed]`: parameters, liquidity, reserved liquidity, collateral total, per-side open-interest accumulators, funding index, protocol fees
-- `pool_authority` PDA, seeds `["authority", pool]`: nothing; signs vault and mint CPIs
-- `custody_vault` [token account](https://solana.com/docs/terminology#token-account) PDA, seeds `["vault", pool]`: all USDC, both provider liquidity and trader collateral
-- `lp_mint` PDA, seeds `["lp_mint", pool]`: the share [mint](https://solana.com/docs/terminology#mint-account); `pool_authority` is the mint authority
+- `Pool` [PDA](https://solana.com/docs/terminology#program-derived-address-pda), seeds `["pool", collateral_mint, oracle_feed]`: parameters, liquidity, reserved liquidity, collateral total, per-side open-interest accumulators, funding index, protocol fees. The pool owns the vault and is the LP mint's authority, and signs vault transfers and mint/burn CPIs with its own seeds; there is no separate signing PDA
+- `custody_vault` [token account](https://solana.com/docs/terminology#token-account) PDA, seeds `["vault", pool]`: all USDC, both provider liquidity and trader collateral; `pool` is its owner
+- `lp_mint` PDA, seeds `["lp_mint", pool]`: the share [mint](https://solana.com/docs/terminology#mint-account); `pool` is the mint authority
 
 ---
 

--- a/finance/perpetual-futures/anchor/programs/perpetual-futures/src/constants.rs
+++ b/finance/perpetual-futures/anchor/programs/perpetual-futures/src/constants.rs
@@ -39,9 +39,6 @@ pub const MAX_LEVERAGE_CEILING: u16 = 100;
 pub const POOL_SEED: &[u8] = b"pool";
 
 #[constant]
-pub const AUTHORITY_SEED: &[u8] = b"authority";
-
-#[constant]
 pub const LP_MINT_SEED: &[u8] = b"lp_mint";
 
 #[constant]

--- a/finance/perpetual-futures/anchor/programs/perpetual-futures/src/instructions/add_liquidity.rs
+++ b/finance/perpetual-futures/anchor/programs/perpetual-futures/src/instructions/add_liquidity.rs
@@ -6,7 +6,7 @@ use anchor_spl::{
     },
 };
 
-use crate::constants::{AUTHORITY_SEED, MINIMUM_LIQUIDITY, POOL_SEED, VAULT_SEED};
+use crate::constants::{MINIMUM_LIQUIDITY, POOL_SEED, VAULT_SEED};
 use crate::errors::PerpError;
 use crate::instructions::shared::{liquidity_provider_aum, refresh_price_and_funding};
 use crate::state::Pool;
@@ -65,20 +65,34 @@ pub fn handle_add_liquidity(
         context.accounts.collateral_mint.decimals(),
     )?;
 
-    let pool_key = pool.address();
-    let authority_seeds: &[&[u8]] = &[AUTHORITY_SEED, pool_key.as_ref(), &[pool.authority_bump]];
+    // The pool signs the CPI below with its own seeds. Copy them out first: a
+    // data account holds a live borrow on its buffer, which the runtime
+    // rejects when the CPI borrows the same account, so the borrow is
+    // released around the CPI and taken back after. Releasing commits the
+    // writes above; reacquiring re-reads the account.
+    let collateral_mint_key = pool.collateral_mint;
+    let oracle_feed_key = pool.oracle_feed;
+    let pool_bump = [pool.bump];
+    let pool_seeds: &[&[u8]] = &[
+        POOL_SEED,
+        collateral_mint_key.as_ref(),
+        oracle_feed_key.as_ref(),
+        &pool_bump,
+    ];
+    context.accounts.pool.release_borrow()?;
     mint_to(
         CpiContext::new_with_signer(
             context.accounts.token_program.address(),
             MintTo {
                 mint: context.accounts.lp_mint.to_cpi_handle_mut(),
                 to: context.accounts.provider_lp.to_cpi_handle_mut(),
-                authority: context.accounts.pool_authority.cpi_handle(),
+                authority: context.accounts.pool.to_cpi_handle(),
             },
-            &[authority_seeds],
+            &[pool_seeds],
         ),
         shares,
     )?;
+    context.accounts.pool.reacquire_borrow_mut()?;
 
     Ok(())
 }
@@ -94,13 +108,6 @@ pub struct AddLiquidityAccountConstraints {
         bump = pool.bump,
     )]
     pub pool: Box<BorshAccount<Pool>>,
-
-    /// CHECK: PDA authority over the vault and liquidity-provider mint.
-    #[account(
-        seeds = [AUTHORITY_SEED, pool.address().as_ref()],
-        bump = pool.authority_bump,
-    )]
-    pub pool_authority: UncheckedAccount,
 
     /// CHECK: validated by the `address = pool.oracle_feed` constraint below.
     #[account(address = pool.oracle_feed)]

--- a/finance/perpetual-futures/anchor/programs/perpetual-futures/src/instructions/close_position.rs
+++ b/finance/perpetual-futures/anchor/programs/perpetual-futures/src/instructions/close_position.rs
@@ -4,7 +4,7 @@ use anchor_spl::{
     token_interface::{transfer_checked, Mint, TokenAccount, TokenInterface, TransferChecked},
 };
 
-use crate::constants::{AUTHORITY_SEED, POOL_SEED, POSITION_SEED, VAULT_SEED};
+use crate::constants::{POOL_SEED, POSITION_SEED, VAULT_SEED};
 use crate::errors::PerpError;
 use crate::instructions::shared::{basis_points_of, refresh_price_and_funding, settle_position};
 use crate::state::{Pool, Position};
@@ -66,8 +66,21 @@ pub fn handle_close_position(
         .checked_add(close_fee)
         .ok_or(PerpError::MathOverflow)?;
 
-    let pool_key = pool.address();
-    let authority_seeds: &[&[u8]] = &[AUTHORITY_SEED, pool_key.as_ref(), &[pool.authority_bump]];
+    // The pool signs the CPI below with its own seeds. Copy them out first: a
+    // data account holds a live borrow on its buffer, which the runtime
+    // rejects when the CPI borrows the same account, so the borrow is
+    // released around the CPI and taken back after. Releasing commits the
+    // writes above; reacquiring re-reads the account.
+    let collateral_mint_key = pool.collateral_mint;
+    let oracle_feed_key = pool.oracle_feed;
+    let pool_bump = [pool.bump];
+    let pool_seeds: &[&[u8]] = &[
+        POOL_SEED,
+        collateral_mint_key.as_ref(),
+        oracle_feed_key.as_ref(),
+        &pool_bump,
+    ];
+    context.accounts.pool.release_borrow()?;
     transfer_checked(
         CpiContext::new_with_signer(
             context.accounts.token_program.address(),
@@ -75,13 +88,14 @@ pub fn handle_close_position(
                 from: context.accounts.custody_vault.to_cpi_handle_mut(),
                 mint: context.accounts.collateral_mint.to_cpi_handle(),
                 to: context.accounts.trader_collateral.to_cpi_handle_mut(),
-                authority: context.accounts.pool_authority.cpi_handle(),
+                authority: context.accounts.pool.to_cpi_handle(),
             },
-            &[authority_seeds],
+            &[pool_seeds],
         ),
         payout,
         context.accounts.collateral_mint.decimals(),
     )?;
+    context.accounts.pool.reacquire_borrow_mut()?;
 
     Ok(())
 }
@@ -106,13 +120,6 @@ pub struct ClosePositionAccountConstraints {
         bump = position.bump,
     )]
     pub position: Box<BorshAccount<Position>>,
-
-    /// CHECK: PDA authority over the vault.
-    #[account(
-        seeds = [AUTHORITY_SEED, pool.address().as_ref()],
-        bump = pool.authority_bump,
-    )]
-    pub pool_authority: UncheckedAccount,
 
     /// CHECK: validated by the `address = pool.oracle_feed` constraint below.
     #[account(address = pool.oracle_feed)]

--- a/finance/perpetual-futures/anchor/programs/perpetual-futures/src/instructions/collect_fees.rs
+++ b/finance/perpetual-futures/anchor/programs/perpetual-futures/src/instructions/collect_fees.rs
@@ -4,7 +4,7 @@ use anchor_spl::{
     token_interface::{transfer_checked, Mint, TokenAccount, TokenInterface, TransferChecked},
 };
 
-use crate::constants::{AUTHORITY_SEED, POOL_SEED, VAULT_SEED};
+use crate::constants::{POOL_SEED, VAULT_SEED};
 use crate::errors::PerpError;
 use crate::state::Pool;
 
@@ -16,8 +16,21 @@ pub fn handle_collect_fees(context: &mut Context<CollectFeesAccountConstraints>)
     // Effects before interaction: zero the balance, then transfer.
     pool.protocol_fees = 0;
 
-    let pool_key = pool.address();
-    let authority_seeds: &[&[u8]] = &[AUTHORITY_SEED, pool_key.as_ref(), &[pool.authority_bump]];
+    // The pool signs the CPI below with its own seeds. Copy them out first: a
+    // data account holds a live borrow on its buffer, which the runtime
+    // rejects when the CPI borrows the same account, so the borrow is
+    // released around the CPI and taken back after. Releasing commits the
+    // writes above; reacquiring re-reads the account.
+    let collateral_mint_key = pool.collateral_mint;
+    let oracle_feed_key = pool.oracle_feed;
+    let pool_bump = [pool.bump];
+    let pool_seeds: &[&[u8]] = &[
+        POOL_SEED,
+        collateral_mint_key.as_ref(),
+        oracle_feed_key.as_ref(),
+        &pool_bump,
+    ];
+    context.accounts.pool.release_borrow()?;
     transfer_checked(
         CpiContext::new_with_signer(
             context.accounts.token_program.address(),
@@ -25,13 +38,14 @@ pub fn handle_collect_fees(context: &mut Context<CollectFeesAccountConstraints>)
                 from: context.accounts.custody_vault.to_cpi_handle_mut(),
                 mint: context.accounts.collateral_mint.to_cpi_handle(),
                 to: context.accounts.authority_collateral.to_cpi_handle_mut(),
-                authority: context.accounts.pool_authority.cpi_handle(),
+                authority: context.accounts.pool.to_cpi_handle(),
             },
-            &[authority_seeds],
+            &[pool_seeds],
         ),
         amount,
         context.accounts.collateral_mint.decimals(),
     )?;
+    context.accounts.pool.reacquire_borrow_mut()?;
 
     Ok(())
 }
@@ -47,13 +61,6 @@ pub struct CollectFeesAccountConstraints {
         bump = pool.bump,
     )]
     pub pool: Box<BorshAccount<Pool>>,
-
-    /// CHECK: PDA authority over the vault.
-    #[account(
-        seeds = [AUTHORITY_SEED, pool.address().as_ref()],
-        bump = pool.authority_bump,
-    )]
-    pub pool_authority: UncheckedAccount,
 
     #[account(address = pool.collateral_mint)]
     pub collateral_mint: Box<InterfaceAccount<Mint>>,

--- a/finance/perpetual-futures/anchor/programs/perpetual-futures/src/instructions/initialize_pool.rs
+++ b/finance/perpetual-futures/anchor/programs/perpetual-futures/src/instructions/initialize_pool.rs
@@ -7,8 +7,7 @@ use anchor_spl::{
 };
 
 use crate::constants::{
-    AUTHORITY_SEED, BASIS_POINTS_DENOMINATOR, LP_MINT_SEED, MAX_LEVERAGE_CEILING, POOL_SEED,
-    VAULT_SEED,
+    BASIS_POINTS_DENOMINATOR, LP_MINT_SEED, MAX_LEVERAGE_CEILING, POOL_SEED, VAULT_SEED,
 };
 use crate::errors::PerpError;
 use crate::state::Pool;
@@ -102,7 +101,6 @@ pub fn handle_initialize_pool(
     pool.liquidation_fee_bps = parameters.liquidation_fee_bps;
     pool.max_confidence_bps = parameters.max_confidence_bps;
     pool.bump = context.bumps.pool;
-    pool.authority_bump = context.bumps.pool_authority;
 
     Ok(())
 }
@@ -128,32 +126,28 @@ pub struct InitializePoolAccountConstraints {
     /// type. Swap for a real Switchboard feed in production.
     pub oracle_feed: UncheckedAccount,
 
-    /// CHECK: PDA that owns the vault and the liquidity-provider mint. Holds no
-    /// data; used only to sign vault and mint CPIs.
-    #[account(
-        seeds = [AUTHORITY_SEED, pool.address().as_ref()],
-        bump,
-    )]
-    pub pool_authority: UncheckedAccount,
-
+    /// Liquidity-provider share mint. The pool account is its mint authority
+    /// and signs every mint and burn with its own seeds.
     #[account(
         init,
         payer = authority,
         seeds = [LP_MINT_SEED, pool.address().as_ref()],
         bump,
         mint::decimals = collateral_mint.decimals(),
-        mint::authority = pool_authority,
+        mint::authority = pool,
         mint::token_program = token_program,
     )]
     pub lp_mint: Box<InterfaceAccount<Mint>>,
 
+    /// Custody vault for all collateral. The pool account owns it and signs
+    /// every transfer out with its own seeds.
     #[account(
         init,
         payer = authority,
         seeds = [VAULT_SEED, pool.address().as_ref()],
         bump,
         token::mint = collateral_mint,
-        token::authority = pool_authority,
+        token::authority = pool,
         token::token_program = token_program,
     )]
     pub custody_vault: Box<InterfaceAccount<TokenAccount>>,

--- a/finance/perpetual-futures/anchor/programs/perpetual-futures/src/instructions/liquidate_position.rs
+++ b/finance/perpetual-futures/anchor/programs/perpetual-futures/src/instructions/liquidate_position.rs
@@ -4,7 +4,7 @@ use anchor_spl::{
     token_interface::{transfer_checked, Mint, TokenAccount, TokenInterface, TransferChecked},
 };
 
-use crate::constants::{AUTHORITY_SEED, POOL_SEED, POSITION_SEED, VAULT_SEED};
+use crate::constants::{POOL_SEED, POSITION_SEED, VAULT_SEED};
 use crate::errors::PerpError;
 use crate::instructions::shared::{basis_points_of, refresh_price_and_funding, settle_position};
 use crate::state::{Pool, Position};
@@ -60,8 +60,21 @@ pub fn handle_liquidate_position(
         .try_into()
         .map_err(|_| PerpError::MathOverflow)?;
 
-    let pool_key = pool.address();
-    let authority_seeds: &[&[u8]] = &[AUTHORITY_SEED, pool_key.as_ref(), &[pool.authority_bump]];
+    // The pool signs the CPI below with its own seeds. Copy them out first: a
+    // data account holds a live borrow on its buffer, which the runtime
+    // rejects when the CPI borrows the same account, so the borrow is
+    // released around the CPI and taken back after. Releasing commits the
+    // writes above; reacquiring re-reads the account.
+    let collateral_mint_key = pool.collateral_mint;
+    let oracle_feed_key = pool.oracle_feed;
+    let pool_bump = [pool.bump];
+    let pool_seeds: &[&[u8]] = &[
+        POOL_SEED,
+        collateral_mint_key.as_ref(),
+        oracle_feed_key.as_ref(),
+        &pool_bump,
+    ];
+    context.accounts.pool.release_borrow()?;
 
     if liquidator_payout > 0 {
         transfer_checked(
@@ -71,9 +84,9 @@ pub fn handle_liquidate_position(
                     from: context.accounts.custody_vault.to_cpi_handle_mut(),
                     mint: context.accounts.collateral_mint.to_cpi_handle(),
                     to: context.accounts.liquidator_collateral.to_cpi_handle_mut(),
-                    authority: context.accounts.pool_authority.cpi_handle(),
+                    authority: context.accounts.pool.to_cpi_handle(),
                 },
-                &[authority_seeds],
+                &[pool_seeds],
             ),
             liquidator_payout,
             context.accounts.collateral_mint.decimals(),
@@ -88,14 +101,15 @@ pub fn handle_liquidate_position(
                     from: context.accounts.custody_vault.to_cpi_handle_mut(),
                     mint: context.accounts.collateral_mint.to_cpi_handle(),
                     to: context.accounts.trader_collateral.to_cpi_handle_mut(),
-                    authority: context.accounts.pool_authority.cpi_handle(),
+                    authority: context.accounts.pool.to_cpi_handle(),
                 },
-                &[authority_seeds],
+                &[pool_seeds],
             ),
             trader_refund,
             context.accounts.collateral_mint.decimals(),
         )?;
     }
+    context.accounts.pool.reacquire_borrow_mut()?;
 
     Ok(())
 }
@@ -125,13 +139,6 @@ pub struct LiquidatePositionAccountConstraints {
         bump = position.bump,
     )]
     pub position: Box<BorshAccount<Position>>,
-
-    /// CHECK: PDA authority over the vault.
-    #[account(
-        seeds = [AUTHORITY_SEED, pool.address().as_ref()],
-        bump = pool.authority_bump,
-    )]
-    pub pool_authority: UncheckedAccount,
 
     /// CHECK: validated by the `address = pool.oracle_feed` constraint below.
     #[account(address = pool.oracle_feed)]

--- a/finance/perpetual-futures/anchor/programs/perpetual-futures/src/instructions/remove_liquidity.rs
+++ b/finance/perpetual-futures/anchor/programs/perpetual-futures/src/instructions/remove_liquidity.rs
@@ -6,7 +6,7 @@ use anchor_spl::{
     },
 };
 
-use crate::constants::{AUTHORITY_SEED, POOL_SEED, VAULT_SEED};
+use crate::constants::{POOL_SEED, VAULT_SEED};
 use crate::errors::PerpError;
 use crate::instructions::shared::{liquidity_provider_aum, refresh_price_and_funding};
 use crate::state::Pool;
@@ -68,8 +68,21 @@ pub fn handle_remove_liquidity(
         shares,
     )?;
 
-    let pool_key = pool.address();
-    let authority_seeds: &[&[u8]] = &[AUTHORITY_SEED, pool_key.as_ref(), &[pool.authority_bump]];
+    // The pool signs the CPI below with its own seeds. Copy them out first: a
+    // data account holds a live borrow on its buffer, which the runtime
+    // rejects when the CPI borrows the same account, so the borrow is
+    // released around the CPI and taken back after. Releasing commits the
+    // writes above; reacquiring re-reads the account.
+    let collateral_mint_key = pool.collateral_mint;
+    let oracle_feed_key = pool.oracle_feed;
+    let pool_bump = [pool.bump];
+    let pool_seeds: &[&[u8]] = &[
+        POOL_SEED,
+        collateral_mint_key.as_ref(),
+        oracle_feed_key.as_ref(),
+        &pool_bump,
+    ];
+    context.accounts.pool.release_borrow()?;
     transfer_checked(
         CpiContext::new_with_signer(
             context.accounts.token_program.address(),
@@ -77,13 +90,14 @@ pub fn handle_remove_liquidity(
                 from: context.accounts.custody_vault.to_cpi_handle_mut(),
                 mint: context.accounts.collateral_mint.to_cpi_handle(),
                 to: context.accounts.provider_collateral.to_cpi_handle_mut(),
-                authority: context.accounts.pool_authority.cpi_handle(),
+                authority: context.accounts.pool.to_cpi_handle(),
             },
-            &[authority_seeds],
+            &[pool_seeds],
         ),
         amount_out,
         context.accounts.collateral_mint.decimals(),
     )?;
+    context.accounts.pool.reacquire_borrow_mut()?;
 
     Ok(())
 }
@@ -99,13 +113,6 @@ pub struct RemoveLiquidityAccountConstraints {
         bump = pool.bump,
     )]
     pub pool: Box<BorshAccount<Pool>>,
-
-    /// CHECK: PDA authority over the vault and liquidity-provider mint.
-    #[account(
-        seeds = [AUTHORITY_SEED, pool.address().as_ref()],
-        bump = pool.authority_bump,
-    )]
-    pub pool_authority: UncheckedAccount,
 
     /// CHECK: validated by the `address = pool.oracle_feed` constraint below.
     #[account(address = pool.oracle_feed)]

--- a/finance/perpetual-futures/anchor/programs/perpetual-futures/src/lib.rs
+++ b/finance/perpetual-futures/anchor/programs/perpetual-futures/src/lib.rs
@@ -78,13 +78,13 @@ pub mod perpetual_futures {
         instructions::handle_liquidate_position(context)
     }
 
-    /// Pool authority sweeps the accumulated protocol fees from the vault.
+    /// The pool operator sweeps the accumulated protocol fees from the vault.
     pub fn collect_fees(context: &mut Context<CollectFeesAccountConstraints>) -> Result<()> {
         instructions::handle_collect_fees(context)
     }
 
-    /// Pool authority retunes the per-slot funding rate, accruing at the old
-    /// rate first.
+    /// The pool operator retunes the per-slot funding rate, accruing at the
+    /// old rate first.
     pub fn set_funding_rate(
         context: &mut Context<SetFundingRateAccountConstraints>,
         funding_rate_per_slot: u64,

--- a/finance/perpetual-futures/anchor/programs/perpetual-futures/src/state/pool.rs
+++ b/finance/perpetual-futures/anchor/programs/perpetual-futures/src/state/pool.rs
@@ -91,9 +91,9 @@ pub struct Pool {
     /// pool will trade against. A wider band is rejected as untrustworthy.
     pub max_confidence_bps: u16,
 
+    /// Bump of this account's own address. The pool owns the custody vault
+    /// and is the LP mint's authority, so it signs vault transfers and
+    /// mint/burn CPIs with `[POOL_SEED, collateral_mint, oracle_feed, bump]`;
+    /// there is no separate signing PDA.
     pub bump: u8,
-
-    /// Bump for the vault/LP-mint authority PDA, stored so CPIs can sign without
-    /// re-deriving it.
-    pub authority_bump: u8,
 }

--- a/finance/perpetual-futures/anchor/programs/perpetual-futures/tests/test_perpetual_futures.rs
+++ b/finance/perpetual-futures/anchor/programs/perpetual-futures/tests/test_perpetual_futures.rs
@@ -53,14 +53,13 @@ struct Market {
     collateral_mint: Address,
     feed: Address,
     pool: Address,
-    pool_authority: Address,
     lp_mint: Address,
     custody_vault: Address,
 }
 
 impl Market {
     /// Stand up a market with the given starting oracle price and per-slot
-    /// funding rate. The admin is both the pool authority and the oracle feed
+    /// funding rate. The admin is both the pool operator and the oracle feed
     /// authority.
     fn new(initial_price: i128, funding_rate_per_slot: u64) -> Market {
         let parameters = PoolParameters {
@@ -134,9 +133,6 @@ impl Market {
             &perpetual_futures::id(),
         )
         .0;
-        let pool_authority =
-            Address::find_program_address(&[b"authority", pool.as_ref()], &perpetual_futures::id())
-                .0;
         let lp_mint =
             Address::find_program_address(&[b"lp_mint", pool.as_ref()], &perpetual_futures::id()).0;
         let custody_vault =
@@ -150,7 +146,6 @@ impl Market {
                 pool,
                 collateral_mint,
                 oracle_feed: feed,
-                pool_authority,
                 lp_mint,
                 custody_vault,
                 token_program: token_program_id(),
@@ -174,7 +169,6 @@ impl Market {
             collateral_mint,
             feed,
             pool,
-            pool_authority,
             lp_mint,
             custody_vault,
         })
@@ -271,7 +265,6 @@ impl Market {
             perpetual_futures::accounts::AddLiquidityAccountConstraints {
                 provider: provider.pubkey(),
                 pool: self.pool,
-                pool_authority: self.pool_authority,
                 oracle_feed: self.feed,
                 collateral_mint: self.collateral_mint,
                 lp_mint: self.lp_mint,
@@ -312,7 +305,6 @@ impl Market {
             perpetual_futures::accounts::RemoveLiquidityAccountConstraints {
                 provider: provider.pubkey(),
                 pool: self.pool,
-                pool_authority: self.pool_authority,
                 oracle_feed: self.feed,
                 collateral_mint: self.collateral_mint,
                 lp_mint: self.lp_mint,
@@ -405,7 +397,6 @@ impl Market {
                 owner: trader.pubkey(),
                 pool: self.pool,
                 position,
-                pool_authority: self.pool_authority,
                 oracle_feed: self.feed,
                 collateral_mint: self.collateral_mint,
                 custody_vault: self.custody_vault,
@@ -443,7 +434,6 @@ impl Market {
                 owner: *owner,
                 pool: self.pool,
                 position,
-                pool_authority: self.pool_authority,
                 oracle_feed: self.feed,
                 collateral_mint: self.collateral_mint,
                 custody_vault: self.custody_vault,
@@ -473,7 +463,6 @@ impl Market {
             perpetual_futures::accounts::CollectFeesAccountConstraints {
                 authority: authority.pubkey(),
                 pool: self.pool,
-                pool_authority: self.pool_authority,
                 collateral_mint: self.collateral_mint,
                 custody_vault: self.custody_vault,
                 authority_collateral,
@@ -538,6 +527,17 @@ fn test_initialize_pool() {
     assert_eq!(pool.max_leverage, 10);
     assert_eq!(pool.liquidity, 0);
     assert_eq!(pool.total_collateral, 0);
+
+    // The pool account itself owns the custody vault and is the LP mint's
+    // authority; there is no separate signing PDA. A token account keeps its
+    // owner at bytes 32..64, and a mint keeps its authority at bytes 4..36
+    // behind a four-byte `COption` tag.
+    let vault = market.svm.get_account(&market.custody_vault).unwrap();
+    let vault_owner = Address::new_from_array(vault.data[32..64].try_into().unwrap());
+    assert_eq!(vault_owner, market.pool);
+    let lp_mint = market.svm.get_account(&market.lp_mint).unwrap();
+    let mint_authority = Address::new_from_array(lp_mint.data[4..36].try_into().unwrap());
+    assert_eq!(mint_authority, market.pool);
 }
 
 #[test]
@@ -915,7 +915,7 @@ fn test_funding_charged_to_long() {
 
 /// The funding rate is quoted per slot, so what a position costs per hour also
 /// depends on the cluster's slot time. When the protocol shortens the slot, the
-/// pool authority retunes the rate, and the retune must settle the slots already
+/// pool operator retunes the rate, and the retune must settle the slots already
 /// elapsed at the old rate rather than repricing them at the new one.
 #[test]
 fn test_set_funding_rate_settles_at_the_old_rate_first() {

--- a/finance/perpetual-futures/quasar/CHANGELOG.md
+++ b/finance/perpetual-futures/quasar/CHANGELOG.md
@@ -1,8 +1,23 @@
 # Changelog
 
+## 2026-09-10
+
+Remove the separate dataless signing PDA (seeds `["authority", pool]`) that
+owned the vault and the LP mint, its seeds struct, and the bump field on `Pool`
+that recorded it. The pool account is already a PDA, so it is now the custody
+vault's owner and the LP mint's authority itself, and signs vault transfers and
+mint/burn CPIs with its own seeds, `["pool", collateral_mint, oracle_feed,
+bump]`: the pattern the escrow example uses for its vault and the vault-strategy
+example uses for its share mint. `initialize_pool`, `add_liquidity`,
+`remove_liquidity`, `close_position`, `liquidate_position` and `collect_fees`
+each take one account fewer. The admin signer stored on `Pool` as `authority`
+(the pool operator) is unchanged.
+`initialize_pool_creates_pool_vault_and_lp_mint` now also checks that the
+vault's owner and the mint's authority are the pool.
+
 ## 2026-08-14
 
-Add `set_funding_rate` (discriminator 7), so the pool authority can retune
+Add `set_funding_rate` (discriminator 7), so the pool operator can retune
 `funding_rate_per_slot` after the pool is created. The rate is quoted per slot,
 so what a position costs per hour depends on the cluster's slot time as well as
 on the rate; Solana lowers the slot time over time, and a pool created before a

--- a/finance/perpetual-futures/quasar/src/instructions/add_liquidity.rs
+++ b/finance/perpetual-futures/quasar/src/instructions/add_liquidity.rs
@@ -3,7 +3,7 @@ use {
         constants::MINIMUM_LIQUIDITY,
         instructions::shared::{err, error, refresh_price_and_funding, traders_unrealized_pnl},
         state::Pool,
-        LpMintPda, PoolAuthorityPda,
+        LpMintPda,
     },
     quasar_lang::cpi::Seed,
     quasar_lang::{prelude::*, sysvars::clock::Clock},
@@ -20,9 +20,6 @@ pub struct AddLiquidity {
         has_one(custody_vault),
     )]
     pub pool: Account<Pool>,
-    /// Authority PDA over the vault and liquidity-provider mint.
-    #[account(address = PoolAuthorityPda::seeds(pool.address()))]
-    pub pool_authority: UncheckedAccount,
     /// CHECK: bound to the pool via its seeds (the pool PDA is derived from it).
     pub oracle_feed: UncheckedAccount,
     pub collateral_mint: Account<Mint>,
@@ -112,10 +109,12 @@ pub fn handle_add_liquidity(
         )
         .invoke()?;
 
-    let bump = [bumps.pool_authority];
+    // The pool signs the CPI below with its own seeds.
+    let bump = [bumps.pool];
     let seeds: &[Seed] = &[
-        Seed::from(b"authority".as_ref()),
-        Seed::from(accounts.pool.address().as_ref()),
+        Seed::from(b"pool".as_ref()),
+        Seed::from(accounts.collateral_mint.address().as_ref()),
+        Seed::from(accounts.oracle_feed.address().as_ref()),
         Seed::from(&bump as &[u8]),
     ];
     accounts
@@ -123,7 +122,7 @@ pub fn handle_add_liquidity(
         .mint_to(
             &accounts.lp_mint,
             &accounts.provider_lp,
-            &accounts.pool_authority,
+            &accounts.pool,
             shares,
         )
         .invoke_signed(seeds)?;

--- a/finance/perpetual-futures/quasar/src/instructions/close_position.rs
+++ b/finance/perpetual-futures/quasar/src/instructions/close_position.rs
@@ -5,7 +5,6 @@ use {
             basis_points_of, err, error, position_funding, position_pnl, refresh_price_and_funding,
         },
         state::{Pool, Position},
-        PoolAuthorityPda,
     },
     quasar_lang::cpi::Seed,
     quasar_lang::{prelude::*, sysvars::clock::Clock},
@@ -29,8 +28,6 @@ pub struct ClosePosition {
         close(dest = owner),
     )]
     pub position: Account<Position>,
-    #[account(address = PoolAuthorityPda::seeds(pool.address()))]
-    pub pool_authority: UncheckedAccount,
     /// CHECK: bound to the pool via its seeds.
     pub oracle_feed: UncheckedAccount,
     pub collateral_mint: Account<Mint>,
@@ -128,10 +125,12 @@ pub fn handle_close_position(
         .ok_or(ProgramError::ArithmeticOverflow)?;
     accounts.pool.protocol_fees.set(new_protocol_fees);
 
-    let bump = [bumps.pool_authority];
+    // The pool signs the CPI below with its own seeds.
+    let bump = [bumps.pool];
     let seeds: &[Seed] = &[
-        Seed::from(b"authority".as_ref()),
-        Seed::from(accounts.pool.address().as_ref()),
+        Seed::from(b"pool".as_ref()),
+        Seed::from(accounts.collateral_mint.address().as_ref()),
+        Seed::from(accounts.oracle_feed.address().as_ref()),
         Seed::from(&bump as &[u8]),
     ];
     accounts
@@ -140,7 +139,7 @@ pub fn handle_close_position(
             &accounts.custody_vault,
             &accounts.collateral_mint,
             &accounts.trader_collateral,
-            &accounts.pool_authority,
+            &accounts.pool,
             payout,
             accounts.collateral_mint.decimals(),
         )

--- a/finance/perpetual-futures/quasar/src/instructions/collect_fees.rs
+++ b/finance/perpetual-futures/quasar/src/instructions/collect_fees.rs
@@ -2,7 +2,6 @@ use {
     crate::{
         instructions::shared::{err, error},
         state::Pool,
-        PoolAuthorityPda,
     },
     quasar_lang::cpi::Seed,
     quasar_lang::prelude::*,
@@ -20,8 +19,6 @@ pub struct CollectFees {
         has_one(custody_vault),
     )]
     pub pool: Account<Pool>,
-    #[account(address = PoolAuthorityPda::seeds(pool.address()))]
-    pub pool_authority: UncheckedAccount,
     /// CHECK: bound to the pool via its seeds.
     pub oracle_feed: UncheckedAccount,
     pub collateral_mint: Account<Mint>,
@@ -49,10 +46,12 @@ pub fn handle_collect_fees(
     }
     accounts.pool.protocol_fees.set(0);
 
-    let bump = [bumps.pool_authority];
+    // The pool signs the CPI below with its own seeds.
+    let bump = [bumps.pool];
     let seeds: &[Seed] = &[
-        Seed::from(b"authority".as_ref()),
-        Seed::from(accounts.pool.address().as_ref()),
+        Seed::from(b"pool".as_ref()),
+        Seed::from(accounts.collateral_mint.address().as_ref()),
+        Seed::from(accounts.oracle_feed.address().as_ref()),
         Seed::from(&bump as &[u8]),
     ];
     accounts
@@ -61,7 +60,7 @@ pub fn handle_collect_fees(
             &accounts.custody_vault,
             &accounts.collateral_mint,
             &accounts.authority_collateral,
-            &accounts.pool_authority,
+            &accounts.pool,
             amount,
             accounts.collateral_mint.decimals(),
         )

--- a/finance/perpetual-futures/quasar/src/instructions/initialize_pool.rs
+++ b/finance/perpetual-futures/quasar/src/instructions/initialize_pool.rs
@@ -3,7 +3,7 @@ use {
         constants::{BASIS_POINTS_DENOMINATOR, MAX_LEVERAGE_CEILING},
         instructions::shared::{err, error},
         state::{Pool, PoolInner},
-        LpMintPda, PoolAuthorityPda, VaultPda,
+        LpMintPda, VaultPda,
     },
     quasar_lang::{prelude::*, sysvars::clock::Clock},
     quasar_spl::prelude::*,
@@ -23,23 +23,22 @@ pub struct InitializePool {
     pub collateral_mint: Account<Mint>,
     /// CHECK: stored on the pool; every read validates layout, scale, freshness.
     pub oracle_feed: UncheckedAccount,
-    /// Authority PDA over the vault and liquidity-provider mint.
-    #[account(address = PoolAuthorityPda::seeds(pool.address()))]
-    pub pool_authority: UncheckedAccount,
+    /// Liquidity-provider share mint; the pool account is its mint authority.
     #[account(
         mut,
         init,
         payer = authority,
         address = LpMintPda::seeds(pool.address()),
-        mint(decimals = 6, authority = pool_authority, freeze_authority = None, token_program = token_program),
+        mint(decimals = 6, authority = pool, freeze_authority = None, token_program = token_program),
     )]
     pub lp_mint: Account<Mint>,
+    /// Custody vault for all collateral; the pool account owns it.
     #[account(
         mut,
         init(idempotent),
         payer = authority,
         address = VaultPda::seeds(pool.address()),
-        token(mint = collateral_mint, authority = pool_authority, token_program = token_program),
+        token(mint = collateral_mint, authority = pool, token_program = token_program),
     )]
     pub custody_vault: Account<Token>,
     pub token_program: Program<TokenProgram>,
@@ -113,7 +112,6 @@ pub fn handle_initialize_pool(
         liquidation_fee_bps,
         max_confidence_bps,
         bump: bumps.pool,
-        authority_bump: bumps.pool_authority,
     });
     Ok(())
 }

--- a/finance/perpetual-futures/quasar/src/instructions/liquidate_position.rs
+++ b/finance/perpetual-futures/quasar/src/instructions/liquidate_position.rs
@@ -8,7 +8,6 @@ use {
             },
         },
         state::{Pool, Position},
-        PoolAuthorityPda,
     },
     quasar_lang::cpi::Seed,
     quasar_lang::{prelude::*, sysvars::clock::Clock},
@@ -35,8 +34,6 @@ pub struct LiquidatePosition {
         close(dest = owner),
     )]
     pub position: Account<Position>,
-    #[account(address = PoolAuthorityPda::seeds(pool.address()))]
-    pub pool_authority: UncheckedAccount,
     /// CHECK: bound to the pool via its seeds.
     pub oracle_feed: UncheckedAccount,
     pub collateral_mint: Account<Mint>,
@@ -131,10 +128,12 @@ pub fn handle_liquidate_position(
         .liquidity
         .set(u64::try_from(new_liquidity).map_err(|_| ProgramError::ArithmeticOverflow)?);
 
-    let bump = [bumps.pool_authority];
+    // The pool signs the CPI below with its own seeds.
+    let bump = [bumps.pool];
     let seeds: &[Seed] = &[
-        Seed::from(b"authority".as_ref()),
-        Seed::from(accounts.pool.address().as_ref()),
+        Seed::from(b"pool".as_ref()),
+        Seed::from(accounts.collateral_mint.address().as_ref()),
+        Seed::from(accounts.oracle_feed.address().as_ref()),
         Seed::from(&bump as &[u8]),
     ];
 
@@ -145,7 +144,7 @@ pub fn handle_liquidate_position(
                 &accounts.custody_vault,
                 &accounts.collateral_mint,
                 &accounts.liquidator_collateral,
-                &accounts.pool_authority,
+                &accounts.pool,
                 liquidator_payout,
                 accounts.collateral_mint.decimals(),
             )
@@ -158,7 +157,7 @@ pub fn handle_liquidate_position(
                 &accounts.custody_vault,
                 &accounts.collateral_mint,
                 &accounts.trader_collateral,
-                &accounts.pool_authority,
+                &accounts.pool,
                 trader_refund,
                 accounts.collateral_mint.decimals(),
             )

--- a/finance/perpetual-futures/quasar/src/instructions/remove_liquidity.rs
+++ b/finance/perpetual-futures/quasar/src/instructions/remove_liquidity.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         instructions::shared::{err, error, refresh_price_and_funding, traders_unrealized_pnl},
         state::Pool,
-        LpMintPda, PoolAuthorityPda,
+        LpMintPda,
     },
     quasar_lang::cpi::Seed,
     quasar_lang::{prelude::*, sysvars::clock::Clock},
@@ -19,8 +19,6 @@ pub struct RemoveLiquidity {
         has_one(custody_vault),
     )]
     pub pool: Account<Pool>,
-    #[account(address = PoolAuthorityPda::seeds(pool.address()))]
-    pub pool_authority: UncheckedAccount,
     /// CHECK: bound to the pool via its seeds.
     pub oracle_feed: UncheckedAccount,
     pub collateral_mint: Account<Mint>,
@@ -113,10 +111,12 @@ pub fn handle_remove_liquidity(
         )
         .invoke()?;
 
-    let bump = [bumps.pool_authority];
+    // The pool signs the CPI below with its own seeds.
+    let bump = [bumps.pool];
     let seeds: &[Seed] = &[
-        Seed::from(b"authority".as_ref()),
-        Seed::from(accounts.pool.address().as_ref()),
+        Seed::from(b"pool".as_ref()),
+        Seed::from(accounts.collateral_mint.address().as_ref()),
+        Seed::from(accounts.oracle_feed.address().as_ref()),
         Seed::from(&bump as &[u8]),
     ];
     accounts
@@ -125,7 +125,7 @@ pub fn handle_remove_liquidity(
             &accounts.custody_vault,
             &accounts.collateral_mint,
             &accounts.provider_collateral,
-            &accounts.pool_authority,
+            &accounts.pool,
             amount_out,
             accounts.collateral_mint.decimals(),
         )

--- a/finance/perpetual-futures/quasar/src/lib.rs
+++ b/finance/perpetual-futures/quasar/src/lib.rs
@@ -18,11 +18,6 @@ use instructions::*;
 
 declare_id!("GaxH8967GVLxtst2SHCtXxqKQqGxgHyxqYvr9WGe1fmC");
 
-/// Authority PDA at seeds = [b"authority", pool]. Signs vault and mint CPIs.
-#[derive(Seeds)]
-#[seeds(b"authority", pool: Address)]
-pub struct PoolAuthorityPda;
-
 /// Liquidity-provider mint PDA at seeds = [b"lp_mint", pool].
 #[derive(Seeds)]
 #[seeds(b"lp_mint", pool: Address)]

--- a/finance/perpetual-futures/quasar/src/state.rs
+++ b/finance/perpetual-futures/quasar/src/state.rs
@@ -3,6 +3,9 @@ use quasar_lang::prelude::*;
 /// One perpetual-futures market. Mirrors the Anchor `Pool` field-for-field; see
 /// the Anchor sibling's README for what each field means. Money fields are raw
 /// base units of the collateral token.
+/// The pool account owns the custody vault and is the liquidity-provider
+/// mint's authority; it signs vault transfers and mint/burn CPIs with its own
+/// seeds. There is no separate signing PDA.
 #[account(discriminator = 100, set_inner)]
 #[seeds(b"pool", collateral_mint: Address, oracle_feed: Address)]
 pub struct Pool {
@@ -36,7 +39,6 @@ pub struct Pool {
     /// will trade against. A wider band is rejected as untrustworthy.
     pub max_confidence_bps: u16,
     pub bump: u8,
-    pub authority_bump: u8,
 }
 
 /// One trader's leveraged position, one PDA per (pool, owner). Unlike the Anchor

--- a/finance/perpetual-futures/quasar/src/tests.rs
+++ b/finance/perpetual-futures/quasar/src/tests.rs
@@ -212,8 +212,17 @@ fn initialize_pool_creates_pool_vault_and_lp_mint(test: &mut Test) {
     let env = setup(test);
     // The pool, vault, and liquidity-provider mint were created.
     assert!(test.account(env.pool).is_some());
-    assert!(test.account(env.custody_vault).is_some());
-    assert!(test.account(env.lp_mint).is_some());
+    let custody_vault = test.account(env.custody_vault).unwrap();
+    let lp_mint = test.account(env.lp_mint).unwrap();
+
+    // The pool account itself owns the custody vault and is the LP mint's
+    // authority; there is no separate signing PDA. A token account keeps its
+    // owner at bytes 32..64, and a mint keeps its authority at bytes 4..36
+    // behind a four-byte `COption` tag.
+    let vault_owner = Pubkey::new_from_array(custody_vault.data[32..64].try_into().unwrap());
+    assert_eq!(vault_owner, env.pool);
+    let mint_authority = Pubkey::new_from_array(lp_mint.data[4..36].try_into().unwrap());
+    assert_eq!(mint_authority, env.pool);
 }
 
 #[quasar_test]
@@ -375,7 +384,7 @@ fn collect_fees_sweeps_the_open_fee_to_the_admin(test: &mut Test) {
 
 /// The funding rate is quoted per slot, so what a position costs per hour also
 /// depends on the cluster's slot time. When the protocol shortens the slot, the
-/// pool authority retunes the rate, and the retune settles the slots already
+/// pool operator retunes the rate, and the retune settles the slots already
 /// elapsed at the old rate rather than repricing them at the new one.
 ///
 /// Both halves below hold the same position for the same slots at the same

--- a/finance/prop-amm/anchor-v1/CHANGELOG.md
+++ b/finance/prop-amm/anchor-v1/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-09-10
+
+The `Market` account now owns both vaults and signs their outgoing transfers
+with its own seeds, the way the escrow example's `offer` account does for its
+vault. The separate dataless signing PDA at seeds `["authority", market]`,
+the bump `Market` stored for it and its seed constant are gone, so
+`initialize_market`, `swap` and `withdraw_inventory` each take one account
+fewer. Tested by `test_market_owns_both_vaults`.
+
 ## 2026-09-08
 
 Move to Anchor 1.2.0, LiteSVM 0.16.0 and solana-kite 0.5.0. No program source

--- a/finance/prop-amm/anchor-v1/README.md
+++ b/finance/prop-amm/anchor-v1/README.md
@@ -86,9 +86,9 @@ option for whoever notices first.
 
 ### Step 1: Maria opens the market
 
-`initialize_market` creates the `Market` account (PDA of the mint pair), a
-dataless vault-authority PDA, and the two vaults, and pins the oracle feed,
-its scale, a 10 bps spread, and a 1% confidence limit. One market per pair:
+`initialize_market` creates the `Market` account (PDA of the mint pair) and
+the two vaults, which the market account itself owns and signs for, and pins
+the oracle feed, its scale, a 10 bps spread, and a 1% confidence limit. One market per pair:
 the deployment is the firm.
 
 ### Step 2: Maria stocks the inventory

--- a/finance/prop-amm/anchor-v1/programs/prop-amm/src/constants.rs
+++ b/finance/prop-amm/anchor-v1/programs/prop-amm/src/constants.rs
@@ -17,9 +17,6 @@ pub const MAX_PRICE_STALENESS_SLOTS: u64 = 150;
 pub const MARKET_SEED: &[u8] = b"market";
 
 #[constant]
-pub const AUTHORITY_SEED: &[u8] = b"authority";
-
-#[constant]
 pub const BASE_VAULT_SEED: &[u8] = b"base_vault";
 
 #[constant]

--- a/finance/prop-amm/anchor-v1/programs/prop-amm/src/instructions/initialize_market.rs
+++ b/finance/prop-amm/anchor-v1/programs/prop-amm/src/instructions/initialize_market.rs
@@ -4,9 +4,7 @@ use anchor_spl::{
     token_interface::{Mint, TokenAccount, TokenInterface},
 };
 
-use crate::constants::{
-    AUTHORITY_SEED, BASE_VAULT_SEED, BASIS_POINTS_DENOMINATOR, MARKET_SEED, QUOTE_VAULT_SEED,
-};
+use crate::constants::{BASE_VAULT_SEED, BASIS_POINTS_DENOMINATOR, MARKET_SEED, QUOTE_VAULT_SEED};
 use crate::errors::PropAmmError;
 use crate::state::Market;
 
@@ -64,7 +62,6 @@ pub fn handle_initialize_market(
     market.max_confidence_bps = parameters.max_confidence_bps;
     market.paused = false;
     market.bump = context.bumps.market;
-    market.authority_bump = context.bumps.market_authority;
 
     Ok(())
 }
@@ -95,21 +92,16 @@ pub struct InitializeMarketAccountConstraints<'info> {
     /// trusted by type. Swap for a real Switchboard feed in production.
     pub oracle_feed: UncheckedAccount<'info>,
 
-    /// CHECK: PDA that owns both vaults. Holds no data; used only to sign
-    /// vault CPIs.
-    #[account(
-        seeds = [AUTHORITY_SEED, market.key().as_ref()],
-        bump,
-    )]
-    pub market_authority: UncheckedAccount<'info>,
-
+    // The market account itself is the token authority of both vaults and
+    // signs their outgoing transfers with its own seeds, so no separate
+    // signing account is needed.
     #[account(
         init,
         payer = operator,
         seeds = [BASE_VAULT_SEED, market.key().as_ref()],
         bump,
         token::mint = base_mint,
-        token::authority = market_authority,
+        token::authority = market,
         token::token_program = token_program,
     )]
     pub base_vault: Box<InterfaceAccount<'info, TokenAccount>>,
@@ -120,7 +112,7 @@ pub struct InitializeMarketAccountConstraints<'info> {
         seeds = [QUOTE_VAULT_SEED, market.key().as_ref()],
         bump,
         token::mint = quote_mint,
-        token::authority = market_authority,
+        token::authority = market,
         token::token_program = token_program,
     )]
     pub quote_vault: Box<InterfaceAccount<'info, TokenAccount>>,

--- a/finance/prop-amm/anchor-v1/programs/prop-amm/src/instructions/swap.rs
+++ b/finance/prop-amm/anchor-v1/programs/prop-amm/src/instructions/swap.rs
@@ -4,7 +4,7 @@ use anchor_spl::{
     token_interface::{transfer_checked, Mint, TokenAccount, TokenInterface, TransferChecked},
 };
 
-use crate::constants::{AUTHORITY_SEED, BASE_VAULT_SEED, MARKET_SEED, QUOTE_VAULT_SEED};
+use crate::constants::{BASE_VAULT_SEED, MARKET_SEED, QUOTE_VAULT_SEED};
 use crate::errors::PropAmmError;
 use crate::quote_math;
 use crate::state::oracle::read_oracle_price;
@@ -111,11 +111,13 @@ pub fn handle_swap(
         PropAmmError::InsufficientInventory
     );
 
-    let market_key = market.key();
-    let authority_seeds: &[&[u8]] = &[
-        AUTHORITY_SEED,
-        market_key.as_ref(),
-        &[market.authority_bump],
+    // The market owns both vaults and signs the payout with its own seeds.
+    let market_bump = [market.bump];
+    let market_seeds: &[&[u8]] = &[
+        MARKET_SEED,
+        market.base_mint.as_ref(),
+        market.quote_mint.as_ref(),
+        &market_bump,
     ];
 
     // The trader pays in, then the vault pays out, atomically or not at all.
@@ -141,9 +143,9 @@ pub fn handle_swap(
                         from: context.accounts.base_vault.to_account_info(),
                         mint: context.accounts.base_mint.to_account_info(),
                         to: context.accounts.trader_base.to_account_info(),
-                        authority: context.accounts.market_authority.to_account_info(),
+                        authority: context.accounts.market.to_account_info(),
                     },
-                    &[authority_seeds],
+                    &[market_seeds],
                 ),
                 amount_out,
                 out_mint_decimals,
@@ -170,9 +172,9 @@ pub fn handle_swap(
                         from: context.accounts.quote_vault.to_account_info(),
                         mint: context.accounts.quote_mint.to_account_info(),
                         to: context.accounts.trader_quote.to_account_info(),
-                        authority: context.accounts.market_authority.to_account_info(),
+                        authority: context.accounts.market.to_account_info(),
                     },
-                    &[authority_seeds],
+                    &[market_seeds],
                 ),
                 amount_out,
                 out_mint_decimals,
@@ -198,13 +200,6 @@ pub struct SwapAccountConstraints<'info> {
         has_one = quote_vault,
     )]
     pub market: Box<Account<'info, Market>>,
-
-    /// CHECK: PDA authority over both vaults; holds no data, only signs.
-    #[account(
-        seeds = [AUTHORITY_SEED, market.key().as_ref()],
-        bump = market.authority_bump,
-    )]
-    pub market_authority: UncheckedAccount<'info>,
 
     /// CHECK: validated by the `has_one = oracle_feed` constraint on the market.
     pub oracle_feed: UncheckedAccount<'info>,

--- a/finance/prop-amm/anchor-v1/programs/prop-amm/src/instructions/withdraw_inventory.rs
+++ b/finance/prop-amm/anchor-v1/programs/prop-amm/src/instructions/withdraw_inventory.rs
@@ -3,7 +3,7 @@ use anchor_spl::token_interface::{
     transfer_checked, Mint, TokenAccount, TokenInterface, TransferChecked,
 };
 
-use crate::constants::{AUTHORITY_SEED, BASE_VAULT_SEED, MARKET_SEED, QUOTE_VAULT_SEED};
+use crate::constants::{BASE_VAULT_SEED, MARKET_SEED, QUOTE_VAULT_SEED};
 use crate::errors::PropAmmError;
 use crate::state::Market;
 
@@ -31,12 +31,14 @@ pub fn handle_withdraw_inventory(
         PropAmmError::InsufficientInventory
     );
 
+    // The market owns both vaults and signs the withdrawal with its own seeds.
     let market = &context.accounts.market;
-    let market_key = market.key();
-    let authority_seeds: &[&[u8]] = &[
-        AUTHORITY_SEED,
-        market_key.as_ref(),
-        &[market.authority_bump],
+    let market_bump = [market.bump];
+    let market_seeds: &[&[u8]] = &[
+        MARKET_SEED,
+        market.base_mint.as_ref(),
+        market.quote_mint.as_ref(),
+        &market_bump,
     ];
 
     if base_amount > 0 {
@@ -47,9 +49,9 @@ pub fn handle_withdraw_inventory(
                     from: context.accounts.base_vault.to_account_info(),
                     mint: context.accounts.base_mint.to_account_info(),
                     to: context.accounts.operator_base.to_account_info(),
-                    authority: context.accounts.market_authority.to_account_info(),
+                    authority: context.accounts.market.to_account_info(),
                 },
-                &[authority_seeds],
+                &[market_seeds],
             ),
             base_amount,
             context.accounts.base_mint.decimals,
@@ -64,9 +66,9 @@ pub fn handle_withdraw_inventory(
                     from: context.accounts.quote_vault.to_account_info(),
                     mint: context.accounts.quote_mint.to_account_info(),
                     to: context.accounts.operator_quote.to_account_info(),
-                    authority: context.accounts.market_authority.to_account_info(),
+                    authority: context.accounts.market.to_account_info(),
                 },
-                &[authority_seeds],
+                &[market_seeds],
             ),
             quote_amount,
             context.accounts.quote_mint.decimals,
@@ -91,13 +93,6 @@ pub struct WithdrawInventoryAccountConstraints<'info> {
         has_one = quote_vault,
     )]
     pub market: Box<Account<'info, Market>>,
-
-    /// CHECK: PDA authority over both vaults; holds no data, only signs.
-    #[account(
-        seeds = [AUTHORITY_SEED, market.key().as_ref()],
-        bump = market.authority_bump,
-    )]
-    pub market_authority: UncheckedAccount<'info>,
 
     pub base_mint: Box<InterfaceAccount<'info, Mint>>,
 

--- a/finance/prop-amm/anchor-v1/programs/prop-amm/src/quote_math.rs
+++ b/finance/prop-amm/anchor-v1/programs/prop-amm/src/quote_math.rs
@@ -67,8 +67,9 @@ pub fn quote_out_for_base_in(
     let numerator = (base_in as u128)
         .checked_mul(bid)?
         .checked_mul(10u128.checked_pow(quote_decimals as u32)?)?;
-    let denominator =
-        10u128.checked_pow(oracle_scale)?.checked_mul(10u128.checked_pow(base_decimals as u32)?)?;
+    let denominator = 10u128
+        .checked_pow(oracle_scale)?
+        .checked_mul(10u128.checked_pow(base_decimals as u32)?)?;
     if denominator == 0 {
         return None;
     }

--- a/finance/prop-amm/anchor-v1/programs/prop-amm/src/state/market.rs
+++ b/finance/prop-amm/anchor-v1/programs/prop-amm/src/state/market.rs
@@ -62,9 +62,8 @@ pub struct Market {
     /// inventory operations still work.
     pub paused: bool,
 
+    /// Bump of this account's own PDA. The market is the token authority of
+    /// both vaults and signs their outgoing transfers with its own seeds, so
+    /// the bump is stored to avoid re-deriving it on every CPI.
     pub bump: u8,
-
-    /// Bump for the vault authority PDA, stored so CPIs can sign without
-    /// re-deriving it.
-    pub authority_bump: u8,
 }

--- a/finance/prop-amm/anchor-v1/programs/prop-amm/tests/test_prop_amm.rs
+++ b/finance/prop-amm/anchor-v1/programs/prop-amm/tests/test_prop_amm.rs
@@ -65,7 +65,6 @@ struct Market {
     quote_mint: Pubkey,
     feed: Pubkey,
     market: Pubkey,
-    market_authority: Pubkey,
     base_vault: Pubkey,
     quote_vault: Pubkey,
 }
@@ -141,8 +140,6 @@ impl Market {
             &prop_amm::id(),
         )
         .0;
-        let market_authority =
-            Pubkey::find_program_address(&[b"authority", market.as_ref()], &prop_amm::id()).0;
         let base_vault =
             Pubkey::find_program_address(&[b"base_vault", market.as_ref()], &prop_amm::id()).0;
         let quote_vault =
@@ -157,7 +154,6 @@ impl Market {
                 base_mint,
                 quote_mint,
                 oracle_feed: feed,
-                market_authority,
                 base_vault,
                 quote_vault,
                 token_program: token_program_id(),
@@ -175,20 +171,12 @@ impl Market {
         .map_err(|_| ())?;
 
         // Fund the operator's inventory accounts.
-        let operator_base = create_associated_token_account(
-            &mut svm,
-            &operator.pubkey(),
-            &base_mint,
-            &payer,
-        )
-        .unwrap();
-        let operator_quote = create_associated_token_account(
-            &mut svm,
-            &operator.pubkey(),
-            &quote_mint,
-            &payer,
-        )
-        .unwrap();
+        let operator_base =
+            create_associated_token_account(&mut svm, &operator.pubkey(), &base_mint, &payer)
+                .unwrap();
+        let operator_quote =
+            create_associated_token_account(&mut svm, &operator.pubkey(), &quote_mint, &payer)
+                .unwrap();
         mint_tokens_to_token_account(
             &mut svm,
             &base_mint,
@@ -216,7 +204,6 @@ impl Market {
             quote_mint,
             feed,
             market,
-            market_authority,
             base_vault,
             quote_vault,
         })
@@ -271,9 +258,10 @@ impl Market {
     /// Simulate a cluster restart at `slot`: prices stamped at or before it
     /// must be rejected until the publisher posts again.
     fn set_last_restart_slot(&mut self, slot: u64) {
-        self.svm.set_sysvar(&solana_sysvar::last_restart_slot::LastRestartSlot {
-            last_restart_slot: slot,
-        });
+        self.svm
+            .set_sysvar(&solana_sysvar::last_restart_slot::LastRestartSlot {
+                last_restart_slot: slot,
+            });
     }
 
     /// Create a wallet holding `base` and `quote` minor units in associated
@@ -360,7 +348,6 @@ impl Market {
                 prop_amm::accounts::WithdrawInventoryAccountConstraints {
                     operator: signer.pubkey(),
                     market: self.market,
-                    market_authority: self.market_authority,
                     base_mint: self.base_mint,
                     quote_mint: self.quote_mint,
                     base_vault: self.base_vault,
@@ -372,9 +359,14 @@ impl Market {
                 .to_account_metas(None),
             )
         };
-        send_transaction_from_instructions(&mut self.svm, vec![instruction], &[signer], &signer.pubkey())
-            .map(|_| ())
-            .map_err(|_| ())
+        send_transaction_from_instructions(
+            &mut self.svm,
+            vec![instruction],
+            &[signer],
+            &signer.pubkey(),
+        )
+        .map(|_| ())
+        .map_err(|_| ())
     }
 
     fn deposit_inventory(&mut self, base_amount: u64, quote_amount: u64) -> Result<(), ()> {
@@ -397,9 +389,14 @@ impl Market {
             }
             .to_account_metas(None),
         );
-        send_transaction_from_instructions(&mut self.svm, vec![instruction], &[signer], &signer.pubkey())
-            .map(|_| ())
-            .map_err(|_| ())
+        send_transaction_from_instructions(
+            &mut self.svm,
+            vec![instruction],
+            &[signer],
+            &signer.pubkey(),
+        )
+        .map(|_| ())
+        .map_err(|_| ())
     }
 
     fn set_quote(&mut self, spread_bps: u16, paused: bool) -> Result<(), ()> {
@@ -427,7 +424,6 @@ impl Market {
             prop_amm::accounts::SwapAccountConstraints {
                 trader: trader.pubkey(),
                 market: self.market,
-                market_authority: self.market_authority,
                 oracle_feed: self.feed,
                 base_mint: self.base_mint,
                 quote_mint: self.quote_mint,
@@ -441,13 +437,25 @@ impl Market {
             }
             .to_account_metas(None),
         );
-        send_transaction_from_instructions(&mut self.svm, vec![instruction], &[trader], &trader.pubkey())
-            .map(|_| ())
-            .map_err(|_| ())
+        send_transaction_from_instructions(
+            &mut self.svm,
+            vec![instruction],
+            &[trader],
+            &trader.pubkey(),
+        )
+        .map(|_| ())
+        .map_err(|_| ())
     }
 
     fn balance(&self, token_account: &Pubkey) -> u64 {
         get_token_account_balance(&self.svm, token_account).unwrap()
+    }
+
+    /// The owner field of a token account: bytes 32..64 of the SPL Token
+    /// account layout, after the mint.
+    fn token_account_owner(&self, token_account: &Pubkey) -> Pubkey {
+        let account = self.svm.get_account(token_account).unwrap();
+        Pubkey::try_from(&account.data[32..64]).unwrap()
     }
 }
 
@@ -587,9 +595,7 @@ fn test_operator_can_withdraw_everything_and_swaps_then_fail() {
 #[test]
 fn test_withdraw_more_than_inventory_fails() {
     let mut market = Market::default_market();
-    assert!(market
-        .withdraw_inventory(1_001 * ONE_TOKEN, 0)
-        .is_err());
+    assert!(market.withdraw_inventory(1_001 * ONE_TOKEN, 0).is_err());
 }
 
 #[test]
@@ -725,12 +731,29 @@ fn test_swap_rejects_insufficient_inventory() {
     // but the vault only holds 1,000 NVDAx.
     let quote_in = 181_681_500_000;
     let (whale, _, _) = market.funded_trader(0, quote_in);
-    assert!(market.swap(&whale, Direction::BuyBase, quote_in, 0).is_err());
+    assert!(market
+        .swap(&whale, Direction::BuyBase, quote_in, 0)
+        .is_err());
 }
 
 // ===========================================================================
 // Parameter validation
 // ===========================================================================
+
+/// The market account is the token authority of both vaults, so it can sign
+/// their outgoing transfers with its own seeds.
+#[test]
+fn test_market_owns_both_vaults() {
+    let market = Market::default_market();
+    assert_eq!(
+        market.token_account_owner(&market.base_vault),
+        market.market
+    );
+    assert_eq!(
+        market.token_account_owner(&market.quote_vault),
+        market.market
+    );
+}
 
 #[test]
 fn test_initialize_market_rejects_zero_spread() {

--- a/finance/prop-amm/anchor/CHANGELOG.md
+++ b/finance/prop-amm/anchor/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-09-10
+
+The `Market` account now owns both vaults and signs their outgoing transfers
+with its own seeds, the way the escrow example's `offer` account does for its
+vault. The separate dataless signing PDA at seeds `["authority", market]`,
+the bump `Market` stored for it and its seed constant are gone, so
+`initialize_market`, `swap` and `withdraw_inventory` each take one account
+fewer. Tested by `test_market_owns_both_vaults`.
+
 ## 2026-08-04
 
 Reject oracle prices from before a cluster restart. A halt stops the slot

--- a/finance/prop-amm/anchor/README.md
+++ b/finance/prop-amm/anchor/README.md
@@ -86,9 +86,9 @@ option for whoever notices first.
 
 ### Step 1: Maria opens the market
 
-`initialize_market` creates the `Market` account (PDA of the mint pair), a
-dataless vault-authority PDA, and the two vaults, and pins the oracle feed,
-its scale, a 10 bps spread, and a 1% confidence limit. One market per pair:
+`initialize_market` creates the `Market` account (PDA of the mint pair) and
+the two vaults, which the market account itself owns and signs for, and pins
+the oracle feed, its scale, a 10 bps spread, and a 1% confidence limit. One market per pair:
 the deployment is the firm.
 
 ### Step 2: Maria stocks the inventory

--- a/finance/prop-amm/anchor/programs/prop-amm/src/constants.rs
+++ b/finance/prop-amm/anchor/programs/prop-amm/src/constants.rs
@@ -17,9 +17,6 @@ pub const MAX_PRICE_STALENESS_SLOTS: u64 = 150;
 pub const MARKET_SEED: &[u8] = b"market";
 
 #[constant]
-pub const AUTHORITY_SEED: &[u8] = b"authority";
-
-#[constant]
 pub const BASE_VAULT_SEED: &[u8] = b"base_vault";
 
 #[constant]

--- a/finance/prop-amm/anchor/programs/prop-amm/src/instructions/initialize_market.rs
+++ b/finance/prop-amm/anchor/programs/prop-amm/src/instructions/initialize_market.rs
@@ -5,9 +5,7 @@ use anchor_spl::{
     token_interface::{Mint, TokenAccount, TokenInterface},
 };
 
-use crate::constants::{
-    AUTHORITY_SEED, BASE_VAULT_SEED, BASIS_POINTS_DENOMINATOR, MARKET_SEED, QUOTE_VAULT_SEED,
-};
+use crate::constants::{BASE_VAULT_SEED, BASIS_POINTS_DENOMINATOR, MARKET_SEED, QUOTE_VAULT_SEED};
 use crate::errors::PropAmmError;
 use crate::state::Market;
 
@@ -65,7 +63,6 @@ pub fn handle_initialize_market(
     market.max_confidence_bps = parameters.max_confidence_bps;
     market.paused = false;
     market.bump = context.bumps.market;
-    market.authority_bump = context.bumps.market_authority;
 
     Ok(())
 }
@@ -96,21 +93,16 @@ pub struct InitializeMarketAccountConstraints {
     /// trusted by type. Swap for a real Switchboard feed in production.
     pub oracle_feed: UncheckedAccount,
 
-    /// CHECK: PDA that owns both vaults. Holds no data; used only to sign
-    /// vault CPIs.
-    #[account(
-        seeds = [AUTHORITY_SEED, market.address().as_ref()],
-        bump,
-    )]
-    pub market_authority: UncheckedAccount,
-
+    // The market account itself is the token authority of both vaults and
+    // signs their outgoing transfers with its own seeds, so no separate
+    // signing account is needed.
     #[account(
         init,
         payer = operator,
         seeds = [BASE_VAULT_SEED, market.address().as_ref()],
         bump,
         token::mint = base_mint,
-        token::authority = market_authority,
+        token::authority = market,
         token::token_program = token_program,
     )]
     pub base_vault: Box<InterfaceAccount<TokenAccount>>,
@@ -121,7 +113,7 @@ pub struct InitializeMarketAccountConstraints {
         seeds = [QUOTE_VAULT_SEED, market.address().as_ref()],
         bump,
         token::mint = quote_mint,
-        token::authority = market_authority,
+        token::authority = market,
         token::token_program = token_program,
     )]
     pub quote_vault: Box<InterfaceAccount<TokenAccount>>,

--- a/finance/prop-amm/anchor/programs/prop-amm/src/instructions/swap.rs
+++ b/finance/prop-amm/anchor/programs/prop-amm/src/instructions/swap.rs
@@ -4,7 +4,7 @@ use anchor_spl::{
     token_interface::{transfer_checked, Mint, TokenAccount, TokenInterface, TransferChecked},
 };
 
-use crate::constants::{AUTHORITY_SEED, BASE_VAULT_SEED, MARKET_SEED, QUOTE_VAULT_SEED};
+use crate::constants::{BASE_VAULT_SEED, MARKET_SEED, QUOTE_VAULT_SEED};
 use crate::errors::PropAmmError;
 use crate::quote_math;
 use crate::state::oracle::read_oracle_price;
@@ -111,11 +111,13 @@ pub fn handle_swap(
         PropAmmError::InsufficientInventory
     );
 
-    let market_key = market.address();
-    let authority_seeds: &[&[u8]] = &[
-        AUTHORITY_SEED,
-        market_key.as_ref(),
-        &[market.authority_bump],
+    // The market owns both vaults and signs the payout with its own seeds.
+    let market_bump = [market.bump];
+    let market_seeds: &[&[u8]] = &[
+        MARKET_SEED,
+        market.base_mint.as_ref(),
+        market.quote_mint.as_ref(),
+        &market_bump,
     ];
 
     // The trader pays in, then the vault pays out, atomically or not at all.
@@ -141,9 +143,9 @@ pub fn handle_swap(
                         from: context.accounts.base_vault.to_cpi_handle_mut(),
                         mint: context.accounts.base_mint.to_cpi_handle(),
                         to: context.accounts.trader_base.to_cpi_handle_mut(),
-                        authority: context.accounts.market_authority.cpi_handle(),
+                        authority: context.accounts.market.cpi_handle(),
                     },
-                    &[authority_seeds],
+                    &[market_seeds],
                 ),
                 amount_out,
                 out_mint_decimals,
@@ -170,9 +172,9 @@ pub fn handle_swap(
                         from: context.accounts.quote_vault.to_cpi_handle_mut(),
                         mint: context.accounts.quote_mint.to_cpi_handle(),
                         to: context.accounts.trader_quote.to_cpi_handle_mut(),
-                        authority: context.accounts.market_authority.cpi_handle(),
+                        authority: context.accounts.market.cpi_handle(),
                     },
-                    &[authority_seeds],
+                    &[market_seeds],
                 ),
                 amount_out,
                 out_mint_decimals,
@@ -193,13 +195,6 @@ pub struct SwapAccountConstraints {
         bump = market.bump,
     )]
     pub market: Box<BorshAccount<Market>>,
-
-    /// CHECK: PDA authority over both vaults; holds no data, only signs.
-    #[account(
-        seeds = [AUTHORITY_SEED, market.address().as_ref()],
-        bump = market.authority_bump,
-    )]
-    pub market_authority: UncheckedAccount,
 
     /// CHECK: validated by the `address = market.oracle_feed` constraint below.
     #[account(address = market.oracle_feed)]

--- a/finance/prop-amm/anchor/programs/prop-amm/src/instructions/withdraw_inventory.rs
+++ b/finance/prop-amm/anchor/programs/prop-amm/src/instructions/withdraw_inventory.rs
@@ -3,7 +3,7 @@ use anchor_spl::token_interface::{
     transfer_checked, Mint, TokenAccount, TokenInterface, TransferChecked,
 };
 
-use crate::constants::{AUTHORITY_SEED, BASE_VAULT_SEED, MARKET_SEED, QUOTE_VAULT_SEED};
+use crate::constants::{BASE_VAULT_SEED, MARKET_SEED, QUOTE_VAULT_SEED};
 use crate::errors::PropAmmError;
 use crate::state::Market;
 
@@ -31,12 +31,14 @@ pub fn handle_withdraw_inventory(
         PropAmmError::InsufficientInventory
     );
 
+    // The market owns both vaults and signs the withdrawal with its own seeds.
     let market = &context.accounts.market;
-    let market_key = market.address();
-    let authority_seeds: &[&[u8]] = &[
-        AUTHORITY_SEED,
-        market_key.as_ref(),
-        &[market.authority_bump],
+    let market_bump = [market.bump];
+    let market_seeds: &[&[u8]] = &[
+        MARKET_SEED,
+        market.base_mint.as_ref(),
+        market.quote_mint.as_ref(),
+        &market_bump,
     ];
 
     if base_amount > 0 {
@@ -47,9 +49,9 @@ pub fn handle_withdraw_inventory(
                     from: context.accounts.base_vault.to_cpi_handle_mut(),
                     mint: context.accounts.base_mint.to_cpi_handle(),
                     to: context.accounts.operator_base.to_cpi_handle_mut(),
-                    authority: context.accounts.market_authority.cpi_handle(),
+                    authority: context.accounts.market.cpi_handle(),
                 },
-                &[authority_seeds],
+                &[market_seeds],
             ),
             base_amount,
             context.accounts.base_mint.decimals(),
@@ -64,9 +66,9 @@ pub fn handle_withdraw_inventory(
                     from: context.accounts.quote_vault.to_cpi_handle_mut(),
                     mint: context.accounts.quote_mint.to_cpi_handle(),
                     to: context.accounts.operator_quote.to_cpi_handle_mut(),
-                    authority: context.accounts.market_authority.cpi_handle(),
+                    authority: context.accounts.market.cpi_handle(),
                 },
-                &[authority_seeds],
+                &[market_seeds],
             ),
             quote_amount,
             context.accounts.quote_mint.decimals(),
@@ -86,13 +88,6 @@ pub struct WithdrawInventoryAccountConstraints {
         bump = market.bump,
     )]
     pub market: Box<BorshAccount<Market>>,
-
-    /// CHECK: PDA authority over both vaults; holds no data, only signs.
-    #[account(
-        seeds = [AUTHORITY_SEED, market.address().as_ref()],
-        bump = market.authority_bump,
-    )]
-    pub market_authority: UncheckedAccount,
 
     #[account(address = market.base_mint)]
     pub base_mint: Box<InterfaceAccount<Mint>>,

--- a/finance/prop-amm/anchor/programs/prop-amm/src/state/market.rs
+++ b/finance/prop-amm/anchor/programs/prop-amm/src/state/market.rs
@@ -62,9 +62,8 @@ pub struct Market {
     /// inventory operations still work.
     pub paused: bool,
 
+    /// Bump of this account's own PDA. The market is the token authority of
+    /// both vaults and signs their outgoing transfers with its own seeds, so
+    /// the bump is stored to avoid re-deriving it on every CPI.
     pub bump: u8,
-
-    /// Bump for the vault authority PDA, stored so CPIs can sign without
-    /// re-deriving it.
-    pub authority_bump: u8,
 }

--- a/finance/prop-amm/anchor/programs/prop-amm/tests/test_prop_amm.rs
+++ b/finance/prop-amm/anchor/programs/prop-amm/tests/test_prop_amm.rs
@@ -63,7 +63,6 @@ struct Market {
     quote_mint: Address,
     feed: Address,
     market: Address,
-    market_authority: Address,
     base_vault: Address,
     quote_vault: Address,
 }
@@ -139,8 +138,6 @@ impl Market {
             &prop_amm::id(),
         )
         .0;
-        let market_authority =
-            Address::find_program_address(&[b"authority", market.as_ref()], &prop_amm::id()).0;
         let base_vault =
             Address::find_program_address(&[b"base_vault", market.as_ref()], &prop_amm::id()).0;
         let quote_vault =
@@ -155,7 +152,6 @@ impl Market {
                 base_mint,
                 quote_mint,
                 oracle_feed: feed,
-                market_authority,
                 base_vault,
                 quote_vault,
                 token_program: token_program_id(),
@@ -206,7 +202,6 @@ impl Market {
             quote_mint,
             feed,
             market,
-            market_authority,
             base_vault,
             quote_vault,
         })
@@ -351,7 +346,6 @@ impl Market {
                 prop_amm::accounts::WithdrawInventoryAccountConstraints {
                     operator: signer.pubkey(),
                     market: self.market,
-                    market_authority: self.market_authority,
                     base_mint: self.base_mint,
                     quote_mint: self.quote_mint,
                     base_vault: self.base_vault,
@@ -428,7 +422,6 @@ impl Market {
             prop_amm::accounts::SwapAccountConstraints {
                 trader: trader.pubkey(),
                 market: self.market,
-                market_authority: self.market_authority,
                 oracle_feed: self.feed,
                 base_mint: self.base_mint,
                 quote_mint: self.quote_mint,
@@ -454,6 +447,13 @@ impl Market {
 
     fn balance(&self, token_account: &Address) -> u64 {
         get_token_account_balance(&self.svm, token_account).unwrap()
+    }
+
+    /// The owner field of a token account: bytes 32..64 of the SPL Token
+    /// account layout, after the mint.
+    fn token_account_owner(&self, token_account: &Address) -> Address {
+        let account = self.svm.get_account(token_account).unwrap();
+        Address::try_from(&account.data[32..64]).unwrap()
     }
 }
 
@@ -735,6 +735,21 @@ fn test_swap_rejects_insufficient_inventory() {
 // ===========================================================================
 // Parameter validation
 // ===========================================================================
+
+/// The market account is the token authority of both vaults, so it can sign
+/// their outgoing transfers with its own seeds.
+#[test]
+fn test_market_owns_both_vaults() {
+    let market = Market::default_market();
+    assert_eq!(
+        market.token_account_owner(&market.base_vault),
+        market.market
+    );
+    assert_eq!(
+        market.token_account_owner(&market.quote_vault),
+        market.market
+    );
+}
 
 #[test]
 fn test_initialize_market_rejects_zero_spread() {

--- a/finance/prop-amm/quasar/CHANGELOG.md
+++ b/finance/prop-amm/quasar/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-09-10
+
+The `Market` account now owns both vaults and signs their outgoing transfers
+with its own seeds, the way the escrow example's `offer` account does for its
+vault. The separate dataless signing PDA at seeds `["authority", market]`,
+its `Seeds` struct and the bump `Market` stored for it are gone, so
+`initialize_market`, `swap` and `withdraw_inventory` each take one account
+fewer. Asserted in `initialize_market_creates_market_and_stocked_vaults`.
+
 ## 2026-08-04
 
 Reject oracle prices from before a cluster restart: `read_oracle_price`

--- a/finance/prop-amm/quasar/src/instructions/initialize_market.rs
+++ b/finance/prop-amm/quasar/src/instructions/initialize_market.rs
@@ -3,7 +3,7 @@ use {
         constants::BASIS_POINTS_DENOMINATOR,
         instructions::shared::{err, error},
         state::{Market, MarketInner},
-        BaseVaultPda, MarketAuthorityPda, QuoteVaultPda,
+        BaseVaultPda, QuoteVaultPda,
     },
     quasar_lang::prelude::*,
     quasar_spl::prelude::*,
@@ -27,15 +27,15 @@ pub struct InitializeMarket {
     /// CHECK: stored on the market; every read validates layout, scale,
     /// freshness, and confidence.
     pub oracle_feed: UncheckedAccount,
-    /// Authority PDA over both vaults. Holds no data; only signs.
-    #[account(address = MarketAuthorityPda::seeds(market.address()))]
-    pub market_authority: UncheckedAccount,
+    // The market account itself is the token authority of both vaults and
+    // signs their outgoing transfers with its own seeds, so no separate
+    // signing account is needed.
     #[account(
         mut,
         init(idempotent),
         payer = operator,
         address = BaseVaultPda::seeds(market.address()),
-        token(mint = base_mint, authority = market_authority, token_program = token_program),
+        token(mint = base_mint, authority = market, token_program = token_program),
     )]
     pub base_vault: Account<Token>,
     #[account(
@@ -43,7 +43,7 @@ pub struct InitializeMarket {
         init(idempotent),
         payer = operator,
         address = QuoteVaultPda::seeds(market.address()),
-        token(mint = quote_mint, authority = market_authority, token_program = token_program),
+        token(mint = quote_mint, authority = market, token_program = token_program),
     )]
     pub quote_vault: Account<Token>,
     pub token_program: Program<TokenProgram>,
@@ -90,7 +90,6 @@ pub fn handle_initialize_market(
         max_confidence_bps,
         paused: 0,
         bump: bumps.market,
-        authority_bump: bumps.market_authority,
     });
     Ok(())
 }

--- a/finance/prop-amm/quasar/src/instructions/swap.rs
+++ b/finance/prop-amm/quasar/src/instructions/swap.rs
@@ -3,7 +3,6 @@ use {
         constants::{DIRECTION_BUY_BASE, DIRECTION_SELL_BASE},
         instructions::shared::{self, err, error},
         state::Market,
-        MarketAuthorityPda,
     },
     quasar_lang::cpi::Seed,
     quasar_lang::{prelude::*, sysvars::clock::Clock},
@@ -21,9 +20,6 @@ pub struct Swap {
         has_one(quote_vault),
     )]
     pub market: Account<Market>,
-    /// Authority PDA over both vaults; holds no data, only signs.
-    #[account(address = MarketAuthorityPda::seeds(market.address()))]
-    pub market_authority: UncheckedAccount,
     /// CHECK: bound to the market via `has_one(oracle_feed)`.
     pub oracle_feed: UncheckedAccount,
     pub base_mint: Account<Mint>,
@@ -141,11 +137,14 @@ pub fn handle_swap(
         return Err(err(error::INSUFFICIENT_INVENTORY));
     }
 
-    let bump = [accounts.market.authority_bump];
-    let market_address = *accounts.market.address();
+    // The market owns both vaults and signs the payout with its own seeds.
+    let bump = [accounts.market.bump];
+    let base_mint = *accounts.base_mint.address();
+    let quote_mint = *accounts.quote_mint.address();
     let seeds: &[Seed] = &[
-        Seed::from(b"authority".as_ref()),
-        Seed::from(market_address.as_ref()),
+        Seed::from(b"market".as_ref()),
+        Seed::from(base_mint.as_ref()),
+        Seed::from(quote_mint.as_ref()),
         Seed::from(&bump as &[u8]),
     ];
 
@@ -168,7 +167,7 @@ pub fn handle_swap(
                 &accounts.base_vault,
                 &accounts.base_mint,
                 &accounts.trader_base,
-                &accounts.market_authority,
+                &accounts.market,
                 amount_out,
                 accounts.base_mint.decimals(),
             )
@@ -191,7 +190,7 @@ pub fn handle_swap(
                 &accounts.quote_vault,
                 &accounts.quote_mint,
                 &accounts.trader_quote,
-                &accounts.market_authority,
+                &accounts.market,
                 amount_out,
                 accounts.quote_mint.decimals(),
             )

--- a/finance/prop-amm/quasar/src/instructions/withdraw_inventory.rs
+++ b/finance/prop-amm/quasar/src/instructions/withdraw_inventory.rs
@@ -2,7 +2,6 @@ use {
     crate::{
         instructions::shared::{err, error},
         state::Market,
-        MarketAuthorityPda,
     },
     quasar_lang::cpi::Seed,
     quasar_lang::prelude::*,
@@ -20,9 +19,6 @@ pub struct WithdrawInventory {
         has_one(quote_vault),
     )]
     pub market: Account<Market>,
-    /// Authority PDA over both vaults; holds no data, only signs.
-    #[account(address = MarketAuthorityPda::seeds(market.address()))]
-    pub market_authority: UncheckedAccount,
     pub base_mint: Account<Mint>,
     pub quote_mint: Account<Mint>,
     #[account(mut)]
@@ -56,11 +52,14 @@ pub fn handle_withdraw_inventory(
         return Err(err(error::INSUFFICIENT_INVENTORY));
     }
 
-    let bump = [accounts.market.authority_bump];
-    let market_address = *accounts.market.address();
+    // The market owns both vaults and signs the withdrawal with its own seeds.
+    let bump = [accounts.market.bump];
+    let base_mint = *accounts.base_mint.address();
+    let quote_mint = *accounts.quote_mint.address();
     let seeds: &[Seed] = &[
-        Seed::from(b"authority".as_ref()),
-        Seed::from(market_address.as_ref()),
+        Seed::from(b"market".as_ref()),
+        Seed::from(base_mint.as_ref()),
+        Seed::from(quote_mint.as_ref()),
         Seed::from(&bump as &[u8]),
     ];
 
@@ -71,7 +70,7 @@ pub fn handle_withdraw_inventory(
                 &accounts.base_vault,
                 &accounts.base_mint,
                 &accounts.operator_base,
-                &accounts.market_authority,
+                &accounts.market,
                 base_amount,
                 accounts.base_mint.decimals(),
             )
@@ -85,7 +84,7 @@ pub fn handle_withdraw_inventory(
                 &accounts.quote_vault,
                 &accounts.quote_mint,
                 &accounts.operator_quote,
-                &accounts.market_authority,
+                &accounts.market,
                 quote_amount,
                 accounts.quote_mint.decimals(),
             )

--- a/finance/prop-amm/quasar/src/lib.rs
+++ b/finance/prop-amm/quasar/src/lib.rs
@@ -18,11 +18,6 @@ use instructions::*;
 
 declare_id!("FPTx81bSwghfrwzaQpgmKPw1TnajK66wif1cQyev4GdD");
 
-/// Authority PDA at seeds = [b"authority", market]. Signs vault CPIs.
-#[derive(Seeds)]
-#[seeds(b"authority", market: Address)]
-pub struct MarketAuthorityPda;
-
 /// Base-token vault PDA at seeds = [b"base_vault", market].
 #[derive(Seeds)]
 #[seeds(b"base_vault", market: Address)]

--- a/finance/prop-amm/quasar/src/state.rs
+++ b/finance/prop-amm/quasar/src/state.rs
@@ -7,6 +7,10 @@ use quasar_lang::prelude::*;
 /// Note what this account does NOT hold, compared to a curve AMM's pool: no
 /// liquidity-provider mint, no fee ledger, no reserves that pricing depends
 /// on. The operator is the only capital in the market.
+///
+/// The market account is also the token authority of both vaults: it signs
+/// their outgoing transfers with its own seeds, so `bump` is stored to avoid
+/// re-deriving it on every CPI.
 #[account(discriminator = 100, set_inner)]
 #[seeds(b"market", base_mint: Address, quote_mint: Address)]
 pub struct Market {
@@ -29,5 +33,4 @@ pub struct Market {
     /// 1 while the operator has pulled its quotes; swaps are rejected.
     pub paused: u8,
     pub bump: u8,
-    pub authority_bump: u8,
 }

--- a/finance/prop-amm/quasar/src/tests.rs
+++ b/finance/prop-amm/quasar/src/tests.rs
@@ -228,6 +228,7 @@ fn set_quote(test: &mut Test, signer: Pubkey, spread_bps: u16, paused: u8) -> Ou
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn swap(
     test: &mut Test,
     env: &Env,
@@ -282,6 +283,12 @@ fn initialize_market_creates_market_and_stocked_vaults(test: &mut Test) {
     assert!(test.account(env.market).is_some());
     assert_eq!(test.tokens(env.base_vault), 1_000 * ONE_TOKEN);
     assert_eq!(test.tokens(env.quote_vault), 200_000 * ONE_TOKEN);
+    // The market account itself is the token authority of both vaults (the
+    // owner field is bytes 32..64 of the SPL Token account layout).
+    let vault_owner =
+        |address: Pubkey| Pubkey::try_from(&test.account(address).unwrap().data[32..64]).unwrap();
+    assert_eq!(vault_owner(env.base_vault), env.market);
+    assert_eq!(vault_owner(env.quote_vault), env.market);
 }
 
 /// Alice buys 5 NVDAx. At $165 with a 10 bps spread the ask is $165.165, so

--- a/finance/token-swap/README.md
+++ b/finance/token-swap/README.md
@@ -82,7 +82,7 @@ Shared configuration for the AMM. **Singleton** - one per deployed program, at P
 
 ### `PoolConfig`
 
-Per-pool configuration / identity record. Identifies a single pool by which `Config` it belongs to and which two mints it trades, and tracks the admin's accumulated trading-fee claim for each side. The actual pool reserves live in separate token accounts (`pool_a`, `pool_b`) owned by `pool_authority` - they are *not* stored here.
+Per-pool configuration / identity record. Identifies a single pool by which `Config` it belongs to and which two mints it trades, and tracks the admin's accumulated trading-fee claim for each side. The actual pool reserves live in separate token accounts (`pool_a`, `pool_b`) owned by the `PoolConfig` account itself - they are *not* stored here. `PoolConfig` is also the LP mint's mint authority, and it signs the transfers out of the reserves and the LP mint/burn CPIs with its own seeds, the way the escrow example's `offer` account signs for its vault.
 
 - `config: Pubkey` - the parent `Config` account.
 - `mint_a: Pubkey` - mint of token A.
@@ -102,7 +102,7 @@ Initializes the singleton `Config` account with the supplied `admin`, `fee`, and
 
 ### `initialize_pool`
 
-Initializes a `PoolConfig` account, an LP mint (`liquidity_provider_mint`), and the two pool reserve token accounts (`pool_a`, `pool_b`) owned by `pool_authority`. Enforces `mint_a < mint_b` for canonical pool addressing.
+Initializes a `PoolConfig` account, an LP mint (`liquidity_provider_mint`) whose mint authority is `pool_config`, and the two pool reserve token accounts (`pool_a`, `pool_b`), the associated token accounts of `pool_config`. Enforces `mint_a < mint_b` for canonical pool addressing.
 
 ### `deposit_liquidity`
 
@@ -140,7 +140,7 @@ Burns LP tokens and returns a proportional share of the **effective reserves** (
 
 ### `claim_admin_fees`
 
-Lets the address stored in `Config.admin` sweep their accumulated trading-fee claim out of a pool. Transfers `admin_fees_owed_a` from `pool_a` to the admin's token-A account and `admin_fees_owed_b` from `pool_b` to the admin's token-B account, signed by `pool_authority`. Then resets both accumulators to zero.
+Lets the address stored in `Config.admin` sweep their accumulated trading-fee claim out of a pool. Transfers `admin_fees_owed_a` from `pool_a` to the admin's token-A account and `admin_fees_owed_b` from `pool_b` to the admin's token-B account, signed by `pool_config`. Then resets both accumulators to zero.
 
 - Authorisation: enforced by Anchor's `address = config.admin` constraint on `admin` plus the `Signer` constraint on the same field. Calls from any other signer are rejected.
 - The admin's token accounts (`admin_token_a`, `admin_token_b`) must already exist - this handler doesn't auto-create them (keeps the example small).
@@ -180,11 +180,10 @@ The singleton `Config` account is set once per deployed program. Every pool inhe
 - **Handler:** `initialize_pool`
 - **Accounts (`InitializePoolAccounts`):**
   - `config` - Alice's `Config`
-  - `pool_config` (PDA, created) - seeds `[config, mint_a, mint_b]`; stores `config`, `mint_a`, `mint_b`, `bump`
-  - `pool_authority` (PDA) - signs for the pool reserves
-  - `liquidity_provider_mint` (created) - the LP-token mint, authority = `pool_authority`
+  - `pool_config` (PDA, created) - seeds `[config, mint_a, mint_b]`; stores `config`, `mint_a`, `mint_b`, `bump`; owns the reserves and signs for them
+  - `liquidity_provider_mint` (created) - the LP-token mint, authority = `pool_config`
   - `mint_a` = NVDAx mint, `mint_b` = USDC mint (with `mint_a < mint_b`)
-  - `pool_a`, `pool_b` (created, ATAs owned by `pool_authority`) - the NVDAx and USDC reserves
+  - `pool_a`, `pool_b` (created, ATAs owned by `pool_config`) - the NVDAx and USDC reserves
   - `payer` = Alice
   - token, ATA, system programs
 - **Args:** none
@@ -198,11 +197,10 @@ Alice immediately creates a second pool for TSLAx (Tesla xStock, ~180 USDC each)
 - **Handler:** `initialize_pool`
 - **Accounts (`InitializePoolAccounts`):**
   - `config` - Alice's `Config` (same singleton)
-  - `pool_config` (PDA, created) - seeds `[config, mint_a, mint_b]`; stores `config`, `mint_a` = TSLAx mint, `mint_b` = USDC mint, `bump`
-  - `pool_authority` (PDA) - signs for this pool's reserves
-  - `liquidity_provider_mint` (created) - a separate LP-token mint for this pool
+  - `pool_config` (PDA, created) - seeds `[config, mint_a, mint_b]`; stores `config`, `mint_a` = TSLAx mint, `mint_b` = USDC mint, `bump`; owns this pool's reserves and signs for them
+  - `liquidity_provider_mint` (created) - a separate LP-token mint for this pool, authority = `pool_config`
   - `mint_a` = TSLAx mint, `mint_b` = USDC mint (with `mint_a < mint_b`)
-  - `pool_a`, `pool_b` (created, ATAs owned by `pool_authority`) - the TSLAx and USDC reserves
+  - `pool_a`, `pool_b` (created, ATAs owned by `pool_config`) - the TSLAx and USDC reserves
   - `payer` = Alice
   - token, ATA, system programs
 - **Args:** none
@@ -219,7 +217,7 @@ Alice picks a 1:5 ratio so the NVDAx/USDC pool launches at ~5 USDC per NVDAx. Sh
 
 - **Handler:** `deposit_liquidity`
 - **Accounts (`DepositLiquidityAccounts`):**
-  - `pool_config`, `pool_authority`, `liquidity_provider_mint`
+  - `pool_config`, `liquidity_provider_mint`
   - `depositor` = Alice (signer)
   - `mint_a`, `mint_b`
   - `pool_a`, `pool_b` (the pool's reserves)
@@ -254,7 +252,7 @@ NVDAx/USDC pool state: **120 NVDAx, 600 USDC**. LP supply ~268.32. Bob owns ~83%
 - **Handler:** `swap_tokens`
 - **Accounts (`SwapTokensAccounts`):**
   - `config` - for the fee
-  - `pool_config`, `pool_authority`
+  - `pool_config`
   - `trader` = Carol (signer)
   - `mint_a`, `mint_b`
   - `pool_a`, `pool_b` (the pool's reserves)
@@ -311,7 +309,6 @@ Separately, Carol decides to add TSLAx exposure on top of her NVDAx purchase. Sh
 - **Accounts (`SwapTokensAccounts`):**
   - `config` - the same singleton `Config` (fee and admin_share_bps apply to all pools)
   - `pool_config` - the TSLAx/USDC `PoolConfig` PDA
-  - `pool_authority` - the TSLAx/USDC pool authority PDA
   - `trader` = Carol (signer)
   - `mint_a` = TSLAx mint, `mint_b` = USDC mint
   - `pool_a`, `pool_b` - the TSLAx/USDC reserves (1 TSLAx, 180 USDC after Alice's seed deposit)
@@ -343,7 +340,7 @@ After trading activity on both pools, Alice sweeps her accumulated slice from th
 - **Handler:** `claim_admin_fees`
 - **Accounts (`ClaimAdminFeesAccounts`):**
   - `config` - Alice's `Config` (the `address = config.admin` constraint on `admin` enforces that only she can call this)
-  - `pool_config`, `pool_authority`
+  - `pool_config`
   - `mint_a`, `mint_b`
   - `pool_a`, `pool_b` (the pool's reserves - the source of the transfers)
   - `admin` = Alice (signer)

--- a/finance/token-swap/anchor-v1/CHANGELOG.md
+++ b/finance/token-swap/anchor-v1/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-09-10
+
+Removed the separate dataless signer PDA (seeds `[config, mint_a, mint_b,
+b"authority"]`) that owned the reserves and the LP mint. The `PoolConfig`
+account now owns both reserves (`pool_a` and `pool_b` are its associated token
+accounts), is the LP mint's mint authority, and signs the transfers out of the
+reserves and the LP mint/burn CPIs with its own seeds
+`[config, mint_a, mint_b, bump]`, the way the escrow example's `offer` account
+signs for its vault. The `b"authority"` seed constant and the extra signer
+account are gone from every instruction, and the reserve addresses changed with
+their owner: derive them as the associated token accounts of `pool_config`.
+
 ## 2026-07-07
 
 Added this changelog. Changes prior to this date were tracked in git history only.

--- a/finance/token-swap/anchor-v1/programs/token-swap/src/constants.rs
+++ b/finance/token-swap/anchor-v1/programs/token-swap/src/constants.rs
@@ -14,7 +14,4 @@ pub const BASIS_POINTS_DIVISOR: u64 = 10_000;
 pub const CONFIG_SEED: &[u8] = b"config";
 
 #[constant]
-pub const AUTHORITY_SEED: &[u8] = b"authority";
-
-#[constant]
 pub const LIQUIDITY_SEED: &[u8] = b"liquidity";

--- a/finance/token-swap/anchor-v1/programs/token-swap/src/instructions/admin/claim_admin_fees.rs
+++ b/finance/token-swap/anchor-v1/programs/token-swap/src/instructions/admin/claim_admin_fees.rs
@@ -2,7 +2,7 @@ use anchor_lang::prelude::*;
 use anchor_spl::token_interface::{self, Mint, TokenAccount, TokenInterface, TransferChecked};
 
 use crate::{
-    constants::{AUTHORITY_SEED, CONFIG_SEED},
+    constants::CONFIG_SEED,
     errors::AmmError,
     state::{Config, PoolConfig},
 };
@@ -35,7 +35,7 @@ pub fn handle_claim_admin_fees(context: Context<ClaimAdminFeesAccountConstraints
     }
 
     // Pre-copy seed bytes before the mutable borrow of pool_config.
-    let authority_bump = context.bumps.pool_authority;
+    let pool_config_bump = [context.accounts.pool_config.bump];
     let config_bytes = context.accounts.pool_config.config.to_bytes();
     let mint_a_bytes = context.accounts.mint_a.key().to_bytes();
     let mint_b_bytes = context.accounts.mint_b.key().to_bytes();
@@ -49,14 +49,13 @@ pub fn handle_claim_admin_fees(context: Context<ClaimAdminFeesAccountConstraints
     }
 
     // Interactions: transfer the owed fees out of the pool reserves.
-    let authority_seeds = &[
+    // `pool_config` owns the reserves and signs with its own seeds.
+    let signer_seeds: &[&[&[u8]]] = &[&[
         config_bytes.as_ref(),
         mint_a_bytes.as_ref(),
         mint_b_bytes.as_ref(),
-        AUTHORITY_SEED,
-        &[authority_bump],
-    ];
-    let signer_seeds = &[&authority_seeds[..]];
+        &pool_config_bump,
+    ]];
 
     if owed_a > 0 {
         token_interface::transfer_checked(
@@ -66,7 +65,7 @@ pub fn handle_claim_admin_fees(context: Context<ClaimAdminFeesAccountConstraints
                     from: context.accounts.pool_a.to_account_info(),
                     mint: context.accounts.mint_a.to_account_info(),
                     to: context.accounts.admin_token_a.to_account_info(),
-                    authority: context.accounts.pool_authority.to_account_info(),
+                    authority: context.accounts.pool_config.to_account_info(),
                 },
                 signer_seeds,
             ),
@@ -83,7 +82,7 @@ pub fn handle_claim_admin_fees(context: Context<ClaimAdminFeesAccountConstraints
                     from: context.accounts.pool_b.to_account_info(),
                     mint: context.accounts.mint_b.to_account_info(),
                     to: context.accounts.admin_token_b.to_account_info(),
-                    authority: context.accounts.pool_authority.to_account_info(),
+                    authority: context.accounts.pool_config.to_account_info(),
                 },
                 signer_seeds,
             ),
@@ -92,7 +91,11 @@ pub fn handle_claim_admin_fees(context: Context<ClaimAdminFeesAccountConstraints
         )?;
     }
 
-    msg!("Admin swept fees: {} of mint_a, {} of mint_b", owed_a, owed_b);
+    msg!(
+        "Admin swept fees: {} of mint_a, {} of mint_b",
+        owed_a,
+        owed_b
+    );
 
     Ok(())
 }
@@ -113,45 +116,33 @@ pub struct ClaimAdminFeesAccountConstraints<'info> {
             pool_config.mint_a.key().as_ref(),
             pool_config.mint_b.key().as_ref(),
         ],
-        bump,
+        bump = pool_config.bump,
         has_one = config,
         has_one = mint_a,
         has_one = mint_b,
     )]
     pub pool_config: Account<'info, PoolConfig>,
 
-    /// CHECK: PDA that owns the pool reserves; signs the outbound transfers.
-    #[account(
-        seeds = [
-            pool_config.config.as_ref(),
-            mint_a.key().as_ref(),
-            mint_b.key().as_ref(),
-            AUTHORITY_SEED,
-        ],
-        bump,
-    )]
-    pub pool_authority: UncheckedAccount<'info>,
-
     pub mint_a: Box<InterfaceAccount<'info, Mint>>,
 
     pub mint_b: Box<InterfaceAccount<'info, Mint>>,
 
-    /// The pool's token-A reserve. The admin's owed token-A fees are paid out
-    /// of this account.
+    /// The pool's token-A reserve, owned by `pool_config`. The admin's owed
+    /// token-A fees are paid out of this account.
     #[account(
         mut,
         associated_token::mint = mint_a,
-        associated_token::authority = pool_authority,
+        associated_token::authority = pool_config,
         associated_token::token_program = token_program,
     )]
     pub pool_a: Box<InterfaceAccount<'info, TokenAccount>>,
 
-    /// The pool's token-B reserve. The admin's owed token-B fees are paid out
-    /// of this account.
+    /// The pool's token-B reserve, owned by `pool_config`. The admin's owed
+    /// token-B fees are paid out of this account.
     #[account(
         mut,
         associated_token::mint = mint_b,
-        associated_token::authority = pool_authority,
+        associated_token::authority = pool_config,
         associated_token::token_program = token_program,
     )]
     pub pool_b: Box<InterfaceAccount<'info, TokenAccount>>,

--- a/finance/token-swap/anchor-v1/programs/token-swap/src/instructions/deposit_liquidity.rs
+++ b/finance/token-swap/anchor-v1/programs/token-swap/src/instructions/deposit_liquidity.rs
@@ -5,7 +5,7 @@ use anchor_spl::{
 };
 
 use crate::{
-    constants::{AUTHORITY_SEED, LIQUIDITY_SEED, MINIMUM_LIQUIDITY},
+    constants::{LIQUIDITY_SEED, MINIMUM_LIQUIDITY},
     errors::AmmError,
     state::PoolConfig,
 };
@@ -19,7 +19,7 @@ fn integer_sqrt(n: u128) -> u128 {
         return n;
     }
     let mut x = n;
-    let mut y = (x + 1) / 2;
+    let mut y = x.div_ceil(2);
     while y < x {
         x = y;
         y = (x + n / x) / 2;
@@ -37,9 +37,7 @@ pub fn handle_deposit_liquidity(
     // silently clamped to the available balance, which broke slippage protection
     // for callers building on top - they expected their input amount to be the
     // amount actually deposited.
-    if amount_a > context.accounts.token_a.amount
-        || amount_b > context.accounts.token_b.amount
-    {
+    if amount_a > context.accounts.token_a.amount || amount_b > context.accounts.token_b.amount {
         return err!(AmmError::InsufficientBalance);
     }
     let mut amount_a = amount_a;
@@ -150,8 +148,7 @@ pub fn handle_deposit_liquidity(
             .checked_mul(amount_b as u128)
             .ok_or(AmmError::MathOverflow)?;
         let sqrt_product = integer_sqrt(product);
-        let sqrt_product_u64 = u64::try_from(sqrt_product)
-            .map_err(|_| AmmError::MathOverflow)?;
+        let sqrt_product_u64 = u64::try_from(sqrt_product).map_err(|_| AmmError::MathOverflow)?;
         if sqrt_product_u64 < MINIMUM_LIQUIDITY {
             return err!(AmmError::DepositTooSmall);
         }
@@ -223,23 +220,25 @@ pub fn handle_deposit_liquidity(
         context.accounts.mint_b.decimals,
     )?;
 
-    // Mint the liquidity to user
-    let authority_bump = context.bumps.pool_authority;
-    let authority_seeds = &[
-        &context.accounts.pool_config.config.to_bytes(),
-        &context.accounts.mint_a.key().to_bytes(),
-        &context.accounts.mint_b.key().to_bytes(),
-        AUTHORITY_SEED,
-        &[authority_bump],
-    ];
-    let signer_seeds = &[&authority_seeds[..]];
+    // Mint the liquidity to the user. `pool_config` is the LP mint's
+    // authority and signs with its own seeds.
+    let config_bytes = context.accounts.pool_config.config.to_bytes();
+    let mint_a_bytes = context.accounts.mint_a.key().to_bytes();
+    let mint_b_bytes = context.accounts.mint_b.key().to_bytes();
+    let pool_config_bump = [context.accounts.pool_config.bump];
+    let signer_seeds: &[&[&[u8]]] = &[&[
+        config_bytes.as_ref(),
+        mint_a_bytes.as_ref(),
+        mint_b_bytes.as_ref(),
+        &pool_config_bump,
+    ]];
     token_interface::mint_to(
         CpiContext::new_with_signer(
             context.accounts.token_program.key(),
             MintTo {
                 mint: context.accounts.liquidity_provider_mint.to_account_info(),
                 to: context.accounts.liquidity_provider_token.to_account_info(),
-                authority: context.accounts.pool_authority.to_account_info(),
+                authority: context.accounts.pool_config.to_account_info(),
             },
             signer_seeds,
         ),
@@ -257,23 +256,11 @@ pub struct DepositLiquidityAccountConstraints<'info> {
             pool_config.mint_a.key().as_ref(),
             pool_config.mint_b.key().as_ref(),
         ],
-        bump,
+        bump = pool_config.bump,
         has_one = mint_a,
         has_one = mint_b,
     )]
     pub pool_config: Box<Account<'info, PoolConfig>>,
-
-    /// CHECK: Read only authority
-    #[account(
-        seeds = [
-            pool_config.config.as_ref(),
-            mint_a.key().as_ref(),
-            mint_b.key().as_ref(),
-            AUTHORITY_SEED,
-        ],
-        bump,
-    )]
-    pub pool_authority: UncheckedAccount<'info>,
 
     /// The account paying for all rents
     pub depositor: Signer<'info>,
@@ -297,7 +284,7 @@ pub struct DepositLiquidityAccountConstraints<'info> {
     #[account(
         mut,
         associated_token::mint = mint_a,
-        associated_token::authority = pool_authority,
+        associated_token::authority = pool_config,
         associated_token::token_program = token_program,
     )]
     pub pool_a: Box<InterfaceAccount<'info, TokenAccount>>,
@@ -305,7 +292,7 @@ pub struct DepositLiquidityAccountConstraints<'info> {
     #[account(
         mut,
         associated_token::mint = mint_b,
-        associated_token::authority = pool_authority,
+        associated_token::authority = pool_config,
         associated_token::token_program = token_program,
     )]
     pub pool_b: Box<InterfaceAccount<'info, TokenAccount>>,

--- a/finance/token-swap/anchor-v1/programs/token-swap/src/instructions/initialize_pool.rs
+++ b/finance/token-swap/anchor-v1/programs/token-swap/src/instructions/initialize_pool.rs
@@ -5,7 +5,7 @@ use anchor_spl::{
 };
 
 use crate::{
-    constants::{AUTHORITY_SEED, CONFIG_SEED, LIQUIDITY_SEED},
+    constants::{CONFIG_SEED, LIQUIDITY_SEED},
     errors::AmmError,
     state::{Config, PoolConfig},
 };
@@ -43,18 +43,8 @@ pub struct InitializePoolAccountConstraints<'info> {
     )]
     pub pool_config: Box<Account<'info, PoolConfig>>,
 
-    /// CHECK: Read only authority
-    #[account(
-        seeds = [
-            config.key().as_ref(),
-            mint_a.key().as_ref(),
-            mint_b.key().as_ref(),
-            AUTHORITY_SEED,
-        ],
-        bump,
-    )]
-    pub pool_authority: UncheckedAccount<'info>,
-
+    /// The LP mint. `pool_config` is its mint authority and signs every
+    /// mint_to with its own seeds.
     #[account(
         init,
         payer = payer,
@@ -66,7 +56,7 @@ pub struct InitializePoolAccountConstraints<'info> {
         ],
         bump,
         mint::decimals = 6,
-        mint::authority = pool_authority,
+        mint::authority = pool_config,
     )]
     pub liquidity_provider_mint: Box<InterfaceAccount<'info, Mint>>,
 
@@ -74,20 +64,23 @@ pub struct InitializePoolAccountConstraints<'info> {
 
     pub mint_b: Box<InterfaceAccount<'info, Mint>>,
 
+    /// The pool's token-A reserve: the associated token account of
+    /// `pool_config`, which signs every transfer out of it.
     #[account(
         init,
         payer = payer,
         associated_token::mint = mint_a,
-        associated_token::authority = pool_authority,
+        associated_token::authority = pool_config,
         associated_token::token_program = token_program,
     )]
     pub pool_a: Box<InterfaceAccount<'info, TokenAccount>>,
 
+    /// The pool's token-B reserve, likewise owned by `pool_config`.
     #[account(
         init,
         payer = payer,
         associated_token::mint = mint_b,
-        associated_token::authority = pool_authority,
+        associated_token::authority = pool_config,
         associated_token::token_program = token_program,
     )]
     pub pool_b: Box<InterfaceAccount<'info, TokenAccount>>,

--- a/finance/token-swap/anchor-v1/programs/token-swap/src/instructions/mod.rs
+++ b/finance/token-swap/anchor-v1/programs/token-swap/src/instructions/mod.rs
@@ -1,13 +1,13 @@
 mod admin;
+mod deposit_liquidity;
 mod initialize_config;
 mod initialize_pool;
-mod deposit_liquidity;
 mod swap_tokens;
 mod withdraw_liquidity;
 
 pub use admin::*;
+pub use deposit_liquidity::*;
 pub use initialize_config::*;
 pub use initialize_pool::*;
-pub use deposit_liquidity::*;
 pub use swap_tokens::*;
 pub use withdraw_liquidity::*;

--- a/finance/token-swap/anchor-v1/programs/token-swap/src/instructions/swap_tokens.rs
+++ b/finance/token-swap/anchor-v1/programs/token-swap/src/instructions/swap_tokens.rs
@@ -5,7 +5,7 @@ use anchor_spl::{
 };
 
 use crate::{
-    constants::{AUTHORITY_SEED, BASIS_POINTS_DIVISOR, CONFIG_SEED},
+    constants::{BASIS_POINTS_DIVISOR, CONFIG_SEED},
     errors::*,
     state::{Config, PoolConfig},
 };
@@ -54,12 +54,13 @@ pub fn handle_swap_tokens(
     // is u64), so the cast is safe - but use try_into anyway to make the
     // invariant explicit in the type system.
     let fee_amount: u64 = u64::try_from(fee_amount).map_err(|_| AmmError::MathOverflow)?;
-    let admin_portion: u64 =
-        u64::try_from(admin_portion).map_err(|_| AmmError::MathOverflow)?;
+    let admin_portion: u64 = u64::try_from(admin_portion).map_err(|_| AmmError::MathOverflow)?;
     // The LP portion stays in the pool reserves (as today - it's "less output
     // for the same input"), boosting the LP curve. The admin portion is
     // accounted for separately so it does *not* grow LP yield.
-    let taxed_input = input_amount.checked_sub(fee_amount).ok_or(AmmError::MathOverflow)?;
+    let taxed_input = input_amount
+        .checked_sub(fee_amount)
+        .ok_or(AmmError::MathOverflow)?;
 
     // Effective reserves = raw vault balance - admin's accumulated claim.
     // The constant-product curve runs on the LP-claimable portion only, so
@@ -124,10 +125,7 @@ pub fn handle_swap_tokens(
     // they're willing to accept (computed offchain at quote time). If the
     // pool shifted between quoting and landing, we revert rather than fill
     // at the worse rate.
-    require!(
-        output >= min_output_amount,
-        AmmError::SlippageExceeded
-    );
+    require!(output >= min_output_amount, AmmError::SlippageExceeded);
 
     // Compute the invariant on the *effective* reserves before the trade.
     // Using raw balances here would let the admin's accumulated fees count
@@ -142,7 +140,7 @@ pub fn handle_swap_tokens(
 
     // Pre-copy seed bytes before the mutable borrow of pool_config below.
     // to_bytes() returns an owned [u8; 32] copy so there are no borrow conflicts.
-    let authority_bump = context.bumps.pool_authority;
+    let pool_config_bump = [context.accounts.pool_config.bump];
     let config_bytes = context.accounts.pool_config.config.to_bytes();
     let mint_a_bytes = context.accounts.mint_a.key().to_bytes();
     let mint_b_bytes = context.accounts.mint_b.key().to_bytes();
@@ -165,15 +163,14 @@ pub fn handle_swap_tokens(
         }
     }
 
-    // Interactions: CPIs after state has been updated.
-    let authority_seeds = &[
+    // Interactions: CPIs after state has been updated. `pool_config` owns the
+    // reserves and signs the outbound transfer with its own seeds.
+    let signer_seeds: &[&[&[u8]]] = &[&[
         config_bytes.as_ref(),
         mint_a_bytes.as_ref(),
         mint_b_bytes.as_ref(),
-        AUTHORITY_SEED,
-        &[authority_bump],
-    ];
-    let signer_seeds = &[&authority_seeds[..]];
+        &pool_config_bump,
+    ]];
     if input_is_token_a {
         token_interface::transfer_checked(
             CpiContext::new(
@@ -195,7 +192,7 @@ pub fn handle_swap_tokens(
                     from: context.accounts.pool_b.to_account_info(),
                     mint: context.accounts.mint_b.to_account_info(),
                     to: context.accounts.token_b.to_account_info(),
-                    authority: context.accounts.pool_authority.to_account_info(),
+                    authority: context.accounts.pool_config.to_account_info(),
                 },
                 signer_seeds,
             ),
@@ -210,7 +207,7 @@ pub fn handle_swap_tokens(
                     from: context.accounts.pool_a.to_account_info(),
                     mint: context.accounts.mint_a.to_account_info(),
                     to: context.accounts.token_a.to_account_info(),
-                    authority: context.accounts.pool_authority.to_account_info(),
+                    authority: context.accounts.pool_config.to_account_info(),
                 },
                 signer_seeds,
             ),
@@ -289,24 +286,12 @@ pub struct SwapTokensAccountConstraints<'info> {
             pool_config.mint_a.key().as_ref(),
             pool_config.mint_b.key().as_ref(),
         ],
-        bump,
+        bump = pool_config.bump,
         has_one = config,
         has_one = mint_a,
         has_one = mint_b,
     )]
     pub pool_config: Account<'info, PoolConfig>,
-
-    /// CHECK: Read only authority
-    #[account(
-        seeds = [
-            pool_config.config.as_ref(),
-            mint_a.key().as_ref(),
-            mint_b.key().as_ref(),
-            AUTHORITY_SEED,
-        ],
-        bump,
-    )]
-    pub pool_authority: UncheckedAccount<'info>,
 
     /// The account doing the swap
     pub trader: Signer<'info>,
@@ -318,7 +303,7 @@ pub struct SwapTokensAccountConstraints<'info> {
     #[account(
         mut,
         associated_token::mint = mint_a,
-        associated_token::authority = pool_authority,
+        associated_token::authority = pool_config,
         associated_token::token_program = token_program,
     )]
     pub pool_a: Box<InterfaceAccount<'info, TokenAccount>>,
@@ -326,7 +311,7 @@ pub struct SwapTokensAccountConstraints<'info> {
     #[account(
         mut,
         associated_token::mint = mint_b,
-        associated_token::authority = pool_authority,
+        associated_token::authority = pool_config,
         associated_token::token_program = token_program,
     )]
     pub pool_b: Box<InterfaceAccount<'info, TokenAccount>>,

--- a/finance/token-swap/anchor-v1/programs/token-swap/src/instructions/withdraw_liquidity.rs
+++ b/finance/token-swap/anchor-v1/programs/token-swap/src/instructions/withdraw_liquidity.rs
@@ -5,7 +5,7 @@ use anchor_spl::{
 };
 
 use crate::{
-    constants::{AUTHORITY_SEED, CONFIG_SEED, LIQUIDITY_SEED, MINIMUM_LIQUIDITY},
+    constants::{CONFIG_SEED, LIQUIDITY_SEED, MINIMUM_LIQUIDITY},
     errors::AmmError,
     state::{Config, PoolConfig},
 };
@@ -16,15 +16,18 @@ pub fn handle_withdraw_liquidity(
     minimum_token_a_out: u64,
     minimum_token_b_out: u64,
 ) -> Result<()> {
-    let authority_bump = context.bumps.pool_authority;
-    let authority_seeds = &[
-        &context.accounts.pool_config.config.to_bytes(),
-        &context.accounts.mint_a.key().to_bytes(),
-        &context.accounts.mint_b.key().to_bytes(),
-        AUTHORITY_SEED,
-        &[authority_bump],
-    ];
-    let signer_seeds = &[&authority_seeds[..]];
+    // `pool_config` owns the reserves and signs the transfers out of them
+    // with its own seeds.
+    let config_bytes = context.accounts.pool_config.config.to_bytes();
+    let mint_a_bytes = context.accounts.mint_a.key().to_bytes();
+    let mint_b_bytes = context.accounts.mint_b.key().to_bytes();
+    let pool_config_bump = [context.accounts.pool_config.bump];
+    let signer_seeds: &[&[&[u8]]] = &[&[
+        config_bytes.as_ref(),
+        mint_a_bytes.as_ref(),
+        mint_b_bytes.as_ref(),
+        &pool_config_bump,
+    ]];
 
     // LPs withdraw a proportional share of the *effective* reserves
     // (vault balance minus the admin's accumulated fee claim). The admin's
@@ -99,7 +102,7 @@ pub fn handle_withdraw_liquidity(
                 from: context.accounts.pool_a.to_account_info(),
                 mint: context.accounts.mint_a.to_account_info(),
                 to: context.accounts.token_a.to_account_info(),
-                authority: context.accounts.pool_authority.to_account_info(),
+                authority: context.accounts.pool_config.to_account_info(),
             },
             signer_seeds,
         ),
@@ -114,7 +117,7 @@ pub fn handle_withdraw_liquidity(
                 from: context.accounts.pool_b.to_account_info(),
                 mint: context.accounts.mint_b.to_account_info(),
                 to: context.accounts.token_b.to_account_info(),
-                authority: context.accounts.pool_authority.to_account_info(),
+                authority: context.accounts.pool_config.to_account_info(),
             },
             signer_seeds,
         ),
@@ -153,23 +156,11 @@ pub struct WithdrawLiquidityAccountConstraints<'info> {
             pool_config.mint_a.key().as_ref(),
             pool_config.mint_b.key().as_ref(),
         ],
-        bump,
+        bump = pool_config.bump,
         has_one = mint_a,
         has_one = mint_b,
     )]
     pub pool_config: Account<'info, PoolConfig>,
-
-    /// CHECK: Read only authority
-    #[account(
-        seeds = [
-            pool_config.config.as_ref(),
-            mint_a.key().as_ref(),
-            mint_b.key().as_ref(),
-            AUTHORITY_SEED,
-        ],
-        bump,
-    )]
-    pub pool_authority: UncheckedAccount<'info>,
 
     pub withdrawer: Signer<'info>,
 
@@ -194,7 +185,7 @@ pub struct WithdrawLiquidityAccountConstraints<'info> {
     #[account(
         mut,
         associated_token::mint = mint_a,
-        associated_token::authority = pool_authority,
+        associated_token::authority = pool_config,
         associated_token::token_program = token_program,
     )]
     pub pool_a: Box<InterfaceAccount<'info, TokenAccount>>,
@@ -202,7 +193,7 @@ pub struct WithdrawLiquidityAccountConstraints<'info> {
     #[account(
         mut,
         associated_token::mint = mint_b,
-        associated_token::authority = pool_authority,
+        associated_token::authority = pool_config,
         associated_token::token_program = token_program,
     )]
     pub pool_b: Box<InterfaceAccount<'info, TokenAccount>>,

--- a/finance/token-swap/anchor-v1/programs/token-swap/src/lib.rs
+++ b/finance/token-swap/anchor-v1/programs/token-swap/src/lib.rs
@@ -30,12 +30,7 @@ pub mod swap_example {
         amount_b: u64,
         minimum_lp_tokens_out: u64,
     ) -> Result<()> {
-        instructions::handle_deposit_liquidity(
-            context,
-            amount_a,
-            amount_b,
-            minimum_lp_tokens_out,
-        )
+        instructions::handle_deposit_liquidity(context, amount_a, amount_b, minimum_lp_tokens_out)
     }
 
     pub fn withdraw_liquidity(
@@ -58,12 +53,7 @@ pub mod swap_example {
         input_amount: u64,
         min_output_amount: u64,
     ) -> Result<()> {
-        instructions::handle_swap_tokens(
-            context,
-            input_is_token_a,
-            input_amount,
-            min_output_amount,
-        )
+        instructions::handle_swap_tokens(context, input_is_token_a, input_amount, min_output_amount)
     }
 
     pub fn claim_admin_fees(context: Context<ClaimAdminFeesAccountConstraints>) -> Result<()> {

--- a/finance/token-swap/anchor-v1/programs/token-swap/src/state/pool_config.rs
+++ b/finance/token-swap/anchor-v1/programs/token-swap/src/state/pool_config.rs
@@ -4,9 +4,14 @@ use anchor_lang::prelude::*;
 ///
 /// Holds the metadata that identifies a single pool: which `Config` it belongs
 /// to, which two mints it trades, and its canonical bump. The actual pool
-/// reserves live in separate token accounts (`pool_a`, `pool_b`) owned by the
-/// pool authority PDA - they are not stored here. This struct is the pool's
+/// reserves live in separate token accounts (`pool_a`, `pool_b`) that this
+/// account owns - they are not stored here. This struct is the pool's
 /// *configuration*, not its state.
+///
+/// This account is also the pool's signing authority: it owns both reserves,
+/// is the mint authority of the LP mint, and signs the transfers out of the
+/// reserves and the LP mint/burn CPIs with its own seeds
+/// `[config, mint_a, mint_b, bump]`.
 ///
 /// In addition to the identity fields, this account tracks the admin's
 /// accumulated trading-fee claim on each side (`admin_fees_owed_a` /

--- a/finance/token-swap/anchor-v1/programs/token-swap/tests/test_swap.rs
+++ b/finance/token-swap/anchor-v1/programs/token-swap/tests/test_swap.rs
@@ -7,7 +7,8 @@ use {
     solana_keypair::Keypair,
     solana_kite::{
         create_associated_token_account, create_token_mint, create_wallet,
-        get_token_account_balance, mint_tokens_to_token_account, send_transaction_from_instructions,
+        get_token_account_balance, mint_tokens_to_token_account,
+        send_transaction_from_instructions,
     },
     solana_signer::Signer,
 };
@@ -63,7 +64,6 @@ struct TestSetup {
     mint_a: Pubkey,
     mint_b: Pubkey,
     pool_config_key: Pubkey,
-    pool_authority: Pubkey,
     liquidity_provider_mint: Pubkey,
     pool_a: Pubkey,
     pool_b: Pubkey,
@@ -92,15 +92,6 @@ fn full_setup() -> TestSetup {
         &[config_key.as_ref(), mint_a.as_ref(), mint_b.as_ref()],
         &program_id,
     );
-    let (pool_authority, _) = Pubkey::find_program_address(
-        &[
-            config_key.as_ref(),
-            mint_a.as_ref(),
-            mint_b.as_ref(),
-            b"authority",
-        ],
-        &program_id,
-    );
     let (liquidity_provider_mint, _) = Pubkey::find_program_address(
         &[
             config_key.as_ref(),
@@ -111,8 +102,10 @@ fn full_setup() -> TestSetup {
         &program_id,
     );
 
-    let pool_a = derive_ata(&pool_authority, &mint_a);
-    let pool_b = derive_ata(&pool_authority, &mint_b);
+    // The reserves are the associated token accounts of `pool_config`, which
+    // owns them and signs every transfer out of them.
+    let pool_a = derive_ata(&pool_config_key, &mint_a);
+    let pool_b = derive_ata(&pool_config_key, &mint_b);
     let liquidity_account = derive_ata(&admin.pubkey(), &liquidity_provider_mint);
 
     // Create ATAs for admin and mint tokens
@@ -121,13 +114,19 @@ fn full_setup() -> TestSetup {
     let holder_account_b =
         create_associated_token_account(&mut svm, &admin.pubkey(), &mint_b, &payer).unwrap();
 
-    mint_tokens_to_token_account(&mut svm, &mint_a, &holder_account_a, minted_amount, &admin).unwrap();
-    mint_tokens_to_token_account(&mut svm, &mint_b, &holder_account_b, minted_amount, &admin).unwrap();
+    mint_tokens_to_token_account(&mut svm, &mint_a, &holder_account_a, minted_amount, &admin)
+        .unwrap();
+    mint_tokens_to_token_account(&mut svm, &mint_b, &holder_account_b, minted_amount, &admin)
+        .unwrap();
 
     // Create AMM
     let initialize_config_ix = Instruction::new_with_bytes(
         program_id,
-        &swap_example::instruction::InitializeConfig { fee, admin_share_bps }.data(),
+        &swap_example::instruction::InitializeConfig {
+            fee,
+            admin_share_bps,
+        }
+        .data(),
         swap_example::accounts::InitializeConfigAccountConstraints {
             config: config_key,
             admin: admin.pubkey(),
@@ -151,7 +150,6 @@ fn full_setup() -> TestSetup {
         swap_example::accounts::InitializePoolAccountConstraints {
             config: config_key,
             pool_config: pool_config_key,
-            pool_authority,
             liquidity_provider_mint,
             mint_a,
             mint_b,
@@ -181,7 +179,6 @@ fn full_setup() -> TestSetup {
         mint_a,
         mint_b,
         pool_config_key,
-        pool_authority,
         liquidity_provider_mint,
         pool_a,
         pool_b,
@@ -202,7 +199,11 @@ fn test_initialize_config() {
 
     let initialize_config_ix = Instruction::new_with_bytes(
         program_id,
-        &swap_example::instruction::InitializeConfig { fee, admin_share_bps }.data(),
+        &swap_example::instruction::InitializeConfig {
+            fee,
+            admin_share_bps,
+        }
+        .data(),
         swap_example::accounts::InitializeConfigAccountConstraints {
             config: config_key,
             admin: admin.pubkey(),
@@ -227,6 +228,42 @@ fn test_initialize_config() {
     assert!(!config_account.data.is_empty());
 }
 
+/// The pool config account is the authority for everything the pool holds:
+/// it owns both reserves and is the LP mint's mint authority, so it alone
+/// signs the transfers out of the reserves and the LP mint/burn CPIs.
+#[test]
+fn test_pool_config_owns_reserves_and_lp_mint() {
+    let ts = full_setup();
+    let expected: &[u8] = ts.pool_config_key.as_ref();
+
+    // SPL token account layout: mint (32 bytes), then owner (32 bytes).
+    for reserve in [&ts.pool_a, &ts.pool_b] {
+        let account = ts.svm.get_account(reserve).expect("reserve should exist");
+        assert_eq!(
+            &account.data[32..64],
+            expected,
+            "reserve owner should be pool_config"
+        );
+    }
+
+    // SPL mint layout: COption<Pubkey> mint_authority = 4-byte tag (1 = Some)
+    // followed by the 32-byte pubkey.
+    let mint = ts
+        .svm
+        .get_account(&ts.liquidity_provider_mint)
+        .expect("LP mint should exist");
+    assert_eq!(
+        &mint.data[0..4],
+        &[1, 0, 0, 0],
+        "LP mint should have a mint authority"
+    );
+    assert_eq!(
+        &mint.data[4..36],
+        expected,
+        "LP mint authority should be pool_config"
+    );
+}
+
 #[test]
 fn test_deposit_liquidity() {
     let mut ts = full_setup();
@@ -244,7 +281,6 @@ fn test_deposit_liquidity() {
         .data(),
         swap_example::accounts::DepositLiquidityAccountConstraints {
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             depositor: ts.admin.pubkey(),
             liquidity_provider_mint: ts.liquidity_provider_mint,
             mint_a: ts.mint_a,
@@ -291,7 +327,6 @@ fn test_swap_a_to_b() {
         .data(),
         swap_example::accounts::DepositLiquidityAccountConstraints {
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             depositor: ts.admin.pubkey(),
             liquidity_provider_mint: ts.liquidity_provider_mint,
             mint_a: ts.mint_a,
@@ -331,7 +366,6 @@ fn test_swap_a_to_b() {
         swap_example::accounts::SwapTokensAccountConstraints {
             config: ts.config_key,
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             trader: ts.admin.pubkey(),
             mint_a: ts.mint_a,
             mint_b: ts.mint_b,
@@ -378,7 +412,6 @@ fn test_withdraw_liquidity() {
         .data(),
         swap_example::accounts::DepositLiquidityAccountConstraints {
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             depositor: ts.admin.pubkey(),
             liquidity_provider_mint: ts.liquidity_provider_mint,
             mint_a: ts.mint_a,
@@ -420,7 +453,6 @@ fn test_withdraw_liquidity() {
         swap_example::accounts::WithdrawLiquidityAccountConstraints {
             config: ts.config_key,
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             withdrawer: ts.admin.pubkey(),
             liquidity_provider_mint: ts.liquidity_provider_mint,
             mint_a: ts.mint_a,
@@ -452,7 +484,12 @@ fn test_withdraw_liquidity() {
 
 /// Helper: do a deposit and one A->B swap on top of `full_setup`.
 /// Returns the swap input amount (token A base units) for fee-arithmetic checks.
-fn deposit_and_swap_a_to_b(ts: &mut TestSetup, deposit_a: u64, deposit_b: u64, swap_in_a: u64) -> u64 {
+fn deposit_and_swap_a_to_b(
+    ts: &mut TestSetup,
+    deposit_a: u64,
+    deposit_b: u64,
+    swap_in_a: u64,
+) -> u64 {
     let deposit_ix = Instruction::new_with_bytes(
         ts.program_id,
         &swap_example::instruction::DepositLiquidity {
@@ -464,7 +501,6 @@ fn deposit_and_swap_a_to_b(ts: &mut TestSetup, deposit_a: u64, deposit_b: u64, s
         .data(),
         swap_example::accounts::DepositLiquidityAccountConstraints {
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             depositor: ts.admin.pubkey(),
             liquidity_provider_mint: ts.liquidity_provider_mint,
             mint_a: ts.mint_a,
@@ -500,7 +536,6 @@ fn deposit_and_swap_a_to_b(ts: &mut TestSetup, deposit_a: u64, deposit_b: u64, s
         swap_example::accounts::SwapTokensAccountConstraints {
             config: ts.config_key,
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             trader: ts.admin.pubkey(),
             mint_a: ts.mint_a,
             mint_b: ts.mint_b,
@@ -534,7 +569,6 @@ fn claim_admin_fees_ix(ts: &TestSetup) -> Instruction {
         swap_example::accounts::ClaimAdminFeesAccountConstraints {
             config: ts.config_key,
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             mint_a: ts.mint_a,
             mint_b: ts.mint_b,
             pool_a: ts.pool_a,
@@ -561,7 +595,6 @@ fn swap_a_to_b(ts: &mut TestSetup, input_amount: u64) {
         swap_example::accounts::SwapTokensAccountConstraints {
             config: ts.config_key,
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             trader: ts.admin.pubkey(),
             mint_a: ts.mint_a,
             mint_b: ts.mint_b,
@@ -600,10 +633,8 @@ fn test_claim_admin_fees() {
     assert!(expected_admin_a > 0, "expected admin portion > 0");
 
     // ---- Phase 1: first claim transfers the accumulated A-side fees ----
-    let admin_balance_a_before =
-        get_token_account_balance(&ts.svm, &ts.holder_account_a).unwrap();
-    let admin_balance_b_before =
-        get_token_account_balance(&ts.svm, &ts.holder_account_b).unwrap();
+    let admin_balance_a_before = get_token_account_balance(&ts.svm, &ts.holder_account_a).unwrap();
+    let admin_balance_b_before = get_token_account_balance(&ts.svm, &ts.holder_account_b).unwrap();
 
     let claim_ix_first = claim_admin_fees_ix(&ts);
     send_transaction_from_instructions(
@@ -614,10 +645,8 @@ fn test_claim_admin_fees() {
     )
     .unwrap();
 
-    let admin_balance_a_after =
-        get_token_account_balance(&ts.svm, &ts.holder_account_a).unwrap();
-    let admin_balance_b_after =
-        get_token_account_balance(&ts.svm, &ts.holder_account_b).unwrap();
+    let admin_balance_a_after = get_token_account_balance(&ts.svm, &ts.holder_account_a).unwrap();
+    let admin_balance_b_after = get_token_account_balance(&ts.svm, &ts.holder_account_b).unwrap();
 
     assert_eq!(
         admin_balance_a_after - admin_balance_a_before,
@@ -640,8 +669,7 @@ fn test_claim_admin_fees() {
     let expected_admin_a_2 = fee_amount_2 * 1667 / 10_000;
     assert!(expected_admin_a_2 > 0, "expected second admin portion > 0");
 
-    let balance_a_pre_claim_2 =
-        get_token_account_balance(&ts.svm, &ts.holder_account_a).unwrap();
+    let balance_a_pre_claim_2 = get_token_account_balance(&ts.svm, &ts.holder_account_a).unwrap();
 
     // Bump the blockhash so this claim-ix tx isn't byte-identical to the
     // earlier one (same accounts + same payload → same signature →
@@ -656,8 +684,7 @@ fn test_claim_admin_fees() {
     )
     .unwrap();
 
-    let balance_a_post_claim_2 =
-        get_token_account_balance(&ts.svm, &ts.holder_account_a).unwrap();
+    let balance_a_post_claim_2 = get_token_account_balance(&ts.svm, &ts.holder_account_a).unwrap();
     assert_eq!(
         balance_a_post_claim_2 - balance_a_pre_claim_2,
         expected_admin_a_2,
@@ -675,7 +702,6 @@ fn test_claim_admin_fees() {
         swap_example::accounts::ClaimAdminFeesAccountConstraints {
             config: ts.config_key,
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             mint_a: ts.mint_a,
             mint_b: ts.mint_b,
             pool_a: ts.pool_a,
@@ -701,7 +727,9 @@ fn test_claim_admin_fees() {
     );
     let err_msg = format!("{:?}", result.unwrap_err());
     assert!(
-        err_msg.contains("NothingToClaim") || err_msg.contains("0x1777") || err_msg.contains("6007"),
+        err_msg.contains("NothingToClaim")
+            || err_msg.contains("0x1777")
+            || err_msg.contains("6007"),
         "expected NothingToClaim error, got: {err_msg}"
     );
 
@@ -736,7 +764,6 @@ fn test_claim_admin_fees_rejects_non_admin() {
         swap_example::accounts::ClaimAdminFeesAccountConstraints {
             config: ts.config_key,
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             mint_a: ts.mint_a,
             mint_b: ts.mint_b,
             pool_a: ts.pool_a,
@@ -778,7 +805,6 @@ fn deposit_ix(ts: &TestSetup, amount_a: u64, amount_b: u64) -> Instruction {
         .data(),
         swap_example::accounts::DepositLiquidityAccountConstraints {
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             depositor: ts.admin.pubkey(),
             liquidity_provider_mint: ts.liquidity_provider_mint,
             mint_a: ts.mint_a,
@@ -847,7 +873,10 @@ fn test_deposit_into_funded_pool_at_correct_ratio() {
         2_000_000,
         "pool_b should grow by the full requested amount_b"
     );
-    assert!(lp_after > lp_before, "LP tokens should be minted to depositor");
+    assert!(
+        lp_after > lp_before,
+        "LP tokens should be minted to depositor"
+    );
 }
 
 /// Test B: depositor offers more token B than the ratio needs. `amount_b`
@@ -953,7 +982,6 @@ fn test_deposit_after_swap_uses_shifted_effective_ratio() {
         swap_example::accounts::SwapTokensAccountConstraints {
             config: ts.config_key,
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             trader: ts.admin.pubkey(),
             mint_a: ts.mint_a,
             mint_b: ts.mint_b,
@@ -999,8 +1027,8 @@ fn test_deposit_after_swap_uses_shifted_effective_ratio() {
     // ratio so both sides should be pulled in full. Pick a base of 1M on the
     // B side and compute the matching A side from effective reserves.
     let deposit_b = 1_000_000u64;
-    let deposit_a = ((deposit_b as u128) * (effective_pool_a as u128)
-        / (effective_pool_b as u128)) as u64;
+    let deposit_a =
+        ((deposit_b as u128) * (effective_pool_a as u128) / (effective_pool_b as u128)) as u64;
 
     let holder_a_before = get_token_account_balance(&ts.svm, &ts.holder_account_a).unwrap();
     let holder_b_before = get_token_account_balance(&ts.svm, &ts.holder_account_b).unwrap();
@@ -1121,8 +1149,8 @@ fn test_lp_mint_after_swap_uses_effective_reserves() {
 
     // Deposit at exactly the effective ratio. Pick deposit_b, derive deposit_a.
     let deposit_b: u64 = 1_000_000;
-    let deposit_a = ((deposit_b as u128) * (effective_pool_a as u128)
-        / (effective_pool_b as u128)) as u64;
+    let deposit_a =
+        ((deposit_b as u128) * (effective_pool_a as u128) / (effective_pool_b as u128)) as u64;
 
     // Expected LP minted = min(a*supply/pool_a, b*supply/pool_b) using the
     // *clamped* (a, b) the program actually transfers. After clamp at the
@@ -1131,12 +1159,12 @@ fn test_lp_mint_after_swap_uses_effective_reserves() {
     // We pass `deposit_a` exactly, so amount_b_required = deposit_a * pool_b
     // / pool_a, which rounds down to ≤ deposit_b. The program then uses
     // (deposit_a, amount_b_required). Compute the expected LP from that.
-    let amount_b_used = ((deposit_a as u128) * (effective_pool_b as u128)
-        / (effective_pool_a as u128)) as u64;
-    let expected_liquidity_from_a = (deposit_a as u128) * (total_supply_before_second as u128)
-        / (effective_pool_a as u128);
-    let expected_liquidity_from_b = (amount_b_used as u128) * (total_supply_before_second as u128)
-        / (effective_pool_b as u128);
+    let amount_b_used =
+        ((deposit_a as u128) * (effective_pool_b as u128) / (effective_pool_a as u128)) as u64;
+    let expected_liquidity_from_a =
+        (deposit_a as u128) * (total_supply_before_second as u128) / (effective_pool_a as u128);
+    let expected_liquidity_from_b =
+        (amount_b_used as u128) * (total_supply_before_second as u128) / (effective_pool_b as u128);
     let expected_liquidity = expected_liquidity_from_a.min(expected_liquidity_from_b) as u64;
 
     let lp_before = get_token_account_balance(&ts.svm, &ts.liquidity_account).unwrap();
@@ -1167,7 +1195,6 @@ fn swap_a_to_b_ix(ts: &TestSetup, input_amount: u64, min_output_amount: u64) -> 
         swap_example::accounts::SwapTokensAccountConstraints {
             config: ts.config_key,
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             trader: ts.admin.pubkey(),
             mint_a: ts.mint_a,
             mint_b: ts.mint_b,
@@ -1201,7 +1228,6 @@ fn deposit_ix_with_min_lp(
         .data(),
         swap_example::accounts::DepositLiquidityAccountConstraints {
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             depositor: ts.admin.pubkey(),
             liquidity_provider_mint: ts.liquidity_provider_mint,
             mint_a: ts.mint_a,
@@ -1238,7 +1264,6 @@ fn withdraw_ix_with_min(
         swap_example::accounts::WithdrawLiquidityAccountConstraints {
             config: ts.config_key,
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             withdrawer: ts.admin.pubkey(),
             liquidity_provider_mint: ts.liquidity_provider_mint,
             mint_a: ts.mint_a,
@@ -1321,8 +1346,7 @@ fn test_deposit_reverts_when_lp_below_min() {
     let achievable_lp = lp_from_a.min(lp_from_b) as u64;
 
     // Require *strictly more* than that - the deposit must revert.
-    let strict_ix =
-        deposit_ix_with_min_lp(&ts, 4_000_000, 1_000_000, achievable_lp + 1);
+    let strict_ix = deposit_ix_with_min_lp(&ts, 4_000_000, 1_000_000, achievable_lp + 1);
     let result = send_transaction_from_instructions(
         &mut ts.svm,
         vec![strict_ix],
@@ -1420,7 +1444,6 @@ fn swap_b_to_a_ix(ts: &TestSetup, input_amount: u64, min_output_amount: u64) -> 
         swap_example::accounts::SwapTokensAccountConstraints {
             config: ts.config_key,
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             trader: ts.admin.pubkey(),
             mint_a: ts.mint_a,
             mint_b: ts.mint_b,

--- a/finance/token-swap/anchor/CHANGELOG.md
+++ b/finance/token-swap/anchor/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-09-10
+
+Removed the separate dataless signer PDA (seeds `[config, mint_a, mint_b,
+b"authority"]`) that owned the reserves and the LP mint. The `PoolConfig`
+account now owns both reserves (`pool_a` and `pool_b` are its associated token
+accounts), is the LP mint's mint authority, and signs the transfers out of the
+reserves and the LP mint/burn CPIs with its own seeds
+`[config, mint_a, mint_b, bump]`, the way the escrow example's `offer` account
+signs for its vault. The `b"authority"` seed constant and the extra signer
+account are gone from every instruction, and the reserve addresses changed with
+their owner: derive them as the associated token accounts of `pool_config`.
+
 ## 2026-07-07
 
 Added this changelog. Changes prior to this date were tracked in git history only.

--- a/finance/token-swap/anchor/programs/token-swap/src/constants.rs
+++ b/finance/token-swap/anchor/programs/token-swap/src/constants.rs
@@ -14,7 +14,4 @@ pub const BASIS_POINTS_DIVISOR: u64 = 10_000;
 pub const CONFIG_SEED: &[u8] = b"config";
 
 #[constant]
-pub const AUTHORITY_SEED: &[u8] = b"authority";
-
-#[constant]
 pub const LIQUIDITY_SEED: &[u8] = b"liquidity";

--- a/finance/token-swap/anchor/programs/token-swap/src/instructions/admin/claim_admin_fees.rs
+++ b/finance/token-swap/anchor/programs/token-swap/src/instructions/admin/claim_admin_fees.rs
@@ -3,7 +3,7 @@ use anchor_spl::token;
 use anchor_spl::token_interface::{self, Mint, TokenAccount, TokenInterface, TransferChecked};
 
 use crate::{
-    constants::{AUTHORITY_SEED, CONFIG_SEED},
+    constants::CONFIG_SEED,
     errors::AmmError,
     state::{Config, PoolConfig},
 };
@@ -38,7 +38,7 @@ pub fn handle_claim_admin_fees(
     }
 
     // Pre-copy seed bytes before the mutable borrow of pool_config.
-    let authority_bump = context.bumps.pool_authority;
+    let pool_config_bump = [context.accounts.pool_config.bump];
     let config_bytes = context.accounts.pool_config.config.to_bytes();
     let mint_a_bytes = context.accounts.mint_a.address().to_bytes();
     let mint_b_bytes = context.accounts.mint_b.address().to_bytes();
@@ -52,14 +52,20 @@ pub fn handle_claim_admin_fees(
     }
 
     // Interactions: transfer the owed fees out of the pool reserves.
-    let authority_seeds = &[
+    // `pool_config` owns the reserves and signs with its own seeds.
+    let signer_seeds: &[&[&[u8]]] = &[&[
         config_bytes.as_ref(),
         mint_a_bytes.as_ref(),
         mint_b_bytes.as_ref(),
-        AUTHORITY_SEED,
-        &[authority_bump],
-    ];
-    let signer_seeds = &[&authority_seeds[..]];
+        &pool_config_bump,
+    ]];
+
+    // `pool_config` signs the CPIs below. It is a data account holding a live
+    // borrow on its buffer, which the runtime would reject when the CPI
+    // borrows the same account, so hand the borrow back for the duration.
+    // `release_borrow` flushes the zeroed accumulators and
+    // `reacquire_borrow_mut` re-reads them once the CPIs are done.
+    context.accounts.pool_config.release_borrow()?;
 
     if owed_a > 0 {
         token_interface::transfer_checked(
@@ -69,7 +75,7 @@ pub fn handle_claim_admin_fees(
                     from: context.accounts.pool_a.to_cpi_handle_mut(),
                     mint: context.accounts.mint_a.to_cpi_handle(),
                     to: context.accounts.admin_token_a.to_cpi_handle_mut(),
-                    authority: context.accounts.pool_authority.cpi_handle(),
+                    authority: context.accounts.pool_config.to_cpi_handle(),
                 },
                 signer_seeds,
             ),
@@ -86,7 +92,7 @@ pub fn handle_claim_admin_fees(
                     from: context.accounts.pool_b.to_cpi_handle_mut(),
                     mint: context.accounts.mint_b.to_cpi_handle(),
                     to: context.accounts.admin_token_b.to_cpi_handle_mut(),
-                    authority: context.accounts.pool_authority.cpi_handle(),
+                    authority: context.accounts.pool_config.to_cpi_handle(),
                 },
                 signer_seeds,
             ),
@@ -94,6 +100,8 @@ pub fn handle_claim_admin_fees(
             context.accounts.mint_b.decimals(),
         )?;
     }
+
+    context.accounts.pool_config.reacquire_borrow_mut()?;
 
     msg!(
         "Admin swept fees: {} of mint_a, {} of mint_b",
@@ -117,21 +125,9 @@ pub struct ClaimAdminFeesAccountConstraints {
             pool_config.mint_a.as_ref(),
             pool_config.mint_b.as_ref(),
         ],
-        bump,
+        bump = pool_config.bump,
     )]
     pub pool_config: BorshAccount<PoolConfig>,
-
-    /// CHECK: PDA that owns the pool reserves; signs the outbound transfers.
-    #[account(
-        seeds = [
-            pool_config.config.as_ref(),
-            mint_a.address().as_ref(),
-            mint_b.address().as_ref(),
-            AUTHORITY_SEED,
-        ],
-        bump,
-    )]
-    pub pool_authority: UncheckedAccount,
 
     #[account(address = pool_config.mint_a)]
     pub mint_a: Box<InterfaceAccount<Mint>>,
@@ -139,22 +135,22 @@ pub struct ClaimAdminFeesAccountConstraints {
     #[account(address = pool_config.mint_b)]
     pub mint_b: Box<InterfaceAccount<Mint>>,
 
-    /// The pool's token-A reserve. The admin's owed token-A fees are paid out
-    /// of this account.
+    /// The pool's token-A reserve, owned by `pool_config`. The admin's owed
+    /// token-A fees are paid out of this account.
     #[account(
         mut,
         associated_token::mint = mint_a,
-        associated_token::authority = pool_authority,
+        associated_token::authority = pool_config,
         associated_token::token_program = token_program,
     )]
     pub pool_a: Box<InterfaceAccount<TokenAccount>>,
 
-    /// The pool's token-B reserve. The admin's owed token-B fees are paid out
-    /// of this account.
+    /// The pool's token-B reserve, owned by `pool_config`. The admin's owed
+    /// token-B fees are paid out of this account.
     #[account(
         mut,
         associated_token::mint = mint_b,
-        associated_token::authority = pool_authority,
+        associated_token::authority = pool_config,
         associated_token::token_program = token_program,
     )]
     pub pool_b: Box<InterfaceAccount<TokenAccount>>,

--- a/finance/token-swap/anchor/programs/token-swap/src/instructions/deposit_liquidity.rs
+++ b/finance/token-swap/anchor/programs/token-swap/src/instructions/deposit_liquidity.rs
@@ -5,7 +5,7 @@ use anchor_spl::{
 };
 
 use crate::{
-    constants::{AUTHORITY_SEED, LIQUIDITY_SEED, MINIMUM_LIQUIDITY},
+    constants::{LIQUIDITY_SEED, MINIMUM_LIQUIDITY},
     errors::AmmError,
     state::PoolConfig,
 };
@@ -221,16 +221,25 @@ pub fn handle_deposit_liquidity(
         context.accounts.mint_b.decimals(),
     )?;
 
-    // Mint the liquidity to user
-    let authority_bump = context.bumps.pool_authority;
-    let authority_seeds = &[
-        &context.accounts.pool_config.config.to_bytes(),
-        &context.accounts.mint_a.address().to_bytes(),
-        &context.accounts.mint_b.address().to_bytes(),
-        AUTHORITY_SEED,
-        &[authority_bump],
-    ];
-    let signer_seeds = &[&authority_seeds[..]];
+    // Mint the liquidity to the user. `pool_config` is the LP mint's
+    // authority and signs with its own seeds.
+    let config_bytes = context.accounts.pool_config.config.to_bytes();
+    let mint_a_bytes = context.accounts.mint_a.address().to_bytes();
+    let mint_b_bytes = context.accounts.mint_b.address().to_bytes();
+    let pool_config_bump = [context.accounts.pool_config.bump];
+    let signer_seeds: &[&[&[u8]]] = &[&[
+        config_bytes.as_ref(),
+        mint_a_bytes.as_ref(),
+        mint_b_bytes.as_ref(),
+        &pool_config_bump,
+    ]];
+
+    // `pool_config` signs the CPI below. It is a data account holding a live
+    // borrow on its buffer, which the runtime would reject when the CPI
+    // borrows the same account, so hand the borrow back for the duration. It
+    // is loaded read-only here, so there is nothing to take back afterwards.
+    context.accounts.pool_config.release_borrow()?;
+
     token_interface::mint_to(
         CpiContext::new_with_signer(
             context.accounts.token_program.address(),
@@ -240,7 +249,7 @@ pub fn handle_deposit_liquidity(
                     .accounts
                     .liquidity_provider_token
                     .to_cpi_handle_mut(),
-                authority: context.accounts.pool_authority.cpi_handle(),
+                authority: context.accounts.pool_config.to_cpi_handle(),
             },
             signer_seeds,
         ),
@@ -252,27 +261,16 @@ pub fn handle_deposit_liquidity(
 
 #[derive(Accounts)]
 pub struct DepositLiquidityAccountConstraints {
+    /// Owns both reserves and is the LP mint's authority; signs the mint_to.
     #[account(
         seeds = [
             pool_config.config.as_ref(),
             pool_config.mint_a.as_ref(),
             pool_config.mint_b.as_ref(),
         ],
-        bump,
+        bump = pool_config.bump,
     )]
     pub pool_config: Box<BorshAccount<PoolConfig>>,
-
-    /// CHECK: Read only authority
-    #[account(
-        seeds = [
-            pool_config.config.as_ref(),
-            mint_a.address().as_ref(),
-            mint_b.address().as_ref(),
-            AUTHORITY_SEED,
-        ],
-        bump,
-    )]
-    pub pool_authority: UncheckedAccount,
 
     /// The account paying for all rents
     pub depositor: Signer,
@@ -298,7 +296,7 @@ pub struct DepositLiquidityAccountConstraints {
     #[account(
         mut,
         associated_token::mint = mint_a,
-        associated_token::authority = pool_authority,
+        associated_token::authority = pool_config,
         associated_token::token_program = token_program,
     )]
     pub pool_a: Box<InterfaceAccount<TokenAccount>>,
@@ -306,7 +304,7 @@ pub struct DepositLiquidityAccountConstraints {
     #[account(
         mut,
         associated_token::mint = mint_b,
-        associated_token::authority = pool_authority,
+        associated_token::authority = pool_config,
         associated_token::token_program = token_program,
     )]
     pub pool_b: Box<InterfaceAccount<TokenAccount>>,

--- a/finance/token-swap/anchor/programs/token-swap/src/instructions/initialize_pool.rs
+++ b/finance/token-swap/anchor/programs/token-swap/src/instructions/initialize_pool.rs
@@ -6,7 +6,7 @@ use anchor_spl::{
 };
 
 use crate::{
-    constants::{AUTHORITY_SEED, CONFIG_SEED, LIQUIDITY_SEED},
+    constants::{CONFIG_SEED, LIQUIDITY_SEED},
     errors::AmmError,
     state::{Config, PoolConfig},
 };
@@ -46,18 +46,8 @@ pub struct InitializePoolAccountConstraints {
     )]
     pub pool_config: Box<BorshAccount<PoolConfig>>,
 
-    /// CHECK: Read only authority
-    #[account(
-        seeds = [
-            config.address().as_ref(),
-            mint_a.address().as_ref(),
-            mint_b.address().as_ref(),
-            AUTHORITY_SEED,
-        ],
-        bump,
-    )]
-    pub pool_authority: UncheckedAccount,
-
+    /// The LP mint. `pool_config` is its mint authority and signs every
+    /// mint_to with its own seeds.
     #[account(
         init,
         payer = payer,
@@ -69,7 +59,7 @@ pub struct InitializePoolAccountConstraints {
         ],
         bump,
         mint::decimals = 6,
-        mint::authority = pool_authority,
+        mint::authority = pool_config,
         // Required when the token program is an `Interface`: without it the
         // init CPI is rejected with InvalidArgument.
         mint::token_program = token_program,
@@ -80,20 +70,23 @@ pub struct InitializePoolAccountConstraints {
 
     pub mint_b: Box<InterfaceAccount<Mint>>,
 
+    /// The pool's token-A reserve: the associated token account of
+    /// `pool_config`, which signs every transfer out of it.
     #[account(
         init,
         payer = payer,
         associated_token::mint = mint_a,
-        associated_token::authority = pool_authority,
+        associated_token::authority = pool_config,
         associated_token::token_program = token_program,
     )]
     pub pool_a: Box<InterfaceAccount<TokenAccount>>,
 
+    /// The pool's token-B reserve, likewise owned by `pool_config`.
     #[account(
         init,
         payer = payer,
         associated_token::mint = mint_b,
-        associated_token::authority = pool_authority,
+        associated_token::authority = pool_config,
         associated_token::token_program = token_program,
     )]
     pub pool_b: Box<InterfaceAccount<TokenAccount>>,

--- a/finance/token-swap/anchor/programs/token-swap/src/instructions/swap_tokens.rs
+++ b/finance/token-swap/anchor/programs/token-swap/src/instructions/swap_tokens.rs
@@ -5,7 +5,7 @@ use anchor_spl::{
 };
 
 use crate::{
-    constants::{AUTHORITY_SEED, BASIS_POINTS_DIVISOR, CONFIG_SEED},
+    constants::{BASIS_POINTS_DIVISOR, CONFIG_SEED},
     errors::*,
     state::{Config, PoolConfig},
 };
@@ -140,7 +140,7 @@ pub fn handle_swap_tokens(
 
     // Pre-copy seed bytes before the mutable borrow of pool_config below.
     // to_bytes() returns an owned [u8; 32] copy so there are no borrow conflicts.
-    let authority_bump = context.bumps.pool_authority;
+    let pool_config_bump = [context.accounts.pool_config.bump];
     let config_bytes = context.accounts.pool_config.config.to_bytes();
     let mint_a_bytes = context.accounts.mint_a.address().to_bytes();
     let mint_b_bytes = context.accounts.mint_b.address().to_bytes();
@@ -163,15 +163,22 @@ pub fn handle_swap_tokens(
         }
     }
 
-    // Interactions: CPIs after state has been updated.
-    let authority_seeds = &[
+    // Interactions: CPIs after state has been updated. `pool_config` owns the
+    // reserves and signs the outbound transfer with its own seeds.
+    let signer_seeds: &[&[&[u8]]] = &[&[
         config_bytes.as_ref(),
         mint_a_bytes.as_ref(),
         mint_b_bytes.as_ref(),
-        AUTHORITY_SEED,
-        &[authority_bump],
-    ];
-    let signer_seeds = &[&authority_seeds[..]];
+        &pool_config_bump,
+    ]];
+
+    // `pool_config` signs a CPI below. It is a data account holding a live
+    // borrow on its buffer, which the runtime would reject when the CPI
+    // borrows the same account, so hand the borrow back for the duration.
+    // `release_borrow` flushes the fee accumulator written above and
+    // `reacquire_borrow_mut` re-reads it once the CPIs are done.
+    context.accounts.pool_config.release_borrow()?;
+
     if input_is_token_a {
         token_interface::transfer_checked(
             CpiContext::new(
@@ -193,7 +200,7 @@ pub fn handle_swap_tokens(
                     from: context.accounts.pool_b.to_cpi_handle_mut(),
                     mint: context.accounts.mint_b.to_cpi_handle(),
                     to: context.accounts.token_b.to_cpi_handle_mut(),
-                    authority: context.accounts.pool_authority.cpi_handle(),
+                    authority: context.accounts.pool_config.to_cpi_handle(),
                 },
                 signer_seeds,
             ),
@@ -208,7 +215,7 @@ pub fn handle_swap_tokens(
                     from: context.accounts.pool_a.to_cpi_handle_mut(),
                     mint: context.accounts.mint_a.to_cpi_handle(),
                     to: context.accounts.token_a.to_cpi_handle_mut(),
-                    authority: context.accounts.pool_authority.cpi_handle(),
+                    authority: context.accounts.pool_config.to_cpi_handle(),
                 },
                 signer_seeds,
             ),
@@ -229,6 +236,8 @@ pub fn handle_swap_tokens(
             context.accounts.mint_b.decimals(),
         )?;
     }
+
+    context.accounts.pool_config.reacquire_borrow_mut()?;
 
     msg!(
         "Traded {} tokens ({} after fees) for {} (admin slice {})",
@@ -288,21 +297,9 @@ pub struct SwapTokensAccountConstraints {
             pool_config.mint_a.as_ref(),
             pool_config.mint_b.as_ref(),
         ],
-        bump,
+        bump = pool_config.bump,
     )]
     pub pool_config: BorshAccount<PoolConfig>,
-
-    /// CHECK: Read only authority
-    #[account(
-        seeds = [
-            pool_config.config.as_ref(),
-            mint_a.address().as_ref(),
-            mint_b.address().as_ref(),
-            AUTHORITY_SEED,
-        ],
-        bump,
-    )]
-    pub pool_authority: UncheckedAccount,
 
     /// The account doing the swap
     pub trader: Signer,
@@ -316,7 +313,7 @@ pub struct SwapTokensAccountConstraints {
     #[account(
         mut,
         associated_token::mint = mint_a,
-        associated_token::authority = pool_authority,
+        associated_token::authority = pool_config,
         associated_token::token_program = token_program,
     )]
     pub pool_a: Box<InterfaceAccount<TokenAccount>>,
@@ -324,7 +321,7 @@ pub struct SwapTokensAccountConstraints {
     #[account(
         mut,
         associated_token::mint = mint_b,
-        associated_token::authority = pool_authority,
+        associated_token::authority = pool_config,
         associated_token::token_program = token_program,
     )]
     pub pool_b: Box<InterfaceAccount<TokenAccount>>,

--- a/finance/token-swap/anchor/programs/token-swap/src/instructions/withdraw_liquidity.rs
+++ b/finance/token-swap/anchor/programs/token-swap/src/instructions/withdraw_liquidity.rs
@@ -5,7 +5,7 @@ use anchor_spl::{
 };
 
 use crate::{
-    constants::{AUTHORITY_SEED, CONFIG_SEED, LIQUIDITY_SEED, MINIMUM_LIQUIDITY},
+    constants::{CONFIG_SEED, LIQUIDITY_SEED, MINIMUM_LIQUIDITY},
     errors::AmmError,
     state::{Config, PoolConfig},
 };
@@ -16,15 +16,18 @@ pub fn handle_withdraw_liquidity(
     minimum_token_a_out: u64,
     minimum_token_b_out: u64,
 ) -> Result<()> {
-    let authority_bump = context.bumps.pool_authority;
-    let authority_seeds = &[
-        &context.accounts.pool_config.config.to_bytes(),
-        &context.accounts.mint_a.address().to_bytes(),
-        &context.accounts.mint_b.address().to_bytes(),
-        AUTHORITY_SEED,
-        &[authority_bump],
-    ];
-    let signer_seeds = &[&authority_seeds[..]];
+    // `pool_config` owns the reserves and signs the transfers out of them
+    // with its own seeds.
+    let config_bytes = context.accounts.pool_config.config.to_bytes();
+    let mint_a_bytes = context.accounts.mint_a.address().to_bytes();
+    let mint_b_bytes = context.accounts.mint_b.address().to_bytes();
+    let pool_config_bump = [context.accounts.pool_config.bump];
+    let signer_seeds: &[&[&[u8]]] = &[&[
+        config_bytes.as_ref(),
+        mint_a_bytes.as_ref(),
+        mint_b_bytes.as_ref(),
+        &pool_config_bump,
+    ]];
 
     // LPs withdraw a proportional share of the *effective* reserves
     // (vault balance minus the admin's accumulated fee claim). The admin's
@@ -91,6 +94,12 @@ pub fn handle_withdraw_liquidity(
         AmmError::WithdrawalBelowMinimum
     );
 
+    // `pool_config` signs the two CPIs below. It is a data account holding a
+    // live borrow on its buffer, which the runtime would reject when the CPI
+    // borrows the same account, so hand the borrow back for the duration. It
+    // is loaded read-only here, so there is nothing to take back afterwards.
+    context.accounts.pool_config.release_borrow()?;
+
     // transfer_checked verifies the mint + decimals at the token program.
     token_interface::transfer_checked(
         CpiContext::new_with_signer(
@@ -99,7 +108,7 @@ pub fn handle_withdraw_liquidity(
                 from: context.accounts.pool_a.to_cpi_handle_mut(),
                 mint: context.accounts.mint_a.to_cpi_handle(),
                 to: context.accounts.token_a.to_cpi_handle_mut(),
-                authority: context.accounts.pool_authority.cpi_handle(),
+                authority: context.accounts.pool_config.to_cpi_handle(),
             },
             signer_seeds,
         ),
@@ -114,7 +123,7 @@ pub fn handle_withdraw_liquidity(
                 from: context.accounts.pool_b.to_cpi_handle_mut(),
                 mint: context.accounts.mint_b.to_cpi_handle(),
                 to: context.accounts.token_b.to_cpi_handle_mut(),
-                authority: context.accounts.pool_authority.cpi_handle(),
+                authority: context.accounts.pool_config.to_cpi_handle(),
             },
             signer_seeds,
         ),
@@ -156,21 +165,9 @@ pub struct WithdrawLiquidityAccountConstraints {
             pool_config.mint_a.as_ref(),
             pool_config.mint_b.as_ref(),
         ],
-        bump,
+        bump = pool_config.bump,
     )]
     pub pool_config: BorshAccount<PoolConfig>,
-
-    /// CHECK: Read only authority
-    #[account(
-        seeds = [
-            pool_config.config.as_ref(),
-            mint_a.address().as_ref(),
-            mint_b.address().as_ref(),
-            AUTHORITY_SEED,
-        ],
-        bump,
-    )]
-    pub pool_authority: UncheckedAccount,
 
     pub withdrawer: Signer,
 
@@ -195,7 +192,7 @@ pub struct WithdrawLiquidityAccountConstraints {
     #[account(
         mut,
         associated_token::mint = mint_a,
-        associated_token::authority = pool_authority,
+        associated_token::authority = pool_config,
         associated_token::token_program = token_program,
     )]
     pub pool_a: Box<InterfaceAccount<TokenAccount>>,
@@ -203,7 +200,7 @@ pub struct WithdrawLiquidityAccountConstraints {
     #[account(
         mut,
         associated_token::mint = mint_b,
-        associated_token::authority = pool_authority,
+        associated_token::authority = pool_config,
         associated_token::token_program = token_program,
     )]
     pub pool_b: Box<InterfaceAccount<TokenAccount>>,

--- a/finance/token-swap/anchor/programs/token-swap/src/state/pool_config.rs
+++ b/finance/token-swap/anchor/programs/token-swap/src/state/pool_config.rs
@@ -4,9 +4,14 @@ use anchor_lang::prelude::*;
 ///
 /// Holds the metadata that identifies a single pool: which `Config` it belongs
 /// to, which two mints it trades, and its canonical bump. The actual pool
-/// reserves live in separate token accounts (`pool_a`, `pool_b`) owned by the
-/// pool authority PDA - they are not stored here. This struct is the pool's
+/// reserves live in separate token accounts (`pool_a`, `pool_b`) that this
+/// account owns - they are not stored here. This struct is the pool's
 /// *configuration*, not its state.
+///
+/// This account is also the pool's signing authority: it owns both reserves,
+/// is the mint authority of the LP mint, and signs the transfers out of the
+/// reserves and the LP mint/burn CPIs with its own seeds
+/// `[config, mint_a, mint_b, bump]`.
 ///
 /// In addition to the identity fields, this account tracks the admin's
 /// accumulated trading-fee claim on each side (`admin_fees_owed_a` /

--- a/finance/token-swap/anchor/programs/token-swap/tests/test_swap.rs
+++ b/finance/token-swap/anchor/programs/token-swap/tests/test_swap.rs
@@ -64,7 +64,6 @@ struct TestSetup {
     mint_a: Address,
     mint_b: Address,
     pool_config_key: Address,
-    pool_authority: Address,
     liquidity_provider_mint: Address,
     pool_a: Address,
     pool_b: Address,
@@ -93,15 +92,6 @@ fn full_setup() -> TestSetup {
         &[config_key.as_ref(), mint_a.as_ref(), mint_b.as_ref()],
         &program_id,
     );
-    let (pool_authority, _) = Address::find_program_address(
-        &[
-            config_key.as_ref(),
-            mint_a.as_ref(),
-            mint_b.as_ref(),
-            b"authority",
-        ],
-        &program_id,
-    );
     let (liquidity_provider_mint, _) = Address::find_program_address(
         &[
             config_key.as_ref(),
@@ -112,8 +102,10 @@ fn full_setup() -> TestSetup {
         &program_id,
     );
 
-    let pool_a = derive_ata(&pool_authority, &mint_a);
-    let pool_b = derive_ata(&pool_authority, &mint_b);
+    // The reserves are the associated token accounts of `pool_config`, which
+    // owns them and signs every transfer out of them.
+    let pool_a = derive_ata(&pool_config_key, &mint_a);
+    let pool_b = derive_ata(&pool_config_key, &mint_b);
     let liquidity_account = derive_ata(&admin.pubkey(), &liquidity_provider_mint);
 
     // Create ATAs for admin and mint tokens
@@ -158,7 +150,6 @@ fn full_setup() -> TestSetup {
         swap_example::accounts::InitializePoolAccountConstraints {
             config: config_key,
             pool_config: pool_config_key,
-            pool_authority,
             liquidity_provider_mint,
             mint_a,
             mint_b,
@@ -188,7 +179,6 @@ fn full_setup() -> TestSetup {
         mint_a,
         mint_b,
         pool_config_key,
-        pool_authority,
         liquidity_provider_mint,
         pool_a,
         pool_b,
@@ -252,6 +242,42 @@ fn test_initialize_config() {
     assert!(!config_account.data.is_empty());
 }
 
+/// The pool config account is the authority for everything the pool holds:
+/// it owns both reserves and is the LP mint's mint authority, so it alone
+/// signs the transfers out of the reserves and the LP mint/burn CPIs.
+#[test]
+fn test_pool_config_owns_reserves_and_lp_mint() {
+    let ts = full_setup();
+    let expected: &[u8] = ts.pool_config_key.as_ref();
+
+    // SPL token account layout: mint (32 bytes), then owner (32 bytes).
+    for reserve in [&ts.pool_a, &ts.pool_b] {
+        let account = ts.svm.get_account(reserve).expect("reserve should exist");
+        assert_eq!(
+            &account.data[32..64],
+            expected,
+            "reserve owner should be pool_config"
+        );
+    }
+
+    // SPL mint layout: COption<Pubkey> mint_authority = 4-byte tag (1 = Some)
+    // followed by the 32-byte pubkey.
+    let mint = ts
+        .svm
+        .get_account(&ts.liquidity_provider_mint)
+        .expect("LP mint should exist");
+    assert_eq!(
+        &mint.data[0..4],
+        &[1, 0, 0, 0],
+        "LP mint should have a mint authority"
+    );
+    assert_eq!(
+        &mint.data[4..36],
+        expected,
+        "LP mint authority should be pool_config"
+    );
+}
+
 #[test]
 fn test_deposit_liquidity() {
     let mut ts = full_setup();
@@ -269,7 +295,6 @@ fn test_deposit_liquidity() {
         .data(),
         swap_example::accounts::DepositLiquidityAccountConstraints {
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             depositor: ts.admin.pubkey(),
             liquidity_provider_mint: ts.liquidity_provider_mint,
             mint_a: ts.mint_a,
@@ -316,7 +341,6 @@ fn test_swap_a_to_b() {
         .data(),
         swap_example::accounts::DepositLiquidityAccountConstraints {
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             depositor: ts.admin.pubkey(),
             liquidity_provider_mint: ts.liquidity_provider_mint,
             mint_a: ts.mint_a,
@@ -356,7 +380,6 @@ fn test_swap_a_to_b() {
         swap_example::accounts::SwapTokensAccountConstraints {
             config: ts.config_key,
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             trader: ts.admin.pubkey(),
             mint_a: ts.mint_a,
             mint_b: ts.mint_b,
@@ -403,7 +426,6 @@ fn test_withdraw_liquidity() {
         .data(),
         swap_example::accounts::DepositLiquidityAccountConstraints {
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             depositor: ts.admin.pubkey(),
             liquidity_provider_mint: ts.liquidity_provider_mint,
             mint_a: ts.mint_a,
@@ -445,7 +467,6 @@ fn test_withdraw_liquidity() {
         swap_example::accounts::WithdrawLiquidityAccountConstraints {
             config: ts.config_key,
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             withdrawer: ts.admin.pubkey(),
             liquidity_provider_mint: ts.liquidity_provider_mint,
             mint_a: ts.mint_a,
@@ -494,7 +515,6 @@ fn deposit_and_swap_a_to_b(
         .data(),
         swap_example::accounts::DepositLiquidityAccountConstraints {
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             depositor: ts.admin.pubkey(),
             liquidity_provider_mint: ts.liquidity_provider_mint,
             mint_a: ts.mint_a,
@@ -530,7 +550,6 @@ fn deposit_and_swap_a_to_b(
         swap_example::accounts::SwapTokensAccountConstraints {
             config: ts.config_key,
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             trader: ts.admin.pubkey(),
             mint_a: ts.mint_a,
             mint_b: ts.mint_b,
@@ -564,7 +583,6 @@ fn claim_admin_fees_ix(ts: &TestSetup) -> Instruction {
         swap_example::accounts::ClaimAdminFeesAccountConstraints {
             config: ts.config_key,
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             mint_a: ts.mint_a,
             mint_b: ts.mint_b,
             pool_a: ts.pool_a,
@@ -591,7 +609,6 @@ fn swap_a_to_b(ts: &mut TestSetup, input_amount: u64) {
         swap_example::accounts::SwapTokensAccountConstraints {
             config: ts.config_key,
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             trader: ts.admin.pubkey(),
             mint_a: ts.mint_a,
             mint_b: ts.mint_b,
@@ -699,7 +716,6 @@ fn test_claim_admin_fees() {
         swap_example::accounts::ClaimAdminFeesAccountConstraints {
             config: ts.config_key,
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             mint_a: ts.mint_a,
             mint_b: ts.mint_b,
             pool_a: ts.pool_a,
@@ -757,7 +773,6 @@ fn test_claim_admin_fees_rejects_non_admin() {
         swap_example::accounts::ClaimAdminFeesAccountConstraints {
             config: ts.config_key,
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             mint_a: ts.mint_a,
             mint_b: ts.mint_b,
             pool_a: ts.pool_a,
@@ -799,7 +814,6 @@ fn deposit_ix(ts: &TestSetup, amount_a: u64, amount_b: u64) -> Instruction {
         .data(),
         swap_example::accounts::DepositLiquidityAccountConstraints {
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             depositor: ts.admin.pubkey(),
             liquidity_provider_mint: ts.liquidity_provider_mint,
             mint_a: ts.mint_a,
@@ -977,7 +991,6 @@ fn test_deposit_after_swap_uses_shifted_effective_ratio() {
         swap_example::accounts::SwapTokensAccountConstraints {
             config: ts.config_key,
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             trader: ts.admin.pubkey(),
             mint_a: ts.mint_a,
             mint_b: ts.mint_b,
@@ -1191,7 +1204,6 @@ fn swap_a_to_b_ix(ts: &TestSetup, input_amount: u64, min_output_amount: u64) -> 
         swap_example::accounts::SwapTokensAccountConstraints {
             config: ts.config_key,
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             trader: ts.admin.pubkey(),
             mint_a: ts.mint_a,
             mint_b: ts.mint_b,
@@ -1225,7 +1237,6 @@ fn deposit_ix_with_min_lp(
         .data(),
         swap_example::accounts::DepositLiquidityAccountConstraints {
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             depositor: ts.admin.pubkey(),
             liquidity_provider_mint: ts.liquidity_provider_mint,
             mint_a: ts.mint_a,
@@ -1262,7 +1273,6 @@ fn withdraw_ix_with_min(
         swap_example::accounts::WithdrawLiquidityAccountConstraints {
             config: ts.config_key,
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             withdrawer: ts.admin.pubkey(),
             liquidity_provider_mint: ts.liquidity_provider_mint,
             mint_a: ts.mint_a,
@@ -1439,7 +1449,6 @@ fn swap_b_to_a_ix(ts: &TestSetup, input_amount: u64, min_output_amount: u64) -> 
         swap_example::accounts::SwapTokensAccountConstraints {
             config: ts.config_key,
             pool_config: ts.pool_config_key,
-            pool_authority: ts.pool_authority,
             trader: ts.admin.pubkey(),
             mint_a: ts.mint_a,
             mint_b: ts.mint_b,

--- a/finance/token-swap/quasar/CHANGELOG.md
+++ b/finance/token-swap/quasar/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [2026-09-10]
+
+### Changed
+
+- Removed the separate dataless signer PDA (seeds
+  `[b"authority", config, mint_a, mint_b]`, with its `#[derive(Seeds)]` marker
+  and seed constant) that owned the reserves and the LP mint. The `PoolConfig`
+  account now owns both reserves, is the LP mint's mint authority, and signs
+  the transfers out of the reserves and the LP mint with its own seeds
+  `[config, mint_a, mint_b, bump]`, the way the escrow example's `offer`
+  account signs for its vault. The extra signer account is gone from every
+  instruction.
+
 ## [2026-07-22]
 
 ### Changed

--- a/finance/token-swap/quasar/src/instructions/claim_admin_fees.rs
+++ b/finance/token-swap/quasar/src/instructions/claim_admin_fees.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         error::AmmError,
         state::{Config, PoolConfig, PoolConfigInner},
-        ConfigPda, PoolAuthorityPda, PoolPda,
+        ConfigPda, PoolPda,
     },
     quasar_lang::cpi::Seed,
     quasar_lang::prelude::*,
@@ -21,9 +21,6 @@ pub struct ClaimAdminFeesAccountConstraints {
         address = PoolPda::seeds(config.address(), mint_a.address(), mint_b.address()),
     )]
     pub pool_config: Account<PoolConfig>,
-    /// Pool authority PDA - signs the outbound transfers.
-    #[account(address = PoolAuthorityPda::seeds(config.address(), mint_a.address(), mint_b.address()))]
-    pub pool_authority: UncheckedAccount,
     pub mint_a: Account<Mint>,
     pub mint_b: Account<Mint>,
     /// Pool's token-A reserve. The admin's owed token-A fees are paid out of
@@ -64,10 +61,10 @@ pub fn handle_claim_admin_fees(
     // variant's behaviour.
     require!(owed_a > 0 || owed_b > 0, AmmError::NothingToClaim);
 
-    // Seed order matches PoolAuthorityPda: [b"authority", config, mint_a, mint_b, bump].
-    let bump = [bumps.pool_authority];
+    // `pool_config` owns the reserves and signs the outbound transfers.
+    // Seed order matches PoolPda: [config, mint_a, mint_b, bump].
+    let bump = [bumps.pool_config];
     let seeds: &[Seed] = &[
-        Seed::from(crate::AUTHORITY_SEED),
         Seed::from(accounts.config.address().as_ref()),
         Seed::from(accounts.mint_a.address().as_ref()),
         Seed::from(accounts.mint_b.address().as_ref()),
@@ -96,7 +93,7 @@ pub fn handle_claim_admin_fees(
                 &accounts.pool_a,
                 &accounts.mint_a,
                 &accounts.admin_token_a,
-                &accounts.pool_authority,
+                &accounts.pool_config,
                 owed_a,
                 accounts.mint_a.decimals(),
             )
@@ -110,7 +107,7 @@ pub fn handle_claim_admin_fees(
                 &accounts.pool_b,
                 &accounts.mint_b,
                 &accounts.admin_token_b,
-                &accounts.pool_authority,
+                &accounts.pool_config,
                 owed_b,
                 accounts.mint_b.decimals(),
             )

--- a/finance/token-swap/quasar/src/instructions/deposit_liquidity.rs
+++ b/finance/token-swap/quasar/src/instructions/deposit_liquidity.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         error::AmmError,
         state::{Config, PoolConfig},
-        ConfigPda, LiquidityMintPda, PoolAuthorityPda, PoolPda,
+        ConfigPda, LiquidityMintPda, PoolPda,
     },
     quasar_lang::cpi::Seed,
     quasar_lang::prelude::*,
@@ -15,11 +15,9 @@ use {
 pub struct DepositLiquidityAccountConstraints {
     #[account(address = ConfigPda::seeds())]
     pub config: Account<Config>,
+    /// Owns both reserves and is the LP mint's authority; signs the mint_to.
     #[account(address = PoolPda::seeds(config.address(), mint_a.address(), mint_b.address()))]
     pub pool_config: Account<PoolConfig>,
-    /// Pool authority PDA.
-    #[account(address = PoolAuthorityPda::seeds(config.address(), mint_a.address(), mint_b.address()))]
-    pub pool_authority: UncheckedAccount,
     /// Depositor (must be signer to authorise transfers).
     pub depositor: Signer,
     /// LP mint at the LiquidityMintPda.
@@ -238,11 +236,10 @@ pub fn handle_deposit_liquidity(
         )
         .invoke()?;
 
-    // Mint LP tokens to the depositor (signed by pool authority).
-    // Seed order matches PoolAuthorityPda: [b"authority", config, mint_a, mint_b, bump].
-    let bump = [bumps.pool_authority];
+    // Mint LP tokens to the depositor, signed by `pool_config` as the LP
+    // mint's authority. Seed order matches PoolPda: [config, mint_a, mint_b, bump].
+    let bump = [bumps.pool_config];
     let seeds: &[Seed] = &[
-        Seed::from(crate::AUTHORITY_SEED),
         Seed::from(accounts.config.address().as_ref()),
         Seed::from(accounts.mint_a.address().as_ref()),
         Seed::from(accounts.mint_b.address().as_ref()),
@@ -254,7 +251,7 @@ pub fn handle_deposit_liquidity(
         .mint_to(
             &accounts.liquidity_provider_mint,
             &accounts.liquidity_provider_token,
-            &accounts.pool_authority,
+            &accounts.pool_config,
             liquidity,
         )
         .invoke_signed(seeds)?;

--- a/finance/token-swap/quasar/src/instructions/initialize_pool.rs
+++ b/finance/token-swap/quasar/src/instructions/initialize_pool.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         state::{Config, PoolConfig, PoolConfigInner},
-        ConfigPda, LiquidityMintPda, PoolAuthorityPda, PoolPda,
+        ConfigPda, LiquidityMintPda, PoolPda,
     },
     quasar_lang::prelude::*,
     quasar_spl::prelude::*,
@@ -9,12 +9,13 @@ use {
 
 /// Seeds:
 /// - `pool_config = [config, mint_a, mint_b]`
-/// - `pool_authority = [b"authority", config, mint_a, mint_b]`
 /// - `liquidity_provider_mint = [b"liquidity", config, mint_a, mint_b]`
 ///
-/// `pool_authority` and `liquidity_provider_mint` derive at different
-/// onchain addresses than the Anchor sibling because `#[derive(Seeds)]`
-/// emits the literal prefix first. Internally consistent within this program.
+/// `pool_config` owns both reserves and is the LP mint's mint authority; it
+/// signs for them with its own seeds. `liquidity_provider_mint` derives at a
+/// different onchain address than the Anchor sibling because
+/// `#[derive(Seeds)]` emits the literal prefix first. Internally consistent
+/// within this program.
 #[derive(Accounts)]
 pub struct InitializePoolAccountConstraints {
     #[account(address = ConfigPda::seeds())]
@@ -26,36 +27,32 @@ pub struct InitializePoolAccountConstraints {
         address = PoolPda::seeds(config.address(), mint_a.address(), mint_b.address()),
     )]
     pub pool_config: Account<PoolConfig>,
-    /// Pool authority PDA - signs for pool token operations.
-    #[account(
-        address = PoolAuthorityPda::seeds(config.address(), mint_a.address(), mint_b.address()),
-    )]
-    pub pool_authority: UncheckedAccount,
-    /// Liquidity token mint - created at a PDA.
+    /// Liquidity token mint - created at a PDA; `pool_config` is its mint
+    /// authority.
     #[account(
         mut,
         init,
         payer = payer,
         address = LiquidityMintPda::seeds(config.address(), mint_a.address(), mint_b.address()),
-        mint(decimals = 6, authority = pool_authority, freeze_authority = None, token_program = token_program),
+        mint(decimals = 6, authority = pool_config, freeze_authority = None, token_program = token_program),
     )]
     pub liquidity_provider_mint: Account<Mint>,
     pub mint_a: Account<Mint>,
     pub mint_b: Account<Mint>,
-    /// Pool's token A reserve.
+    /// Pool's token A reserve, owned by `pool_config`.
     #[account(
         mut,
         init(idempotent),
         payer = payer,
-        token(mint = mint_a, authority = pool_authority, token_program = token_program),
+        token(mint = mint_a, authority = pool_config, token_program = token_program),
     )]
     pub pool_a: Account<Token>,
-    /// Pool's token B reserve.
+    /// Pool's token B reserve, owned by `pool_config`.
     #[account(
         mut,
         init(idempotent),
         payer = payer,
-        token(mint = mint_b, authority = pool_authority, token_program = token_program),
+        token(mint = mint_b, authority = pool_config, token_program = token_program),
     )]
     pub pool_b: Account<Token>,
     #[account(mut)]

--- a/finance/token-swap/quasar/src/instructions/swap_tokens.rs
+++ b/finance/token-swap/quasar/src/instructions/swap_tokens.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         error::AmmError,
         state::{Config, PoolConfig, PoolConfigInner},
-        ConfigPda, PoolAuthorityPda, PoolPda, BASIS_POINTS_DIVISOR,
+        ConfigPda, PoolPda, BASIS_POINTS_DIVISOR,
     },
     quasar_lang::cpi::Seed,
     quasar_lang::prelude::*,
@@ -10,7 +10,8 @@ use {
 };
 
 /// `pool_config` is mutable because each swap accumulates the admin's slice
-/// of the trading fee into `admin_fees_owed_a` / `admin_fees_owed_b`.
+/// of the trading fee into `admin_fees_owed_a` / `admin_fees_owed_b`. It also
+/// owns both reserves and signs the outbound transfer with its own seeds.
 #[derive(Accounts)]
 pub struct SwapTokensAccountConstraints {
     #[account(address = ConfigPda::seeds())]
@@ -20,9 +21,6 @@ pub struct SwapTokensAccountConstraints {
         address = PoolPda::seeds(config.address(), mint_a.address(), mint_b.address()),
     )]
     pub pool_config: Account<PoolConfig>,
-    /// Pool authority PDA.
-    #[account(address = PoolAuthorityPda::seeds(config.address(), mint_a.address(), mint_b.address()))]
-    pub pool_authority: UncheckedAccount,
     pub trader: Signer,
     pub mint_a: Account<Mint>,
     pub mint_b: Account<Mint>,
@@ -181,11 +179,11 @@ pub fn handle_swap_tokens(
         admin_fees_owed_b: new_owed_b,
     });
 
-    // Interactions: the token transfers, after state is written.
-    // Seed order matches PoolAuthorityPda: [b"authority", config, mint_a, mint_b, bump].
-    let bump = [bumps.pool_authority];
+    // Interactions: the token transfers, after state is written. `pool_config`
+    // owns the reserves and signs the outbound transfer with its own seeds.
+    // Seed order matches PoolPda: [config, mint_a, mint_b, bump].
+    let bump = [bumps.pool_config];
     let seeds: &[Seed] = &[
-        Seed::from(crate::AUTHORITY_SEED),
         Seed::from(accounts.config.address().as_ref()),
         Seed::from(accounts.mint_a.address().as_ref()),
         Seed::from(accounts.mint_b.address().as_ref()),
@@ -212,7 +210,7 @@ pub fn handle_swap_tokens(
                 &accounts.pool_b,
                 &accounts.mint_b,
                 &accounts.token_b,
-                &accounts.pool_authority,
+                &accounts.pool_config,
                 output,
                 accounts.mint_b.decimals(),
             )
@@ -225,7 +223,7 @@ pub fn handle_swap_tokens(
                 &accounts.pool_a,
                 &accounts.mint_a,
                 &accounts.token_a,
-                &accounts.pool_authority,
+                &accounts.pool_config,
                 output,
                 accounts.mint_a.decimals(),
             )

--- a/finance/token-swap/quasar/src/instructions/withdraw_liquidity.rs
+++ b/finance/token-swap/quasar/src/instructions/withdraw_liquidity.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         error::AmmError,
         state::{Config, PoolConfig},
-        ConfigPda, LiquidityMintPda, PoolAuthorityPda, PoolPda,
+        ConfigPda, LiquidityMintPda, PoolPda,
     },
     quasar_lang::cpi::Seed,
     quasar_lang::prelude::*,
@@ -13,11 +13,9 @@ use {
 pub struct WithdrawLiquidityAccountConstraints {
     #[account(address = ConfigPda::seeds())]
     pub config: Account<Config>,
+    /// Owns both reserves and signs the transfers out of them.
     #[account(address = PoolPda::seeds(config.address(), mint_a.address(), mint_b.address()))]
     pub pool_config: Account<PoolConfig>,
-    /// Pool authority PDA.
-    #[account(address = PoolAuthorityPda::seeds(config.address(), mint_a.address(), mint_b.address()))]
-    pub pool_authority: UncheckedAccount,
     pub depositor: Signer,
     /// LP mint at the LiquidityMintPda.
     ///
@@ -66,10 +64,10 @@ pub fn handle_withdraw_liquidity(
     minimum_token_b_out: u64,
     bumps: &WithdrawLiquidityAccountConstraintsBumps,
 ) -> Result<(), ProgramError> {
-    // Seed order matches PoolAuthorityPda: [b"authority", config, mint_a, mint_b, bump].
-    let bump = [bumps.pool_authority];
+    // `pool_config` owns the reserves and signs the transfers out of them.
+    // Seed order matches PoolPda: [config, mint_a, mint_b, bump].
+    let bump = [bumps.pool_config];
     let seeds: &[Seed] = &[
-        Seed::from(crate::AUTHORITY_SEED),
         Seed::from(accounts.config.address().as_ref()),
         Seed::from(accounts.mint_a.address().as_ref()),
         Seed::from(accounts.mint_b.address().as_ref()),
@@ -133,7 +131,7 @@ pub fn handle_withdraw_liquidity(
             &accounts.pool_a,
             &accounts.mint_a,
             &accounts.token_a,
-            &accounts.pool_authority,
+            &accounts.pool_config,
             amount_a,
             accounts.mint_a.decimals(),
         )
@@ -146,7 +144,7 @@ pub fn handle_withdraw_liquidity(
             &accounts.pool_b,
             &accounts.mint_b,
             &accounts.token_b,
-            &accounts.pool_authority,
+            &accounts.pool_config,
             amount_b,
             accounts.mint_b.decimals(),
         )

--- a/finance/token-swap/quasar/src/lib.rs
+++ b/finance/token-swap/quasar/src/lib.rs
@@ -19,8 +19,6 @@ pub const MINIMUM_LIQUIDITY: u64 = 100;
 pub const BASIS_POINTS_DIVISOR: u64 = 10_000;
 /// Seed for the global Config PDA (singleton).
 pub const CONFIG_SEED: &[u8] = b"config";
-/// Seed for the pool authority PDA.
-pub const AUTHORITY_SEED: &[u8] = b"authority";
 /// Seed for the liquidity mint PDA.
 pub const LIQUIDITY_SEED: &[u8] = b"liquidity";
 
@@ -34,21 +32,13 @@ pub const LIQUIDITY_SEED: &[u8] = b"liquidity";
 pub struct ConfigPda;
 
 /// `PoolConfig` PDA at seeds = [config, mint_a, mint_b] - no string prefix.
+///
+/// This account is also the pool's signing authority: it owns both reserves,
+/// is the LP mint's mint authority, and signs the transfers out of the
+/// reserves and the LP mint with these seeds plus its bump.
 #[derive(Seeds)]
 #[seeds(b"", config: Address, mint_a: Address, mint_b: Address)]
 pub struct PoolPda;
-
-/// Pool-authority PDA at seeds = [config, mint_a, mint_b, b"authority"].
-/// Modelled with prefix b"authority" + the three Address args; the
-/// rendered slice list ends up [config, mint_a, mint_b, b"authority"] when
-/// you use `with_bump`. Note: the new \`#[seeds]\` puts the literal
-/// prefix first, so the onchain derivation order is
-/// [b"authority", config, mint_a, mint_b] - different from the original
-/// Anchor scheme. Programs are independent so this is consistent and
-/// correct on its own; the addresses just won't match the Anchor copy.
-#[derive(Seeds)]
-#[seeds(b"authority", config: Address, mint_a: Address, mint_b: Address)]
-pub struct PoolAuthorityPda;
 
 /// Liquidity-mint PDA at seeds = [b"liquidity", config, mint_a, mint_b].
 #[derive(Seeds)]

--- a/finance/token-swap/quasar/src/state.rs
+++ b/finance/token-swap/quasar/src/state.rs
@@ -25,9 +25,12 @@ pub struct Config {
 ///
 /// Holds the metadata that identifies a single pool: which `Config` it belongs
 /// to and which two mints it trades. The actual pool reserves live in separate
-/// token accounts (`pool_a`, `pool_b`) owned by the pool authority PDA - they
-/// are not stored here. This struct is the pool's *configuration*, not its
-/// state.
+/// token accounts (`pool_a`, `pool_b`) that this account owns - they are not
+/// stored here. This struct is the pool's *configuration*, not its state.
+///
+/// This account is also the pool's signing authority: it owns both reserves,
+/// is the mint authority of the LP mint, and signs the transfers out of the
+/// reserves and the LP mint with its own seeds `[config, mint_a, mint_b, bump]`.
 ///
 /// Also tracks the admin's accumulated trading-fee claim per side
 /// (`admin_fees_owed_a` / `admin_fees_owed_b`). Those amounts physically sit

--- a/finance/token-swap/quasar/src/tests.rs
+++ b/finance/token-swap/quasar/src/tests.rs
@@ -73,7 +73,6 @@ const BAD_TOKEN_A: Pubkey = Pubkey::new_from_array([23; 32]);
 const BAD_TOKEN_B: Pubkey = Pubkey::new_from_array([24; 32]);
 
 struct PoolEnv {
-    config: Pubkey,
     pool_config: Pubkey,
     lp_mint: Pubkey,
 }
@@ -96,9 +95,9 @@ fn setup_pool(test: &mut Test) -> PoolEnv {
     test.add(Mint::new(PAYER).at(MINT_A).decimals(6));
     test.add(Mint::new(PAYER).at(MINT_B).decimals(6));
 
-    // initialize_pool: the pool_config, pool authority, and LP-mint PDAs are
-    // derived by the builder; pool_a/pool_b are non-PDA token accounts the
-    // program creates at the given addresses.
+    // initialize_pool: the pool_config and LP-mint PDAs are derived by the
+    // builder; pool_a/pool_b are non-PDA token accounts the program creates
+    // at the given addresses, owned by pool_config.
     test.send(InitializePoolInstruction {
         mint_a: MINT_A,
         mint_b: MINT_B,
@@ -110,7 +109,6 @@ fn setup_pool(test: &mut Test) -> PoolEnv {
 
     let config = test.derive_pda(ConfigPda::seeds());
     PoolEnv {
-        config,
         pool_config: test.derive_pda(PoolPda::seeds(&config, &MINT_A, &MINT_B)),
         lp_mint: test.derive_pda(LiquidityMintPda::seeds(&config, &MINT_A, &MINT_B)),
     }
@@ -277,6 +275,30 @@ fn initialize_pool_creates_pool_config_and_lp_mint(test: &mut Test) {
     // LP mint PDA must be a valid SPL mint (82 bytes, owned by token program).
     let lp = test.account(env.lp_mint).expect("lp_mint missing");
     assert_eq!(lp.data.len(), 82, "LP mint should be 82 bytes");
+
+    // pool_config is the authority for everything the pool holds: the LP
+    // mint's mint authority (SPL mint layout: a 4-byte COption tag, 1 = Some,
+    // then the 32-byte pubkey) and the owner of both reserves (SPL token
+    // account layout: mint at 0..32, owner at 32..64).
+    let expected: &[u8] = env.pool_config.as_ref();
+    assert_eq!(
+        &lp.data[0..4],
+        &[1, 0, 0, 0],
+        "LP mint must have an authority"
+    );
+    assert_eq!(
+        &lp.data[4..36],
+        expected,
+        "LP mint authority must be pool_config"
+    );
+    for reserve in [POOL_A, POOL_B] {
+        let account = test.account(reserve).expect("reserve missing");
+        assert_eq!(
+            &account.data[32..64],
+            expected,
+            "reserve owner must be pool_config"
+        );
+    }
 }
 
 // ─── deposit_liquidity ───────────────────────────────────────────────────────

--- a/finance/vault-strategy/anchor-v1/CHANGELOG.md
+++ b/finance/vault-strategy/anchor-v1/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-09-10
+
+- **The mock swap router signs as its config account.** The router used a second, dataless PDA as the owner of its USDC treasury and the mint authority of the basket mints. That PDA is removed: `router_config` (`["router_config"]`) now owns the treasury, is the mint authority of the basket mints, and signs the router's `mint_to` and `transfer_checked` CPIs with its own seeds and stored bump, mirroring how the strategy PDA signs for the share mint and vaults. The extra account is gone from every router instruction, from the vault's `deposit` and `rebalance` contexts, and from the router CPI account lists; the treasury is now the `router_config` account's USDC associated token account. Tests and the web app's PDA helpers, instruction builders, and IDL follow.
+
 ## 2026-07-20
 
 - **`WhitelistEntry` renamed `ApprovedAsset`** (and `whitelist_asset` renamed `approve_asset`, PDA seed `"whitelist"` renamed `"approved_asset"`), naming the account after what it is: one curator-approved asset bound to its official price feed. The unused `AssetNotWhitelisted` error is removed; approval is checked by the `ApprovedAsset` account's existence. Doc comments and README now state that the `Registry` account is the curator record at the root of the approved set, not the list itself.

--- a/finance/vault-strategy/anchor-v1/README.md
+++ b/finance/vault-strategy/anchor-v1/README.md
@@ -120,7 +120,7 @@ A price move pushes the basket off target. `rebalance(sell_amount, usdc_to_inves
 
 ## Mock Swap Router vs Production
 
-The `mock-swap-router` exists only for testing: it stores a `usdc_per_token` rate per asset, holds the basket mints' authority, and mints/burns to simulate swaps. The `Strategy` stores the router program pubkey at creation, and `deposit` and `rebalance` require the router account to match it (`InvalidSwapRouter`). In production, replace the router CPIs with [Jupiter](https://jup.ag); the strategy PDA still signs.
+The `mock-swap-router` exists only for testing: it stores a `usdc_per_token` rate per asset, holds the basket mints' authority, and mints/burns to simulate swaps. Its single `router_config` account (`["router_config"]`) is both its state and its signer: it owns the USDC treasury, is the mint authority of every basket mint, and signs the router's token CPIs with its own seeds, the same way the strategy PDA does for the vaults. The `Strategy` stores the router program pubkey at creation, and `deposit` and `rebalance` require the router account to match it (`InvalidSwapRouter`). In production, replace the router CPIs with [Jupiter](https://jup.ag); the strategy PDA still signs.
 
 ---
 

--- a/finance/vault-strategy/anchor-v1/app/src/idl/vault_strategy.json
+++ b/finance/vault-strategy/anchor-v1/app/src/idl/vault_strategy.json
@@ -401,10 +401,6 @@
           "writable": true
         },
         {
-          "name": "router_authority",
-          "writable": true
-        },
-        {
           "name": "swap_router_program",
           "address": "SWPR8Rk3aq3DrDGLdaANq7xCMnXoUFUJWJJmCWxc8Jm"
         },
@@ -721,10 +717,6 @@
         },
         {
           "name": "router_usdc_treasury",
-          "writable": true
-        },
-        {
-          "name": "router_authority",
           "writable": true
         },
         {

--- a/finance/vault-strategy/anchor-v1/app/src/solana/instructions.ts
+++ b/finance/vault-strategy/anchor-v1/app/src/solana/instructions.ts
@@ -7,7 +7,6 @@ import {
   assetConfigPda,
   assetRatePda,
   registryPda,
-  routerAuthorityPda,
   routerConfigPda,
   routerUsdcTreasury,
   shareMintPda,
@@ -66,7 +65,6 @@ export function buildDepositIx(
       vaultUsdc: view.usdcVault,
       routerConfig: routerConfigPda(router),
       routerUsdcTreasury: routerUsdcTreasury(s.usdcMint, router),
-      routerAuthority: routerAuthorityPda(router),
       swapRouterProgram: router,
       ...TOKEN_PROGRAMS,
     })
@@ -153,7 +151,6 @@ export function buildRebalanceIx(
       buyRate: assetRatePda(buy.mint, router),
       routerConfig: routerConfigPda(router),
       routerUsdcTreasury: routerUsdcTreasury(s.usdcMint, router),
-      routerAuthority: routerAuthorityPda(router),
       swapRouterProgram: router,
       ...TOKEN_PROGRAMS,
     })

--- a/finance/vault-strategy/anchor-v1/app/src/solana/pdas.ts
+++ b/finance/vault-strategy/anchor-v1/app/src/solana/pdas.ts
@@ -38,13 +38,9 @@ export const approvedAssetPda = (registry: PublicKey, mint: PublicKey): PublicKe
 // The strategy stores which router it uses, so these accept the router program id
 // (defaulting to the configured one) to stay correct if a strategy points elsewhere.
 
-/** ["router_config"] */
+/** ["router_config"] — also owns the router's treasury and signs its token CPIs */
 export const routerConfigPda = (routerProgram: PublicKey = ROUTER_PROGRAM_ID): PublicKey =>
   pda([seed("router_config")], routerProgram);
-
-/** ["router_authority"] */
-export const routerAuthorityPda = (routerProgram: PublicKey = ROUTER_PROGRAM_ID): PublicKey =>
-  pda([seed("router_authority")], routerProgram);
 
 /** ["rate", mint] */
 export const assetRatePda = (mint: PublicKey, routerProgram: PublicKey = ROUTER_PROGRAM_ID): PublicKey =>
@@ -60,8 +56,8 @@ export const vaultAta = (mint: PublicKey, strategy: PublicKey): PublicKey =>
 export const userAta = (mint: PublicKey, owner: PublicKey): PublicKey =>
   getAssociatedTokenAddressSync(mint, owner, false);
 
-/** Router USDC treasury = ATA(usdc, router_authority). */
+/** Router USDC treasury = ATA(usdc, router_config). */
 export const routerUsdcTreasury = (usdcMint: PublicKey, routerProgram: PublicKey = ROUTER_PROGRAM_ID): PublicKey =>
-  getAssociatedTokenAddressSync(usdcMint, routerAuthorityPda(routerProgram), true);
+  getAssociatedTokenAddressSync(usdcMint, routerConfigPda(routerProgram), true);
 
 export { ASSOCIATED_TOKEN_PROGRAM_ID, TOKEN_PROGRAM_ID };

--- a/finance/vault-strategy/anchor-v1/programs/mock-swap-router/src/instructions/initialize_router.rs
+++ b/finance/vault-strategy/anchor-v1/programs/mock-swap-router/src/instructions/initialize_router.rs
@@ -19,13 +19,6 @@ pub struct InitializeRouterAccountConstraints<'info> {
     )]
     pub router_config: Account<'info, RouterConfig>,
 
-    /// CHECK: PDA used as mint authority only - no data stored
-    #[account(
-        seeds = [b"router_authority"],
-        bump
-    )]
-    pub router_authority: UncheckedAccount<'info>,
-
     pub token_program: Interface<'info, TokenInterface>,
     pub system_program: Program<'info, System>,
 }

--- a/finance/vault-strategy/anchor-v1/programs/mock-swap-router/src/instructions/set_rate.rs
+++ b/finance/vault-strategy/anchor-v1/programs/mock-swap-router/src/instructions/set_rate.rs
@@ -31,18 +31,12 @@ pub struct SetRateAccountConstraints<'info> {
     )]
     pub asset_rate: Account<'info, AssetRate>,
 
-    /// CHECK: PDA used as mint authority only
-    #[account(
-        seeds = [b"router_authority"],
-        bump
-    )]
-    pub router_authority: UncheckedAccount<'info>,
-
+    /// The router's USDC treasury, owned by `router_config`.
     #[account(
         init_if_needed,
         payer = authority,
         associated_token::mint = usdc_mint,
-        associated_token::authority = router_authority,
+        associated_token::authority = router_config,
         associated_token::token_program = token_program
     )]
     pub router_usdc_treasury: InterfaceAccount<'info, TokenAccount>,

--- a/finance/vault-strategy/anchor-v1/programs/mock-swap-router/src/instructions/swap_asset_for_usdc.rs
+++ b/finance/vault-strategy/anchor-v1/programs/mock-swap-router/src/instructions/swap_asset_for_usdc.rs
@@ -13,6 +13,8 @@ use crate::state::{AssetRate, RouterConfig};
 pub struct SwapAssetForUsdcAccountConstraints<'info> {
     pub caller: Signer<'info>,
 
+    /// Owns the USDC treasury and is the mint authority of every asset the
+    /// router mints; signs the treasury transfer below with its own seeds.
     #[account(
         seeds = [b"router_config"],
         bump = router_config.bump
@@ -52,17 +54,10 @@ pub struct SwapAssetForUsdcAccountConstraints<'info> {
     #[account(
         mut,
         associated_token::mint = usdc_mint,
-        associated_token::authority = router_authority,
+        associated_token::authority = router_config,
         associated_token::token_program = token_program
     )]
     pub router_usdc_treasury: Box<InterfaceAccount<'info, TokenAccount>>,
-
-    /// CHECK: PDA used as treasury authority - validated by seeds constraint
-    #[account(
-        seeds = [b"router_authority"],
-        bump
-    )]
-    pub router_authority: UncheckedAccount<'info>,
 
     pub associated_token_program: Program<'info, AssociatedToken>,
     pub token_program: Interface<'info, TokenInterface>,
@@ -96,15 +91,15 @@ pub fn handle_swap_asset_for_usdc(
         asset_amount_in,
     )?;
 
-    // Transfer USDC from router treasury to caller - router_authority PDA signs
-    let router_authority_bump = context.bumps.router_authority;
-    let signer_seeds: &[&[&[u8]]] = &[&[b"router_authority", &[router_authority_bump]]];
+    // Transfer USDC from router treasury to caller - router_config owns the treasury and signs
+    let router_config_bump = context.accounts.router_config.bump;
+    let signer_seeds: &[&[&[u8]]] = &[&[b"router_config", &[router_config_bump]]];
 
     let transfer_accounts = TransferChecked {
         from: context.accounts.router_usdc_treasury.to_account_info(),
         mint: context.accounts.usdc_mint.to_account_info(),
         to: context.accounts.caller_usdc_account.to_account_info(),
-        authority: context.accounts.router_authority.to_account_info(),
+        authority: context.accounts.router_config.to_account_info(),
     };
     transfer_checked(
         CpiContext::new_with_signer(

--- a/finance/vault-strategy/anchor-v1/programs/mock-swap-router/src/instructions/swap_usdc_for_asset.rs
+++ b/finance/vault-strategy/anchor-v1/programs/mock-swap-router/src/instructions/swap_usdc_for_asset.rs
@@ -14,6 +14,8 @@ pub struct SwapUsdcForAssetAccountConstraints<'info> {
     /// The caller - e.g. the vault strategy PDA (can be a signer or a PDA signer via CPI)
     pub caller: Signer<'info>,
 
+    /// Owns the USDC treasury and is the mint authority of every asset the
+    /// router mints; signs the mint below with its own seeds.
     #[account(
         seeds = [b"router_config"],
         bump = router_config.bump
@@ -52,17 +54,10 @@ pub struct SwapUsdcForAssetAccountConstraints<'info> {
     #[account(
         mut,
         associated_token::mint = usdc_mint,
-        associated_token::authority = router_authority,
+        associated_token::authority = router_config,
         associated_token::token_program = token_program
     )]
     pub router_usdc_treasury: Box<InterfaceAccount<'info, TokenAccount>>,
-
-    /// CHECK: PDA used as mint authority - validated by seeds constraint
-    #[account(
-        seeds = [b"router_authority"],
-        bump
-    )]
-    pub router_authority: UncheckedAccount<'info>,
 
     pub associated_token_program: Program<'info, AssociatedToken>,
     pub token_program: Interface<'info, TokenInterface>,
@@ -99,14 +94,14 @@ pub fn handle_swap_usdc_for_asset(
     let cpi_ctx = CpiContext::new(context.accounts.token_program.key(), transfer_accounts);
     transfer_checked(cpi_ctx, usdc_amount_in, context.accounts.usdc_mint.decimals)?;
 
-    // Mint asset tokens to caller - router_authority PDA signs
-    let router_authority_bump = context.bumps.router_authority;
-    let signer_seeds: &[&[&[u8]]] = &[&[b"router_authority", &[router_authority_bump]]];
+    // Mint asset tokens to caller - router_config is the mint authority and signs
+    let router_config_bump = context.accounts.router_config.bump;
+    let signer_seeds: &[&[&[u8]]] = &[&[b"router_config", &[router_config_bump]]];
 
     let mint_accounts = MintTo {
         mint: context.accounts.asset_mint.to_account_info(),
         to: context.accounts.caller_asset_account.to_account_info(),
-        authority: context.accounts.router_authority.to_account_info(),
+        authority: context.accounts.router_config.to_account_info(),
     };
     let cpi_ctx = CpiContext::new_with_signer(
         context.accounts.token_program.key(),

--- a/finance/vault-strategy/anchor-v1/programs/vault-strategy/src/instructions/deposit.rs
+++ b/finance/vault-strategy/anchor-v1/programs/vault-strategy/src/instructions/deposit.rs
@@ -58,17 +58,14 @@ pub struct DepositAccountConstraints<'info> {
     )]
     pub vault_usdc: Box<InterfaceAccount<'info, TokenAccount>>,
 
-    /// CHECK: Router config PDA from the mock-swap-router program
+    /// CHECK: Router config PDA from the mock-swap-router program; it owns the
+    /// treasury and signs the router's token CPIs
     #[account(mut)]
     pub router_config: UncheckedAccount<'info>,
 
-    /// CHECK: Router USDC treasury ATA
+    /// CHECK: Router USDC treasury ATA, owned by the router config account
     #[account(mut)]
     pub router_usdc_treasury: UncheckedAccount<'info>,
-
-    /// CHECK: Router authority PDA from the mock-swap-router program
-    #[account(mut)]
-    pub router_authority: UncheckedAccount<'info>,
 
     #[account(
         constraint = swap_router_program.key() == strategy.swap_router @ VaultError::InvalidSwapRouter
@@ -241,7 +238,6 @@ pub fn handle_deposit<'info>(
             caller_usdc_account: context.accounts.vault_usdc.to_account_info(),
             caller_asset_account: vault_account.clone(),
             router_usdc_treasury: context.accounts.router_usdc_treasury.to_account_info(),
-            router_authority: context.accounts.router_authority.to_account_info(),
             associated_token_program: context.accounts.associated_token_program.to_account_info(),
             token_program: context.accounts.token_program.to_account_info(),
             system_program: context.accounts.system_program.to_account_info(),

--- a/finance/vault-strategy/anchor-v1/programs/vault-strategy/src/instructions/rebalance.rs
+++ b/finance/vault-strategy/anchor-v1/programs/vault-strategy/src/instructions/rebalance.rs
@@ -87,13 +87,9 @@ pub struct RebalanceAccountConstraints<'info> {
     #[account(mut)]
     pub router_config: UncheckedAccount<'info>,
 
-    /// CHECK: Router USDC treasury ATA
+    /// CHECK: Router USDC treasury ATA, owned by the router config account
     #[account(mut)]
     pub router_usdc_treasury: UncheckedAccount<'info>,
-
-    /// CHECK: Router authority PDA
-    #[account(mut)]
-    pub router_authority: UncheckedAccount<'info>,
 
     #[account(
         constraint = swap_router_program.key() == strategy.swap_router @ VaultError::InvalidSwapRouter
@@ -173,7 +169,6 @@ pub fn handle_rebalance(
         caller_asset_account: context.accounts.vault_sell.to_account_info(),
         caller_usdc_account: context.accounts.vault_usdc.to_account_info(),
         router_usdc_treasury: context.accounts.router_usdc_treasury.to_account_info(),
-        router_authority: context.accounts.router_authority.to_account_info(),
         associated_token_program: context.accounts.associated_token_program.to_account_info(),
         token_program: context.accounts.token_program.to_account_info(),
         system_program: context.accounts.system_program.to_account_info(),
@@ -198,7 +193,6 @@ pub fn handle_rebalance(
         caller_usdc_account: context.accounts.vault_usdc.to_account_info(),
         caller_asset_account: context.accounts.vault_buy.to_account_info(),
         router_usdc_treasury: context.accounts.router_usdc_treasury.to_account_info(),
-        router_authority: context.accounts.router_authority.to_account_info(),
         associated_token_program: context.accounts.associated_token_program.to_account_info(),
         token_program: context.accounts.token_program.to_account_info(),
         system_program: context.accounts.system_program.to_account_info(),

--- a/finance/vault-strategy/anchor-v1/programs/vault-strategy/tests/vault_strategy.rs
+++ b/finance/vault-strategy/anchor-v1/programs/vault-strategy/tests/vault_strategy.rs
@@ -108,7 +108,6 @@ struct TestContext {
     approved_tsla: Pubkey,
     approved_nvda: Pubkey,
     router_config_pda: Pubkey,
-    router_authority_pda: Pubkey,
     tsla_rate_pda: Pubkey,
     nvda_rate_pda: Pubkey,
     vault_usdc: Pubkey,
@@ -167,15 +166,16 @@ fn setup_full() -> TestContext {
     let tsla_mint = create_token_mint(&mut svm, &payer, TOKEN_DECIMALS, None).unwrap();
     let nvda_mint = create_token_mint(&mut svm, &payer, TOKEN_DECIMALS, None).unwrap();
 
-    let (router_authority_pda, _) =
-        Pubkey::find_program_address(&[b"router_authority"], &router_program_id);
+    let (router_config_pda, _) =
+        Pubkey::find_program_address(&[b"router_config"], &router_program_id);
 
-    // The router mints basket assets on swap, so it must hold their mint authority.
+    // The router mints basket assets on swap, so its config account, which signs
+    // the router's token CPIs, must hold their mint authority.
     for basket_mint in [&tsla_mint, &nvda_mint] {
         let ix = spl_token::instruction::set_authority(
             &spl_token::ID,
             basket_mint,
-            Some(&router_authority_pda),
+            Some(&router_config_pda),
             spl_token::instruction::AuthorityType::MintTokens,
             &payer.pubkey(),
             &[],
@@ -200,8 +200,6 @@ fn setup_full() -> TestContext {
         &[b"approved_asset", registry_pda.as_ref(), nvda_mint.as_ref()],
         &vault_program_id,
     );
-    let (router_config_pda, _) =
-        Pubkey::find_program_address(&[b"router_config"], &router_program_id);
     let (tsla_rate_pda, _) =
         Pubkey::find_program_address(&[b"rate", tsla_mint.as_ref()], &router_program_id);
     let (nvda_rate_pda, _) =
@@ -210,7 +208,7 @@ fn setup_full() -> TestContext {
     let vault_usdc = derive_ata(&strategy_pda, &usdc_mint);
     let vault_tsla = derive_ata(&strategy_pda, &tsla_mint);
     let vault_nvda = derive_ata(&strategy_pda, &nvda_mint);
-    let router_usdc_treasury = derive_ata(&router_authority_pda, &usdc_mint);
+    let router_usdc_treasury = derive_ata(&router_config_pda, &usdc_mint);
 
     let price_feed_tsla = Keypair::new().pubkey();
     let price_feed_nvda = Keypair::new().pubkey();
@@ -225,7 +223,6 @@ fn setup_full() -> TestContext {
             authority: payer.pubkey(),
             usdc_mint,
             router_config: router_config_pda,
-            router_authority: router_authority_pda,
             token_program: token_program_id(),
             system_program: system_program::id(),
         }
@@ -251,7 +248,6 @@ fn setup_full() -> TestContext {
                 asset_mint: mint,
                 usdc_mint,
                 asset_rate: rate_pda,
-                router_authority: router_authority_pda,
                 router_usdc_treasury,
                 associated_token_program: ata_program_id(),
                 token_program: token_program_id(),
@@ -324,7 +320,6 @@ fn setup_full() -> TestContext {
         approved_tsla,
         approved_nvda,
         router_config_pda,
-        router_authority_pda,
         tsla_rate_pda,
         nvda_rate_pda,
         vault_usdc,
@@ -466,7 +461,6 @@ fn deposit_named_metas(ctx: &TestContext, user: &Keypair) -> Vec<AccountMeta> {
         vault_usdc: ctx.vault_usdc,
         router_config: ctx.router_config_pda,
         router_usdc_treasury: ctx.router_usdc_treasury,
-        router_authority: ctx.router_authority_pda,
         swap_router_program: ctx.router_program_id,
         associated_token_program: ata_program_id(),
         token_program: token_program_id(),
@@ -537,7 +531,6 @@ fn set_router_rate(ctx: &mut TestContext, mint: Pubkey, rate: u64, rate_pda: Pub
             asset_mint: mint,
             usdc_mint: ctx.usdc_mint,
             asset_rate: rate_pda,
-            router_authority: ctx.router_authority_pda,
             router_usdc_treasury: ctx.router_usdc_treasury,
             associated_token_program: ata_program_id(),
             token_program: token_program_id(),
@@ -655,7 +648,6 @@ fn do_rebalance(
             buy_rate,
             router_config: ctx.router_config_pda,
             router_usdc_treasury: ctx.router_usdc_treasury,
-            router_authority: ctx.router_authority_pda,
             swap_router_program: ctx.router_program_id,
             associated_token_program: ata_program_id(),
             token_program: token_program_id(),

--- a/finance/vault-strategy/anchor/CHANGELOG.md
+++ b/finance/vault-strategy/anchor/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-09-10
+
+- **The mock swap router signs as its config account.** The router used a second, dataless PDA as the owner of its USDC treasury and the mint authority of the basket mints. That PDA is removed: `router_config` (`["router_config"]`) now owns the treasury, is the mint authority of the basket mints, and signs the router's `mint_to` and `transfer_checked` CPIs with its own seeds and stored bump, mirroring how the strategy PDA signs for the share mint and vaults. The extra account is gone from every router instruction, from the vault's `deposit` and `rebalance` contexts, and from the router CPI account lists; the treasury is now the `router_config` account's USDC associated token account. Tests and the web app's PDA helpers, instruction builders, and IDL follow.
+
 ## 2026-07-20
 
 - **`WhitelistEntry` renamed `ApprovedAsset`** (and `whitelist_asset` renamed `approve_asset`, PDA seed `"whitelist"` renamed `"approved_asset"`), naming the account after what it is: one curator-approved asset bound to its official price feed. The unused `AssetNotWhitelisted` error is removed; approval is checked by the `ApprovedAsset` account's existence. Doc comments and README now state that the `Registry` account is the curator record at the root of the approved set, not the list itself.

--- a/finance/vault-strategy/anchor/README.md
+++ b/finance/vault-strategy/anchor/README.md
@@ -120,7 +120,7 @@ A price move pushes the basket off target. `rebalance(sell_amount, usdc_to_inves
 
 ## Mock Swap Router vs Production
 
-The `mock-swap-router` exists only for testing: it stores a `usdc_per_token` rate per asset, holds the basket mints' authority, and mints/burns to simulate swaps. The `Strategy` stores the router program pubkey at creation, and `deposit` and `rebalance` require the router account to match it (`InvalidSwapRouter`). In production, replace the router CPIs with [Jupiter](https://jup.ag); the strategy PDA still signs.
+The `mock-swap-router` exists only for testing: it stores a `usdc_per_token` rate per asset, holds the basket mints' authority, and mints/burns to simulate swaps. Its single `router_config` account (`["router_config"]`) is both its state and its signer: it owns the USDC treasury, is the mint authority of every basket mint, and signs the router's token CPIs with its own seeds, the same way the strategy PDA does for the vaults. The `Strategy` stores the router program pubkey at creation, and `deposit` and `rebalance` require the router account to match it (`InvalidSwapRouter`). In production, replace the router CPIs with [Jupiter](https://jup.ag); the strategy PDA still signs.
 
 ---
 

--- a/finance/vault-strategy/anchor/app/src/idl/vault_strategy.json
+++ b/finance/vault-strategy/anchor/app/src/idl/vault_strategy.json
@@ -401,10 +401,6 @@
           "writable": true
         },
         {
-          "name": "router_authority",
-          "writable": true
-        },
-        {
           "name": "swap_router_program",
           "address": "SWPR8Rk3aq3DrDGLdaANq7xCMnXoUFUJWJJmCWxc8Jm"
         },
@@ -721,10 +717,6 @@
         },
         {
           "name": "router_usdc_treasury",
-          "writable": true
-        },
-        {
-          "name": "router_authority",
           "writable": true
         },
         {

--- a/finance/vault-strategy/anchor/app/src/solana/instructions.ts
+++ b/finance/vault-strategy/anchor/app/src/solana/instructions.ts
@@ -7,7 +7,6 @@ import {
   assetConfigPda,
   assetRatePda,
   registryPda,
-  routerAuthorityPda,
   routerConfigPda,
   routerUsdcTreasury,
   shareMintPda,
@@ -66,7 +65,6 @@ export function buildDepositIx(
       vaultUsdc: view.usdcVault,
       routerConfig: routerConfigPda(router),
       routerUsdcTreasury: routerUsdcTreasury(s.usdcMint, router),
-      routerAuthority: routerAuthorityPda(router),
       swapRouterProgram: router,
       ...TOKEN_PROGRAMS,
     })
@@ -153,7 +151,6 @@ export function buildRebalanceIx(
       buyRate: assetRatePda(buy.mint, router),
       routerConfig: routerConfigPda(router),
       routerUsdcTreasury: routerUsdcTreasury(s.usdcMint, router),
-      routerAuthority: routerAuthorityPda(router),
       swapRouterProgram: router,
       ...TOKEN_PROGRAMS,
     })

--- a/finance/vault-strategy/anchor/app/src/solana/pdas.ts
+++ b/finance/vault-strategy/anchor/app/src/solana/pdas.ts
@@ -38,13 +38,9 @@ export const approvedAssetPda = (registry: PublicKey, mint: PublicKey): PublicKe
 // The strategy stores which router it uses, so these accept the router program id
 // (defaulting to the configured one) to stay correct if a strategy points elsewhere.
 
-/** ["router_config"] */
+/** ["router_config"] — also owns the router's treasury and signs its token CPIs */
 export const routerConfigPda = (routerProgram: PublicKey = ROUTER_PROGRAM_ID): PublicKey =>
   pda([seed("router_config")], routerProgram);
-
-/** ["router_authority"] */
-export const routerAuthorityPda = (routerProgram: PublicKey = ROUTER_PROGRAM_ID): PublicKey =>
-  pda([seed("router_authority")], routerProgram);
 
 /** ["rate", mint] */
 export const assetRatePda = (mint: PublicKey, routerProgram: PublicKey = ROUTER_PROGRAM_ID): PublicKey =>
@@ -60,8 +56,8 @@ export const vaultAta = (mint: PublicKey, strategy: PublicKey): PublicKey =>
 export const userAta = (mint: PublicKey, owner: PublicKey): PublicKey =>
   getAssociatedTokenAddressSync(mint, owner, false);
 
-/** Router USDC treasury = ATA(usdc, router_authority). */
+/** Router USDC treasury = ATA(usdc, router_config). */
 export const routerUsdcTreasury = (usdcMint: PublicKey, routerProgram: PublicKey = ROUTER_PROGRAM_ID): PublicKey =>
-  getAssociatedTokenAddressSync(usdcMint, routerAuthorityPda(routerProgram), true);
+  getAssociatedTokenAddressSync(usdcMint, routerConfigPda(routerProgram), true);
 
 export { ASSOCIATED_TOKEN_PROGRAM_ID, TOKEN_PROGRAM_ID };

--- a/finance/vault-strategy/anchor/programs/mock-swap-router/src/instructions/initialize_router.rs
+++ b/finance/vault-strategy/anchor/programs/mock-swap-router/src/instructions/initialize_router.rs
@@ -19,13 +19,6 @@ pub struct InitializeRouterAccountConstraints {
     )]
     pub router_config: BorshAccount<RouterConfig>,
 
-    /// CHECK: PDA used as mint authority only - no data stored
-    #[account(
-        seeds = [b"router_authority"],
-        bump
-    )]
-    pub router_authority: UncheckedAccount,
-
     pub token_program: Interface<'static, TokenInterface>,
     pub system_program: Program<System>,
 }

--- a/finance/vault-strategy/anchor/programs/mock-swap-router/src/instructions/set_rate.rs
+++ b/finance/vault-strategy/anchor/programs/mock-swap-router/src/instructions/set_rate.rs
@@ -28,18 +28,12 @@ pub struct SetRateAccountConstraints {
     )]
     pub asset_rate: BorshAccount<AssetRate>,
 
-    /// CHECK: PDA used as mint authority only
-    #[account(
-        seeds = [b"router_authority"],
-        bump
-    )]
-    pub router_authority: UncheckedAccount,
-
+    /// The router's USDC treasury, owned by `router_config`.
     #[account(
         init_if_needed,
         payer = authority,
         associated_token::mint = usdc_mint,
-        associated_token::authority = router_authority,
+        associated_token::authority = router_config,
         associated_token::token_program = token_program
     )]
     pub router_usdc_treasury: InterfaceAccount<TokenAccount>,

--- a/finance/vault-strategy/anchor/programs/mock-swap-router/src/instructions/swap_asset_for_usdc.rs
+++ b/finance/vault-strategy/anchor/programs/mock-swap-router/src/instructions/swap_asset_for_usdc.rs
@@ -13,6 +13,8 @@ use crate::state::{AssetRate, RouterConfig};
 pub struct SwapAssetForUsdcAccountConstraints {
     pub caller: Signer,
 
+    /// Owns the USDC treasury and is the mint authority of every asset the
+    /// router mints; signs the treasury transfer below with its own seeds.
     #[account(
         seeds = [b"router_config"],
         bump = router_config.bump
@@ -52,17 +54,10 @@ pub struct SwapAssetForUsdcAccountConstraints {
     #[account(
         mut,
         associated_token::mint = usdc_mint,
-        associated_token::authority = router_authority,
+        associated_token::authority = router_config,
         associated_token::token_program = token_program
     )]
     pub router_usdc_treasury: Box<InterfaceAccount<TokenAccount>>,
-
-    /// CHECK: PDA used as treasury authority - validated by seeds constraint
-    #[account(
-        seeds = [b"router_authority"],
-        bump
-    )]
-    pub router_authority: UncheckedAccount,
 
     pub associated_token_program: Program<AssociatedToken>,
     pub token_program: Interface<'static, TokenInterface>,
@@ -96,15 +91,15 @@ pub fn handle_swap_asset_for_usdc(
         asset_amount_in,
     )?;
 
-    // Transfer USDC from router treasury to caller - router_authority PDA signs
-    let router_authority_bump = context.bumps.router_authority;
-    let signer_seeds: &[&[&[u8]]] = &[&[b"router_authority", &[router_authority_bump]]];
+    // Transfer USDC from router treasury to caller - router_config owns the treasury and signs
+    let router_config_bump = context.accounts.router_config.bump;
+    let signer_seeds: &[&[&[u8]]] = &[&[b"router_config", &[router_config_bump]]];
 
     let transfer_accounts = TransferChecked {
         from: context.accounts.router_usdc_treasury.to_cpi_handle_mut(),
         mint: context.accounts.usdc_mint.to_cpi_handle(),
         to: context.accounts.caller_usdc_account.to_cpi_handle_mut(),
-        authority: context.accounts.router_authority.cpi_handle(),
+        authority: context.accounts.router_config.to_cpi_handle(),
     };
     transfer_checked(
         CpiContext::new_with_signer(

--- a/finance/vault-strategy/anchor/programs/mock-swap-router/src/instructions/swap_usdc_for_asset.rs
+++ b/finance/vault-strategy/anchor/programs/mock-swap-router/src/instructions/swap_usdc_for_asset.rs
@@ -14,6 +14,8 @@ pub struct SwapUsdcForAssetAccountConstraints {
     /// The caller - e.g. the vault strategy PDA (can be a signer or a PDA signer via CPI)
     pub caller: Signer,
 
+    /// Owns the USDC treasury and is the mint authority of every asset the
+    /// router mints; signs the mint below with its own seeds.
     #[account(
         seeds = [b"router_config"],
         bump = router_config.bump
@@ -52,17 +54,10 @@ pub struct SwapUsdcForAssetAccountConstraints {
     #[account(
         mut,
         associated_token::mint = usdc_mint,
-        associated_token::authority = router_authority,
+        associated_token::authority = router_config,
         associated_token::token_program = token_program
     )]
     pub router_usdc_treasury: Box<InterfaceAccount<TokenAccount>>,
-
-    /// CHECK: PDA used as mint authority - validated by seeds constraint
-    #[account(
-        seeds = [b"router_authority"],
-        bump
-    )]
-    pub router_authority: UncheckedAccount,
 
     pub associated_token_program: Program<AssociatedToken>,
     pub token_program: Interface<'static, TokenInterface>,
@@ -103,14 +98,14 @@ pub fn handle_swap_usdc_for_asset(
         context.accounts.usdc_mint.decimals(),
     )?;
 
-    // Mint asset tokens to caller - router_authority PDA signs
-    let router_authority_bump = context.bumps.router_authority;
-    let signer_seeds: &[&[&[u8]]] = &[&[b"router_authority", &[router_authority_bump]]];
+    // Mint asset tokens to caller - router_config is the mint authority and signs
+    let router_config_bump = context.accounts.router_config.bump;
+    let signer_seeds: &[&[&[u8]]] = &[&[b"router_config", &[router_config_bump]]];
 
     let mint_accounts = MintTo {
         mint: context.accounts.asset_mint.to_cpi_handle_mut(),
         to: context.accounts.caller_asset_account.to_cpi_handle_mut(),
-        authority: context.accounts.router_authority.cpi_handle(),
+        authority: context.accounts.router_config.to_cpi_handle(),
     };
     let cpi_ctx = CpiContext::new_with_signer(
         context.accounts.token_program.address(),

--- a/finance/vault-strategy/anchor/programs/vault-strategy/src/instructions/deposit.rs
+++ b/finance/vault-strategy/anchor/programs/vault-strategy/src/instructions/deposit.rs
@@ -58,17 +58,14 @@ pub struct DepositAccountConstraints {
     )]
     pub vault_usdc: Box<InterfaceAccount<TokenAccount>>,
 
-    /// CHECK: Router config PDA from the mock-swap-router program
+    /// CHECK: Router config PDA from the mock-swap-router program; it owns the
+    /// treasury and signs the router's token CPIs
     #[account(mut)]
     pub router_config: UncheckedAccount,
 
-    /// CHECK: Router USDC treasury ATA
+    /// CHECK: Router USDC treasury ATA, owned by the router config account
     #[account(mut)]
     pub router_usdc_treasury: UncheckedAccount,
-
-    /// CHECK: Router authority PDA from the mock-swap-router program
-    #[account(mut)]
-    pub router_authority: UncheckedAccount,
 
     #[account(
         constraint = *swap_router_program.address() == strategy.swap_router @ VaultError::InvalidSwapRouter
@@ -249,7 +246,6 @@ pub fn handle_deposit(
             caller_usdc_account: context.accounts.vault_usdc.to_cpi_handle_mut(),
             caller_asset_account: CpiHandleMut::writable(&mut vault_account),
             router_usdc_treasury: context.accounts.router_usdc_treasury.cpi_handle_mut(),
-            router_authority: context.accounts.router_authority.cpi_handle(),
             associated_token_program: context.accounts.associated_token_program.cpi_handle(),
             token_program: context.accounts.token_program.cpi_handle(),
             system_program: context.accounts.system_program.cpi_handle(),

--- a/finance/vault-strategy/anchor/programs/vault-strategy/src/instructions/rebalance.rs
+++ b/finance/vault-strategy/anchor/programs/vault-strategy/src/instructions/rebalance.rs
@@ -87,13 +87,9 @@ pub struct RebalanceAccountConstraints {
     #[account(mut)]
     pub router_config: UncheckedAccount,
 
-    /// CHECK: Router USDC treasury ATA
+    /// CHECK: Router USDC treasury ATA, owned by the router config account
     #[account(mut)]
     pub router_usdc_treasury: UncheckedAccount,
-
-    /// CHECK: Router authority PDA
-    #[account(mut)]
-    pub router_authority: UncheckedAccount,
 
     #[account(
         constraint = *swap_router_program.address() == strategy.swap_router @ VaultError::InvalidSwapRouter
@@ -179,7 +175,6 @@ pub fn handle_rebalance(
         caller_asset_account: context.accounts.vault_sell.to_cpi_handle_mut(),
         caller_usdc_account: context.accounts.vault_usdc.to_cpi_handle_mut(),
         router_usdc_treasury: context.accounts.router_usdc_treasury.cpi_handle_mut(),
-        router_authority: context.accounts.router_authority.cpi_handle(),
         associated_token_program: context.accounts.associated_token_program.cpi_handle(),
         token_program: context.accounts.token_program.cpi_handle(),
         system_program: context.accounts.system_program.cpi_handle(),
@@ -204,7 +199,6 @@ pub fn handle_rebalance(
         caller_usdc_account: context.accounts.vault_usdc.to_cpi_handle_mut(),
         caller_asset_account: context.accounts.vault_buy.to_cpi_handle_mut(),
         router_usdc_treasury: context.accounts.router_usdc_treasury.cpi_handle_mut(),
-        router_authority: context.accounts.router_authority.cpi_handle(),
         associated_token_program: context.accounts.associated_token_program.cpi_handle(),
         token_program: context.accounts.token_program.cpi_handle(),
         system_program: context.accounts.system_program.cpi_handle(),

--- a/finance/vault-strategy/anchor/programs/vault-strategy/tests/vault_strategy.rs
+++ b/finance/vault-strategy/anchor/programs/vault-strategy/tests/vault_strategy.rs
@@ -105,7 +105,6 @@ struct TestContext {
     approved_tsla: Address,
     approved_nvda: Address,
     router_config_pda: Address,
-    router_authority_pda: Address,
     tsla_rate_pda: Address,
     nvda_rate_pda: Address,
     vault_usdc: Address,
@@ -164,15 +163,16 @@ fn setup_full() -> TestContext {
     let tsla_mint = create_token_mint(&mut svm, &payer, TOKEN_DECIMALS, None).unwrap();
     let nvda_mint = create_token_mint(&mut svm, &payer, TOKEN_DECIMALS, None).unwrap();
 
-    let (router_authority_pda, _) =
-        Address::find_program_address(&[b"router_authority"], &router_program_id);
+    let (router_config_pda, _) =
+        Address::find_program_address(&[b"router_config"], &router_program_id);
 
-    // The router mints basket assets on swap, so it must hold their mint authority.
+    // The router mints basket assets on swap, so its config account, which signs
+    // the router's token CPIs, must hold their mint authority.
     for basket_mint in [&tsla_mint, &nvda_mint] {
         let ix = spl_token::instruction::set_authority(
             &spl_token::ID,
             basket_mint,
-            Some(&router_authority_pda),
+            Some(&router_config_pda),
             spl_token::instruction::AuthorityType::MintTokens,
             &payer.pubkey(),
             &[],
@@ -197,8 +197,6 @@ fn setup_full() -> TestContext {
         &[b"approved_asset", registry_pda.as_ref(), nvda_mint.as_ref()],
         &vault_program_id,
     );
-    let (router_config_pda, _) =
-        Address::find_program_address(&[b"router_config"], &router_program_id);
     let (tsla_rate_pda, _) =
         Address::find_program_address(&[b"rate", tsla_mint.as_ref()], &router_program_id);
     let (nvda_rate_pda, _) =
@@ -207,7 +205,7 @@ fn setup_full() -> TestContext {
     let vault_usdc = derive_ata(&strategy_pda, &usdc_mint);
     let vault_tsla = derive_ata(&strategy_pda, &tsla_mint);
     let vault_nvda = derive_ata(&strategy_pda, &nvda_mint);
-    let router_usdc_treasury = derive_ata(&router_authority_pda, &usdc_mint);
+    let router_usdc_treasury = derive_ata(&router_config_pda, &usdc_mint);
 
     let price_feed_tsla = Keypair::new().pubkey();
     let price_feed_nvda = Keypair::new().pubkey();
@@ -222,7 +220,6 @@ fn setup_full() -> TestContext {
             authority: payer.pubkey(),
             usdc_mint,
             router_config: router_config_pda,
-            router_authority: router_authority_pda,
             token_program: token_program_id(),
             system_program: system_program::ID,
         }
@@ -248,7 +245,6 @@ fn setup_full() -> TestContext {
                 asset_mint: mint,
                 usdc_mint,
                 asset_rate: rate_pda,
-                router_authority: router_authority_pda,
                 router_usdc_treasury,
                 associated_token_program: ata_program_id(),
                 token_program: token_program_id(),
@@ -321,7 +317,6 @@ fn setup_full() -> TestContext {
         approved_tsla,
         approved_nvda,
         router_config_pda,
-        router_authority_pda,
         tsla_rate_pda,
         nvda_rate_pda,
         vault_usdc,
@@ -463,7 +458,6 @@ fn deposit_named_metas(ctx: &TestContext, user: &Keypair) -> Vec<AccountMeta> {
         vault_usdc: ctx.vault_usdc,
         router_config: ctx.router_config_pda,
         router_usdc_treasury: ctx.router_usdc_treasury,
-        router_authority: ctx.router_authority_pda,
         swap_router_program: ctx.router_program_id,
         associated_token_program: ata_program_id(),
         token_program: token_program_id(),
@@ -534,7 +528,6 @@ fn set_router_rate(ctx: &mut TestContext, mint: Address, rate: u64, rate_pda: Ad
             asset_mint: mint,
             usdc_mint: ctx.usdc_mint,
             asset_rate: rate_pda,
-            router_authority: ctx.router_authority_pda,
             router_usdc_treasury: ctx.router_usdc_treasury,
             associated_token_program: ata_program_id(),
             token_program: token_program_id(),
@@ -652,7 +645,6 @@ fn do_rebalance(
             buy_rate,
             router_config: ctx.router_config_pda,
             router_usdc_treasury: ctx.router_usdc_treasury,
-            router_authority: ctx.router_authority_pda,
             swap_router_program: ctx.router_program_id,
             associated_token_program: ata_program_id(),
             token_program: token_program_id(),

--- a/finance/vault-strategy/quasar/CHANGELOG.md
+++ b/finance/vault-strategy/quasar/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [2026-09-10]
+
+### Changed
+
+- The mock swap router signs as its config account. The router used a second,
+  dataless PDA as the owner of its USDC treasury and the mint authority of the
+  asset mints. That PDA, its `Seeds` struct, and its seed constant are removed:
+  the `RouterConfig` account (`["router_config"]`) now owns the treasury, is
+  the mint authority of the asset mints, and signs the router's `mint_to` and
+  `transfer_checked` CPIs with its own seeds and stored bump, the way the
+  Strategy PDA signs for the share mint and vaults. The extra account is
+  dropped from `set_rate`, both swap instructions, the vault's `deposit` and
+  `rebalance` contexts, and the hand-built router CPIs, which now pass nine
+  accounts instead of ten. Both test suites give the asset mint's mint
+  authority to the router config account.
+
 ## [2026-07-22]
 
 ### Changed

--- a/finance/vault-strategy/quasar/README.md
+++ b/finance/vault-strategy/quasar/README.md
@@ -14,7 +14,11 @@ Quasar project:
 - `vault-strategy/` - the vault itself (program ID
   `VLT5W7bqhRN4nCdRpXm8UfHRxZd9EuZGqiSAkGHQfGh`).
 - `mock-swap-router/` - a stand-in constant-rate swap venue the vault trades
-  through (program ID `SWPR8Rk3aq3DrDGLdaANq7xCMnXoUFUJWJJmCWxc8Jm`).
+  through (program ID `SWPR8Rk3aq3DrDGLdaANq7xCMnXoUFUJWJJmCWxc8Jm`). Its
+  `RouterConfig` account (`["router_config"]`) is both its state and its
+  signer: it owns the USDC treasury, is the mint authority of every asset it
+  mints, and signs the router's token CPIs with its own seeds, as the Strategy
+  PDA does for the vaults.
 
 Both share the same program IDs as the Anchor build. The mock router mints an
 asset against USDC at an admin-set fixed rate, standing in for a real AMM or

--- a/finance/vault-strategy/quasar/mock-swap-router/src/instructions/set_rate.rs
+++ b/finance/vault-strategy/quasar/mock-swap-router/src/instructions/set_rate.rs
@@ -1,7 +1,7 @@
 use quasar_lang::prelude::*;
 use quasar_spl::prelude::*;
 
-use crate::state::{AssetRate, AssetRateInner, RouterAuthorityPda, RouterConfig, TreasuryPda};
+use crate::state::{AssetRate, AssetRateInner, RouterConfig, TreasuryPda};
 
 #[derive(Accounts)]
 pub struct SetRateAccountConstraints {
@@ -21,13 +21,11 @@ pub struct SetRateAccountConstraints {
     )]
     pub asset_rate: Account<AssetRate>,
 
-    #[account(address = RouterAuthorityPda::seeds())]
-    pub router_authority: UncheckedAccount,
-
+    // The USDC treasury, owned by the router config account.
     #[account(
         init(idempotent),
         payer = authority,
-        token(mint = usdc_mint, authority = router_authority, token_program = token_program),
+        token(mint = usdc_mint, authority = router_config, token_program = token_program),
         address = TreasuryPda::seeds(),
     )]
     pub router_usdc_treasury: InterfaceAccount<Token>,

--- a/finance/vault-strategy/quasar/mock-swap-router/src/instructions/swap_asset_for_usdc.rs
+++ b/finance/vault-strategy/quasar/mock-swap-router/src/instructions/swap_asset_for_usdc.rs
@@ -3,14 +3,14 @@ use quasar_lang::prelude::*;
 use quasar_spl::prelude::*;
 
 use crate::errors::RouterError;
-use crate::state::{
-    AssetRate, RouterAuthorityPda, RouterConfig, TreasuryPda, ROUTER_AUTHORITY_SEED,
-};
+use crate::state::{AssetRate, RouterConfig, TreasuryPda, ROUTER_CONFIG_SEED};
 
 #[derive(Accounts)]
 pub struct SwapAssetForUsdcAccountConstraints {
     pub caller: Signer,
 
+    // Owns the USDC treasury and is the mint authority of every asset the
+    // router mints; signs the treasury transfer below with its own seeds.
     #[account(address = RouterConfig::seeds())]
     pub router_config: Account<RouterConfig>,
 
@@ -30,9 +30,6 @@ pub struct SwapAssetForUsdcAccountConstraints {
     #[account(mut, address = TreasuryPda::seeds())]
     pub router_usdc_treasury: InterfaceAccount<Token>,
 
-    #[account(address = RouterAuthorityPda::seeds())]
-    pub router_authority: UncheckedAccount,
-
     pub token_program: Program<TokenProgram>,
 }
 
@@ -41,7 +38,6 @@ pub fn handle_swap_asset_for_usdc(
     accounts: &mut SwapAssetForUsdcAccountConstraints,
     asset_amount_in: u64,
     minimum_usdc_out: u64,
-    bumps: &SwapAssetForUsdcAccountConstraintsBumps,
 ) -> Result<(), ProgramError> {
     require_keys_eq!(
         accounts.asset_rate.mint,
@@ -77,17 +73,17 @@ pub fn handle_swap_asset_for_usdc(
         )
         .invoke()?;
 
-    // Pay USDC from the treasury to the caller; the router-authority PDA is the
-    // treasury authority and signs.
-    let bump = [bumps.router_authority];
-    let seeds = [Seed::from(ROUTER_AUTHORITY_SEED), Seed::from(bump.as_ref())];
+    // Pay USDC from the treasury to the caller; the router config account owns
+    // the treasury and signs.
+    let bump = [accounts.router_config.bump];
+    let seeds = [Seed::from(ROUTER_CONFIG_SEED), Seed::from(bump.as_ref())];
     accounts
         .token_program
         .transfer_checked(
             &accounts.router_usdc_treasury,
             &accounts.usdc_mint,
             &accounts.caller_usdc_account,
-            &accounts.router_authority,
+            &accounts.router_config,
             usdc_out,
             accounts.usdc_mint.decimals,
         )

--- a/finance/vault-strategy/quasar/mock-swap-router/src/instructions/swap_usdc_for_asset.rs
+++ b/finance/vault-strategy/quasar/mock-swap-router/src/instructions/swap_usdc_for_asset.rs
@@ -3,15 +3,15 @@ use quasar_lang::prelude::*;
 use quasar_spl::prelude::*;
 
 use crate::errors::RouterError;
-use crate::state::{
-    AssetRate, RouterAuthorityPda, RouterConfig, TreasuryPda, ROUTER_AUTHORITY_SEED,
-};
+use crate::state::{AssetRate, RouterConfig, TreasuryPda, ROUTER_CONFIG_SEED};
 
 #[derive(Accounts)]
 pub struct SwapUsdcForAssetAccountConstraints {
     // The caller - the vault-strategy PDA when invoked via CPI (a PDA signer).
     pub caller: Signer,
 
+    // Owns the USDC treasury and is the mint authority of every asset the
+    // router mints; signs the mint below with its own seeds.
     #[account(address = RouterConfig::seeds())]
     pub router_config: Account<RouterConfig>,
 
@@ -31,9 +31,6 @@ pub struct SwapUsdcForAssetAccountConstraints {
     #[account(mut, address = TreasuryPda::seeds())]
     pub router_usdc_treasury: InterfaceAccount<Token>,
 
-    #[account(address = RouterAuthorityPda::seeds())]
-    pub router_authority: UncheckedAccount,
-
     pub token_program: Program<TokenProgram>,
 }
 
@@ -42,7 +39,6 @@ pub fn handle_swap_usdc_for_asset(
     accounts: &mut SwapUsdcForAssetAccountConstraints,
     usdc_amount_in: u64,
     minimum_asset_out: u64,
-    bumps: &SwapUsdcForAssetAccountConstraintsBumps,
 ) -> Result<(), ProgramError> {
     require_keys_eq!(
         accounts.asset_rate.mint,
@@ -77,16 +73,16 @@ pub fn handle_swap_usdc_for_asset(
         )
         .invoke()?;
 
-    // Mint asset tokens to the caller; the router-authority PDA is the mint
+    // Mint asset tokens to the caller; the router config account is the mint
     // authority and signs.
-    let bump = [bumps.router_authority];
-    let seeds = [Seed::from(ROUTER_AUTHORITY_SEED), Seed::from(bump.as_ref())];
+    let bump = [accounts.router_config.bump];
+    let seeds = [Seed::from(ROUTER_CONFIG_SEED), Seed::from(bump.as_ref())];
     accounts
         .token_program
         .mint_to(
             &accounts.asset_mint,
             &accounts.caller_asset_account,
-            &accounts.router_authority,
+            &accounts.router_config,
             asset_out,
         )
         .invoke_signed(&seeds)?;

--- a/finance/vault-strategy/quasar/mock-swap-router/src/lib.rs
+++ b/finance/vault-strategy/quasar/mock-swap-router/src/lib.rs
@@ -47,7 +47,6 @@ mod quasar_mock_swap_router {
             &mut ctx.accounts,
             usdc_amount_in,
             minimum_asset_out,
-            &ctx.bumps,
         )
     }
 
@@ -61,7 +60,6 @@ mod quasar_mock_swap_router {
             &mut ctx.accounts,
             asset_amount_in,
             minimum_usdc_out,
-            &ctx.bumps,
         )
     }
 }

--- a/finance/vault-strategy/quasar/mock-swap-router/src/state/mod.rs
+++ b/finance/vault-strategy/quasar/mock-swap-router/src/state/mod.rs
@@ -2,10 +2,11 @@ use quasar_lang::prelude::*;
 
 pub const ROUTER_CONFIG_SEED: &[u8] = b"router_config";
 pub const ASSET_RATE_SEED: &[u8] = b"rate";
-pub const ROUTER_AUTHORITY_SEED: &[u8] = b"router_authority";
 
 /// Router configuration. PDA: `["router_config"]`. A single deployment-wide
 /// account naming the authority (who may set rates) and the base USDC mint.
+/// It is also the authority of the USDC treasury and the mint authority of
+/// every asset mint the router mints, and signs those CPIs with its own seeds.
 #[account(discriminator = 1, set_inner)]
 #[seeds(b"router_config")]
 pub struct RouterConfig {
@@ -25,14 +26,8 @@ pub struct AssetRate {
     pub bump: u8,
 }
 
-/// PDA that is the mint authority of every asset mint and the authority of the
-/// USDC treasury: `["router_authority"]`.
-#[derive(Seeds)]
-#[seeds(b"router_authority")]
-pub struct RouterAuthorityPda;
-
 /// PDA token account (USDC) the router pays out of and collects into:
-/// `["treasury"]`, authority = RouterAuthorityPda.
+/// `["treasury"]`, authority = RouterConfig.
 #[derive(Seeds)]
 #[seeds(b"treasury")]
 pub struct TreasuryPda;

--- a/finance/vault-strategy/quasar/mock-swap-router/src/tests.rs
+++ b/finance/vault-strategy/quasar/mock-swap-router/src/tests.rs
@@ -5,7 +5,7 @@
 use {
     crate::{
         cpi::{InitializeRouterInstruction, SetRateInstruction, SwapUsdcForAssetInstruction},
-        state::{AssetRate, RouterAuthorityPda, TreasuryPda},
+        state::{AssetRate, RouterConfig, TreasuryPda},
     },
     quasar_test::prelude::*,
 };
@@ -22,7 +22,7 @@ const CALLER_ASSET: Pubkey = Pubkey::new_from_array([5; 32]);
 
 #[quasar_test]
 fn initialize_and_swap_usdc_for_asset(test: &mut Test) {
-    let router_authority = test.derive_pda(RouterAuthorityPda::seeds());
+    let router_config = test.derive_pda(RouterConfig::seeds());
     let treasury = test.derive_pda(TreasuryPda::seeds());
     let rate = test.derive_pda(AssetRate::seeds(&ASSET_MINT));
 
@@ -31,13 +31,9 @@ fn initialize_and_swap_usdc_for_asset(test: &mut Test) {
 
     test.add(Wallet::new().at(AUTHORITY));
     test.add(Mint::new(AUTHORITY).at(USDC_MINT).decimals(DECIMALS));
-    // The asset mint's authority is the router-authority PDA, so the router
+    // The asset mint's authority is the router config account, so the router
     // can mint it.
-    test.add(
-        Mint::new(router_authority)
-            .at(ASSET_MINT)
-            .decimals(DECIMALS),
-    );
+    test.add(Mint::new(router_config).at(ASSET_MINT).decimals(DECIMALS));
     test.add(
         TokenAccount::new(USDC_MINT, AUTHORITY)
             .at(CALLER_USDC)

--- a/finance/vault-strategy/quasar/vault-strategy/src/instructions/deposit.rs
+++ b/finance/vault-strategy/quasar/vault-strategy/src/instructions/deposit.rs
@@ -12,8 +12,8 @@ use crate::state::{
 
 /// Discriminator of the router's `swap_usdc_for_asset` instruction.
 const ROUTER_SWAP_USDC_FOR_ASSET: u8 = 2;
-/// One `swap_usdc_for_asset` CPI: 10 accounts, 17 data bytes (disc + 2 u64).
-const SWAP_ACCOUNTS: usize = 10;
+/// One `swap_usdc_for_asset` CPI: 9 accounts, 17 data bytes (disc + 2 u64).
+const SWAP_ACCOUNTS: usize = 9;
 const SWAP_DATA_LEN: usize = 17;
 /// remaining_accounts arrive as, per asset index 0..asset_count:
 ///   [asset_config, vault, asset_mint, asset_rate, price_feed]
@@ -47,14 +47,13 @@ pub struct DepositAccountConstraints {
     #[account(mut, address = UsdcVaultPda::seeds(strategy.address()))]
     pub vault_usdc: InterfaceAccount<Token>,
 
-    /// Router config PDA (mock-swap-router).
+    /// Router config PDA (mock-swap-router); it owns the treasury and signs the
+    /// router's token CPIs.
     #[account(mut)]
     pub router_config: UncheckedAccount,
-    /// Router USDC treasury.
+    /// Router USDC treasury, owned by the router config account.
     #[account(mut)]
     pub router_usdc_treasury: UncheckedAccount,
-    /// Router mint-authority PDA.
-    pub router_authority: UncheckedAccount,
     /// The swap router program, verified against the strategy's stored router.
     pub swap_router_program: UncheckedAccount,
 
@@ -239,7 +238,7 @@ pub fn handle_deposit(
         // Router `swap_usdc_for_asset` account order:
         //   caller, router_config, asset_rate, usdc_mint, asset_mint,
         //   caller_usdc_account, caller_asset_account, router_usdc_treasury,
-        //   router_authority, token_program.
+        //   token_program.
         let mut cpi = CpiDynamic::<SWAP_ACCOUNTS, SWAP_DATA_LEN>::new(&router_program_addr);
         cpi.push_account(accounts.strategy.to_account_view(), true, false)?;
         cpi.push_account(accounts.router_config.to_account_view(), false, false)?;
@@ -249,7 +248,6 @@ pub fn handle_deposit(
         cpi.push_account(accounts.vault_usdc.to_account_view(), false, true)?;
         cpi.push_account(&vault_view, false, true)?;
         cpi.push_account(accounts.router_usdc_treasury.to_account_view(), false, true)?;
-        cpi.push_account(accounts.router_authority.to_account_view(), false, false)?;
         cpi.push_account(accounts.token_program.to_account_view(), false, false)?;
         cpi.set_data(&data)?;
         cpi.invoke_signed(&seeds)?;

--- a/finance/vault-strategy/quasar/vault-strategy/src/instructions/rebalance.rs
+++ b/finance/vault-strategy/quasar/vault-strategy/src/instructions/rebalance.rs
@@ -9,7 +9,7 @@ use crate::state::{AssetConfig, Strategy, STRATEGY_SEED};
 
 const ROUTER_SWAP_USDC_FOR_ASSET: u8 = 2;
 const ROUTER_SWAP_ASSET_FOR_USDC: u8 = 3;
-const SWAP_ACCOUNTS: usize = 10;
+const SWAP_ACCOUNTS: usize = 9;
 const SWAP_DATA_LEN: usize = 17;
 
 #[derive(Accounts)]
@@ -52,11 +52,11 @@ pub struct RebalanceAccountConstraints {
     pub sell_rate: UncheckedAccount,
     pub buy_rate: UncheckedAccount,
 
+    /// Router config PDA; it owns the treasury and signs the router's token CPIs.
     #[account(mut)]
     pub router_config: UncheckedAccount,
     #[account(mut)]
     pub router_usdc_treasury: UncheckedAccount,
-    pub router_authority: UncheckedAccount,
     pub swap_router_program: UncheckedAccount,
 
     pub token_program: Program<TokenProgram>,
@@ -157,7 +157,7 @@ pub fn handle_rebalance(
     // Step 1: sell the basket token for USDC. Router `swap_asset_for_usdc`
     // order: caller, router_config, asset_rate, usdc_mint, asset_mint,
     // caller_asset_account, caller_usdc_account, router_usdc_treasury,
-    // router_authority, token_program.
+    // token_program.
     let mut sell_data = [0u8; SWAP_DATA_LEN];
     sell_data[0] = ROUTER_SWAP_ASSET_FOR_USDC;
     sell_data[1..9].copy_from_slice(&sell_amount.to_le_bytes());
@@ -171,7 +171,6 @@ pub fn handle_rebalance(
     sell_cpi.push_account(accounts.vault_sell.to_account_view(), false, true)?;
     sell_cpi.push_account(accounts.vault_usdc.to_account_view(), false, true)?;
     sell_cpi.push_account(accounts.router_usdc_treasury.to_account_view(), false, true)?;
-    sell_cpi.push_account(accounts.router_authority.to_account_view(), false, false)?;
     sell_cpi.push_account(accounts.token_program.to_account_view(), false, false)?;
     sell_cpi.set_data(&sell_data)?;
     sell_cpi.invoke_signed(&seeds)?;
@@ -179,7 +178,7 @@ pub fn handle_rebalance(
     // Step 2: buy the basket token with USDC. Router `swap_usdc_for_asset`
     // order: caller, router_config, asset_rate, usdc_mint, asset_mint,
     // caller_usdc_account, caller_asset_account, router_usdc_treasury,
-    // router_authority, token_program.
+    // token_program.
     let mut buy_data = [0u8; SWAP_DATA_LEN];
     buy_data[0] = ROUTER_SWAP_USDC_FOR_ASSET;
     buy_data[1..9].copy_from_slice(&usdc_to_invest.to_le_bytes());
@@ -193,7 +192,6 @@ pub fn handle_rebalance(
     buy_cpi.push_account(accounts.vault_usdc.to_account_view(), false, true)?;
     buy_cpi.push_account(accounts.vault_buy.to_account_view(), false, true)?;
     buy_cpi.push_account(accounts.router_usdc_treasury.to_account_view(), false, true)?;
-    buy_cpi.push_account(accounts.router_authority.to_account_view(), false, false)?;
     buy_cpi.push_account(accounts.token_program.to_account_view(), false, false)?;
     buy_cpi.set_data(&buy_data)?;
     buy_cpi.invoke_signed(&seeds)?;

--- a/finance/vault-strategy/quasar/vault-strategy/src/tests.rs
+++ b/finance/vault-strategy/quasar/vault-strategy/src/tests.rs
@@ -45,9 +45,6 @@ fn router_id() -> Pubkey {
 fn router_config_pda() -> Pubkey {
     Pubkey::find_program_address(&[b"router_config"], &router_id()).0
 }
-fn router_authority_pda() -> Pubkey {
-    Pubkey::find_program_address(&[b"router_authority"], &router_id()).0
-}
 fn router_treasury_pda() -> Pubkey {
     Pubkey::find_program_address(&[b"treasury"], &router_id()).0
 }
@@ -162,9 +159,9 @@ fn deposit_mints_shares_and_deploys_into_the_basket(test: &mut Test) {
     test.add(Program::new(router_id(), &router_elf));
     test.warp_to_timestamp(NOW);
 
-    let r_authority = router_authority_pda();
-    // The asset mint is minted by the router authority.
-    setup_strategy(test, r_authority);
+    // The router config account is the asset mint's mint authority, so the
+    // router can mint it on swap.
+    setup_strategy(test, router_config_pda());
     let w = pdas(test);
 
     test.add(Wallet::new().at(DEPOSITOR));
@@ -213,7 +210,6 @@ fn deposit_mints_shares_and_deploys_into_the_basket(test: &mut Test) {
             AccountMeta::new_readonly(ASSET_MINT, false),
             AccountMeta::new_readonly(USDC_MINT, false),
             AccountMeta::new(router_rate_pda(&ASSET_MINT), false),
-            AccountMeta::new_readonly(r_authority, false),
             AccountMeta::new(router_treasury_pda(), false),
             AccountMeta::new_readonly(rent_id, false),
             AccountMeta::new_readonly(SPL_TOKEN_PROGRAM_ID, false),
@@ -233,7 +229,6 @@ fn deposit_mints_shares_and_deploys_into_the_basket(test: &mut Test) {
         depositor_share_account: DEPOSITOR_SHARE,
         router_config: router_config_pda(),
         router_usdc_treasury: router_treasury_pda(),
-        router_authority: r_authority,
         swap_router_program: router_id(),
         usdc_amount: DEPOSIT,
         minimum_shares: DEPOSIT,


### PR DESCRIPTION
## Summary

Five finance examples kept a dataless "authority" PDA beside their state account, existing only to own the vaults and mints and to sign for them: the token swap, the prop AMM, the perpetual futures pool, the options venue, and the vault strategy's mock swap router. A program-owned data account signs with its own seeds just as well, as the escrow's offer account already does, and its seeds never change however its data does. The extra account bought nothing but one more account per instruction and one more stored bump, and no reader could be given a reason for it.

This PR removes it everywhere, in all three ports of each example (Anchor v2, Anchor v1, Quasar):

| Example | State account that now owns and signs | What it owns |
| --- | --- | --- |
| token swap | `pool_config` | `pool_a`, `pool_b` (now its associated token accounts), the LP mint |
| prop AMM | `market` | base and quote vaults |
| perpetual futures | `pool` | the custody vault, the LP share mint |
| options | `market` | underlying and quote vaults |
| vault strategy's mock router | `router_config` | the router treasury, the asset mints it mints |

- The `authority_bump` fields, `AUTHORITY_SEED` constants, and Quasar `*AuthorityPda` seed structs are gone. Handlers sign with the state account's own seeds; in Anchor v2 that means releasing the account's data borrow around the CPI where the account is mutable, the pattern the escrow's `take_offer` already uses.
- Every affected port's tests assert the new ownership (reserve or vault owner and mint authority equal the state account), the token swap tests derive the reserves as ATAs of the pool config, and the vault strategy's web app and IDL pass one account fewer to the router.
- READMEs and each port's changelog follow, and the repository changelog records the change.
- Pre-existing formatting drift and clippy findings in the prop AMM and token swap v1 and Quasar ports were fixed so the gates pass; those are formatting and lint only.

The book's matching change is quicknode/solana-book#107, which should merge after this one.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` clean in all three ports of all five examples (fifteen crates), with the `.so` files rebuilt via `cargo build-sbf` / `quasar build` before the tests
- [x] Repository-wide grep for the removed identifiers and for "authority PDA" in the finance examples prints nothing
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RdEWCoCChaoKPhvcftHVG